### PR TITLE
Show spinner on button while tx is created

### DIFF
--- a/src/components/Dialog/CreatePayment.tsx
+++ b/src/components/Dialog/CreatePayment.tsx
@@ -29,9 +29,17 @@ interface State {
   submissionFailed: boolean
   submissionPromise: Promise<any> | null
   transaction: Transaction | null
+  txCreationPending: boolean
 }
 
 class CreatePaymentDialog extends React.Component<Props, State> {
+  state: State = {
+    submissionFailed: false,
+    submissionPromise: null,
+    transaction: null,
+    txCreationPending: false
+  }
+
   createMemo = (formValues: PaymentCreationValues) => {
     switch (formValues.memoType) {
       case "id":
@@ -45,6 +53,7 @@ class CreatePaymentDialog extends React.Component<Props, State> {
 
   createTransaction = async (formValues: PaymentCreationValues) => {
     try {
+      this.setState({ txCreationPending: true })
       const asset = this.props.trustedAssets.find(trustedAsset => trustedAsset.code === formValues.asset)
 
       const payment = await createPaymentOperation({
@@ -61,6 +70,8 @@ class CreatePaymentDialog extends React.Component<Props, State> {
       this.props.sendTransaction(tx)
     } catch (error) {
       addError(error)
+    } finally {
+      this.setState({ txCreationPending: false })
     }
   }
 
@@ -72,6 +83,7 @@ class CreatePaymentDialog extends React.Component<Props, State> {
         onClose={this.props.onClose}
         onSubmit={this.createTransaction}
         trustedAssets={this.props.trustedAssets}
+        txCreationPending={this.state.txCreationPending}
       />
     )
   }

--- a/src/components/Dialog/PaymentForm.tsx
+++ b/src/components/Dialog/PaymentForm.tsx
@@ -14,6 +14,7 @@ interface PaymentFormDrawerProps {
   onClose: () => void
   onSubmit: (values: PaymentCreationValues) => void
   trustedAssets?: Asset[]
+  txCreationPending?: boolean
 }
 
 const PaymentFormDrawer = (props: PaymentFormDrawerProps) => {
@@ -38,7 +39,11 @@ const PaymentFormDrawer = (props: PaymentFormDrawerProps) => {
             {props.account.testnet ? "Testnet" : null}
           </Typography>
           <div style={{ marginTop: 32 }}>
-            <CreatePaymentForm onSubmit={props.onSubmit} trustedAssets={trustedAssets} />
+            <CreatePaymentForm
+              onSubmit={props.onSubmit}
+              trustedAssets={trustedAssets}
+              txCreationPending={props.txCreationPending}
+            />
           </div>
         </CardContent>
       </Card>

--- a/src/components/Form/CreatePayment.tsx
+++ b/src/components/Form/CreatePayment.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Asset } from "stellar-sdk"
 import Button from "@material-ui/core/Button"
+import CircularProgress from "@material-ui/core/CircularProgress"
 import FormControl from "@material-ui/core/FormControl"
 import InputLabel from "@material-ui/core/InputLabel"
 import MenuItem from "@material-ui/core/MenuItem"
@@ -78,6 +79,7 @@ interface PaymentCreationFormProps {
   errors: PaymentCreationErrors
   formValues: PaymentCreationValues
   trustedAssets: Asset[]
+  txCreationPending?: boolean
   setFormValue: (fieldName: keyof PaymentCreationValues, value: string) => void
   onSubmit: () => void
 }
@@ -156,7 +158,11 @@ const PaymentCreationForm = (props: PaymentCreationFormProps) => {
       </Box>
       <Box margin="64px 0 0">
         <Button variant="contained" color="primary" onClick={handleSubmitEvent} type="submit">
-          <SendIcon style={{ marginRight: 8 }} />
+          {props.txCreationPending ? (
+            <CircularProgress size="1.5em" style={{ color: "white", marginRight: 12 }} />
+          ) : (
+            <SendIcon style={{ marginRight: 8 }} />
+          )}
           Create Payment
         </Button>
       </Box>
@@ -166,6 +172,7 @@ const PaymentCreationForm = (props: PaymentCreationFormProps) => {
 
 interface Props {
   trustedAssets: Asset[]
+  txCreationPending?: boolean
   onSubmit?: (formValues: PaymentCreationValues) => any
 }
 


### PR DESCRIPTION
Fixes a UX reported by Meinhard:

> after pressing "CREATE PAYMENT" the interface sometimes stalls for a few a while seconds (feels like stargazer, aaaahhh)