### PR TITLE
Fix tx confirmation, improve password error handling

### DIFF
--- a/src/components/Dialog/TransactionConfirmation.tsx
+++ b/src/components/Dialog/TransactionConfirmation.tsx
@@ -17,6 +17,7 @@ interface TxConfirmationDialogProps {
   account: Account
   disabled?: boolean
   open: boolean
+  passwordError?: Error | null
   submissionProgress?: React.ReactNode
   transaction: Transaction | null
   onClose: () => void
@@ -43,6 +44,7 @@ function TxConfirmationDialog(props: TxConfirmationDialogProps) {
               disabled={props.disabled}
               onConfirm={formValues => props.onSubmitTransaction(props.transaction as Transaction, formValues)}
               onCancel={props.onClose}
+              passwordError={props.passwordError}
             />
           </div>
         ) : null}

--- a/src/components/Form/TxConfirmation.tsx
+++ b/src/components/Form/TxConfirmation.tsx
@@ -16,6 +16,7 @@ interface FormValues {
 interface Props {
   account: Account
   disabled?: boolean
+  passwordError?: Error | null
   transaction: Transaction
   onConfirm?: (formValues: FormValues) => any
   onCancel?: () => any
@@ -66,6 +67,7 @@ class TxConfirmationForm extends React.Component<Props, State> {
 
   render() {
     const { account, disabled, transaction, onCancel = () => undefined } = this.props
+    const passwordError = this.props.passwordError || this.state.errors.password
 
     return (
       <form onSubmit={this.onSubmit}>
@@ -77,8 +79,8 @@ class TxConfirmationForm extends React.Component<Props, State> {
           />
           {account.requiresPassword ? (
             <TextField
-              error={Boolean(this.state.errors.password)}
-              label={this.state.errors.password ? renderFormFieldError(this.state.errors.password) : "Password"}
+              error={Boolean(passwordError)}
+              label={passwordError ? renderFormFieldError(passwordError) : "Password"}
               type="password"
               autoFocus
               fullWidth


### PR DESCRIPTION
- Fixes a bug where you could not do a second payment from the same account right after the first one (would just show the successful-submission screen of the last tx)
- Improves error handling for account passwords entered before tx submission

Closes #338.