### PR TITLE
Use a separate key store for electron development

### DIFF
--- a/electron/lib/storage.js
+++ b/electron/lib/storage.js
@@ -1,7 +1,11 @@
 const { app, ipcMain } = require("electron")
+const isDev = require("electron-is-dev")
 const Store = require("electron-store")
 
-const mainStore = new Store()
+// Use different key stores for development and production
+const mainStore = new Store({
+  name: isDev ? "development" : "config"
+})
 
 ipcMain.on("storage:keys:readSync", event => {
   event.returnValue = mainStore.has("keys") ? mainStore.get("keys") : {}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@material-ui/icons": "^2.0.0",
     "big.js": "^5.0.3",
     "electron-debug": "^2.0.0",
+    "electron-is-dev": "^0.3.0",
     "electron-store": "^2.0.0",
     "history": "^4.7.2",
     "key-store": "^1.0.0",


### PR DESCRIPTION
So you can experiment as much as you want without accidentally deleting your production keys.