### PR TITLE
Improve top drag-area linear-gradient styling

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -44,15 +44,17 @@ const App = () => (
     <MuiThemeProvider theme={theme}>
       <Providers>
         <VerticalLayout height="100%">
-          <Route exact path="/" component={AllAccountsPage} />
-          <Route exact path="/account/create/mainnet" component={withProps({ testnet: false })(CreateAccountPage)} />
-          <Route exact path="/account/create/testnet" component={withProps({ testnet: true })(CreateAccountPage)} />
-          <Route exact path="/account/:id" component={AccountPage} />
-          <Route exact path="/account/:id/assets" component={AccountAssetsPage} />
-          <Route exact path="/account/:id/signers" component={ManageSignersPage} />
-          <DesktopNotifications />
-          <NotificationContainer />
-          <OpenDialogs />
+          <VerticalLayout height="100%" grow overflow="auto">
+            <Route exact path="/" component={AllAccountsPage} />
+            <Route exact path="/account/create/mainnet" component={withProps({ testnet: false })(CreateAccountPage)} />
+            <Route exact path="/account/create/testnet" component={withProps({ testnet: true })(CreateAccountPage)} />
+            <Route exact path="/account/:id" component={AccountPage} />
+            <Route exact path="/account/:id/assets" component={AccountAssetsPage} />
+            <Route exact path="/account/:id/signers" component={ManageSignersPage} />
+            <DesktopNotifications />
+            <NotificationContainer />
+            <OpenDialogs />
+          </VerticalLayout>
         </VerticalLayout>
       </Providers>
     </MuiThemeProvider>

--- a/src/base-styles.css
+++ b/src/base-styles.css
@@ -24,6 +24,8 @@ body,
   height: 28px;
   margin: 0;
   padding: 0;
+  overflow: hidden;
   z-index: 1;
   -webkit-app-region: drag;
+  -webkit-mask: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
 }

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -1,13 +1,16 @@
 import React from "react"
 import { Box } from "./Box"
-import { primaryBackground, primaryBackgroundColor } from "../../theme"
+import { primaryBackground } from "../../theme"
 
-const FramelessWindowInvisibleTitleBar = (props: { backgroundColor?: React.CSSProperties["backgroundColor"] }) => {
+const FramelessWindowInvisibleTitleBar = (props: { background?: React.CSSProperties["background"] }) => {
   if (process.env.PLATFORM === "darwin") {
     // Add invisible window-drag area and a bit of additional v-space on top
     // Need to define a static CSS class for it, since `-webkit-app-region` in CSS-in-JS might lead to trouble
-    const background = props.backgroundColor ? `linear-gradient(${props.backgroundColor}, transparent)` : undefined
-    return <div className="mac-frameless-window-invisible-title-bar" style={{ background }} />
+    return (
+      <div className="mac-frameless-window-invisible-title-bar">
+        <div style={{ background: props.background, width: "100%", height: "200%" }} />
+      </div>
+    )
   } else {
     return null
   }
@@ -21,9 +24,9 @@ interface SectionProps {
 }
 
 const Section = (props: SectionProps) => {
-  const backgroundColor = props.brandColored ? primaryBackgroundColor : props.backgroundColor
+  const background = props.brandColored ? primaryBackground : props.backgroundColor || "white"
   const style: React.CSSProperties = {
-    background: props.brandColored ? primaryBackground : props.backgroundColor || "white",
+    background,
     color: props.brandColored ? "white" : undefined,
     flexGrow: 1,
     position: "relative",
@@ -31,7 +34,7 @@ const Section = (props: SectionProps) => {
   }
   return (
     <>
-      {props.top ? <FramelessWindowInvisibleTitleBar backgroundColor={backgroundColor} /> : null}
+      {props.top ? <FramelessWindowInvisibleTitleBar background={background} /> : null}
       <Box component="section" padding={16} style={style}>
         {/* Add a little padding to the top if window is frameless */}
         {props.top ? <div style={{ width: "100%", padding: "4px 0 0", margin: 0 }} /> : null}


### PR DESCRIPTION
Somewhat a follow-up of #245. Styling was missing on a few pages and didn't look perfectly well on the pages where it was shown.