### PR TITLE
Separate HTML files for dev & production

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "prettier": "prettier --write '{src,stories}/**/*.{ts,tsx}' *.md electron/*.js",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "tslint --project .",
-    "prebuild:electron": "NODE_ENV=production parcel build ./src/index.html --public-url=./ --detailed-report --target=electron --no-source-maps",
+    "prebuild:electron": "NODE_ENV=production parcel build ./src/index.prod.html --public-url=./ --detailed-report --target=electron --no-source-maps",
     "build:linux": "PLATFORM=linux npm run prebuild:electron && build --linux --x64 --config ./electron-build.yml",
     "build:mac": "PLATFORM=darwin npm run prebuild:electron && build --mac --x64 --config ./electron-build.yml",
     "build:win": "PLATFORM=win32 npm run prebuild:electron && build --win --ia32  --config ./electron-build.yml",
     "dev": "run-p dev:bundle dev:app:delayed",
     "dev:app": "NODE_ENV=development electron -r ./electron/development .",
     "dev:app:delayed": "sleep 2 && run-s dev:app",
-    "dev:bundle": "NODE_ENV=development parcel watch ./src/index.html --public-url=./ --target=electron"
+    "dev:bundle": "NODE_ENV=development parcel watch ./src/index.dev.html --public-url=./ --target=electron"
   },
   "lint-staged": {
     "ignore": [

--- a/src/index.dev.html
+++ b/src/index.dev.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://*.stellar.org ws://localhost:*; style-src 'self' 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://*.stellar.org ws://localhost:*; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval';">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>SatoshiPay Wallet</title>
     <link href="./fonts.css" rel="stylesheet">

--- a/src/index.prod.html
+++ b/src/index.prod.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://*.stellar.org; style-src 'self' 'unsafe-inline';">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>SatoshiPay Wallet</title>
+    <link href="./fonts.css" rel="stylesheet">
+    <link href="./base-styles.css" rel="stylesheet">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="./app.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -10,8 +10,8 @@
   "homepage": "https://github.com/satoshipay/wallet",
   "scripts": {
     "prebuild": "rm -rf dist/",
-    "build": "NODE_ENV=production ../node_modules/.bin/parcel build ../src/index.html --public-url=./ --detailed-report",
-    "dev": "NODE_ENV=development ../node_modules/.bin/parcel serve ../src/index.html -p 3000"
+    "build": "NODE_ENV=production ../node_modules/.bin/parcel build ../src/index.prod.html --public-url=./ --detailed-report",
+    "dev": "NODE_ENV=development ../node_modules/.bin/parcel serve ../src/index.dev.html -p 3000"
   },
   "browser": {
     "../src/platform/electron/key-store": false


### PR DESCRIPTION
Fixes the Content-Security-Policy. We need `unsafe-eval` for HMR.