### PR TITLE
Disable electron node-integration, expose `window.electron`

### DIFF
--- a/electron/lib/preload.js
+++ b/electron/lib/preload.js
@@ -1,0 +1,32 @@
+const { ipcRenderer } = require("electron")
+
+const electronProcess = process
+
+const readKeys = () => ipcRenderer.sendSync("storage:keys:readSync")
+const updateKeys = data => ipcRenderer.sendSync("storage:keys:storeSync", data)
+
+const readSettings = () => ipcRenderer.sendSync("storage:settings:readSync")
+const updateSettings = updatedSettings => ipcRenderer.sendSync("storage:settings:storeSync", updatedSettings)
+
+const readIgnoredSignatureRequestHashes = () => ipcRenderer.sendSync("storage:ignoredSignatureRequests:readSync")
+const updateIgnoredSignatureRequestHashes = updatedSignatureRequestHashes =>
+  ipcRenderer.sendSync("storage:ignoredSignatureRequests:storeSync", updatedSignatureRequestHashes)
+
+const electron = {
+  readIgnoredSignatureRequestHashes,
+  readKeys,
+  readSettings,
+  updateIgnoredSignatureRequestHashes,
+  updateKeys,
+  updateSettings
+}
+
+global.electron = window.electron = electron
+
+process.once("loaded", () => {
+  global.process = window.process = {
+    env: electronProcess.env,
+    pid: electronProcess.pid,
+    platform: electronProcess.platform
+  }
+})

--- a/electron/lib/window.js
+++ b/electron/lib/window.js
@@ -17,11 +17,17 @@ function createMainWindow() {
     height: 600,
     minWidth: 400,
     minHeight: 300,
-    title: "SatoshiPay Wallet",
+    title: "Solar Wallet",
     icon: path.join(__dirname, "../build/icon.png"),
     backgroundColor: "#0196E8",
-    nodeIntegration: false,
-    titleBarStyle: process.platform === "darwin" ? "hidden" : "default"
+    titleBarStyle: process.platform === "darwin" ? "hidden" : "default",
+    webPreferences: {
+      nodeIntegration: false,
+      nodeIntegrationInWorker: false,
+      preload: path.join(__dirname, "preload.js"),
+      sandbox: true,
+      webviewTag: false
+    }
   })
 
   const pathname =

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "prettier": "prettier --write '{src,stories}/**/*.{ts,tsx}' *.md electron/*.js",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "tslint --project .",
-    "prebuild:electron": "NODE_ENV=production parcel build ./src/index.prod.njk --public-url=./ --detailed-report --target=electron --no-source-maps",
+    "prebuild:electron": "NODE_ENV=production parcel build ./src/index.prod.njk --public-url=./ --detailed-report --no-source-maps",
     "build:linux": "PLATFORM=linux npm run prebuild:electron && build --linux --x64 --config ./electron-build.yml",
     "build:mac": "PLATFORM=darwin npm run prebuild:electron && build --mac --x64 --config ./electron-build.yml",
     "build:win": "PLATFORM=win32 npm run prebuild:electron && build --win --ia32  --config ./electron-build.yml",
     "dev": "run-p dev:bundle dev:app:delayed",
     "dev:app": "NODE_ENV=development run-electron -r ./electron/development .",
     "dev:app:delayed": "sleep 2 && run-s dev:app",
-    "dev:bundle": "NODE_ENV=development parcel watch ./src/index.dev.njk --public-url=./ --target=electron"
+    "dev:bundle": "NODE_ENV=development parcel watch ./src/index.dev.njk --hmr-hostname localhost --public-url=./"
   },
   "lint-staged": {
     "ignore": [

--- a/src/platform/electron/key-store.ts
+++ b/src/platform/electron/key-store.ts
@@ -1,8 +1,8 @@
 import { createStore } from "key-store"
-import { ipcRenderer } from "electron"
 
 export default function createKeyStore() {
-  const readData = () => ipcRenderer.sendSync("storage:keys:readSync")
-  const saveData = (data: any) => ipcRenderer.sendSync("storage:keys:storeSync", data)
-  return createStore(saveData, readData())
+  if (!window.electron) {
+    throw new Error("No electron runtime context available.")
+  }
+  return createStore(window.electron.updateKeys, window.electron.readKeys())
 }

--- a/src/platform/electron/settings.ts
+++ b/src/platform/electron/settings.ts
@@ -1,18 +1,29 @@
-import { ipcRenderer } from "electron"
 import { SettingsData } from "../types"
 
 export function loadSettings() {
-  return ipcRenderer.sendSync("storage:settings:readSync")
+  if (!window.electron) {
+    throw new Error("No electron runtime context available.")
+  }
+  return window.electron.readSettings()
 }
 
 export function saveSettings(updatedSettings: Partial<SettingsData>) {
-  ipcRenderer.sendSync("storage:settings:storeSync", updatedSettings)
+  if (!window.electron) {
+    throw new Error("No electron runtime context available.")
+  }
+  window.electron.updateSettings(updatedSettings)
 }
 
 export function loadIgnoredSignatureRequestHashes() {
-  return ipcRenderer.sendSync("storage:ignoredSignatureRequests:readSync")
+  if (!window.electron) {
+    throw new Error("No electron runtime context available.")
+  }
+  return window.electron.readIgnoredSignatureRequestHashes()
 }
 
-export function saveIgnoredSignatureRequestHashes(updatedSignatureRequestHashes: string[]) {
-  ipcRenderer.sendSync("storage:ignoredSignatureRequests:storeSync", updatedSignatureRequestHashes)
+export function saveIgnoredSignatureRequestHashes(updatedHashes: string[]) {
+  if (!window.electron) {
+    throw new Error("No electron runtime context available.")
+  }
+  window.electron.updateIgnoredSignatureRequestHashes(updatedHashes)
 }

--- a/src/platform/key-store.ts
+++ b/src/platform/key-store.ts
@@ -1,10 +1,8 @@
 import { KeyStore } from "key-store"
 import { PrivateKeyData, PublicKeyData } from "./types"
 
-const runningInElectron = () => Boolean(process.pid)
-
 export default function getKeyStore(): KeyStore<PrivateKeyData, PublicKeyData> {
-  if (runningInElectron()) {
+  if (window.electron) {
     const createElectronKeyStore = require("./electron/key-store").default
     return createElectronKeyStore()
   } else if (process.browser) {

--- a/src/platform/settings.ts
+++ b/src/platform/settings.ts
@@ -9,11 +9,10 @@ interface SettingsStore {
   saveSettings(settingsUpdate: Partial<SettingsData>): void
 }
 
-const runningInElectron = () => Boolean(process.pid)
 const implementation = getImplementation()
 
 function getImplementation(): SettingsStore {
-  if (runningInElectron()) {
+  if (window.electron) {
     return require("./electron/settings")
   } else if (process.browser) {
     return require("./web/settings")

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1,0 +1,19 @@
+interface SettingsData {
+  agreedToTermsAt?: string
+  multisignature: boolean
+  testnet: boolean
+}
+
+interface ElectronContext {
+  readIgnoredSignatureRequestHashes(): string[]
+  readKeys(): any
+  readSettings(): SettingsData
+  updateIgnoredSignatureRequestHashes(updatedHashes: string[]): void
+  updateKeys(keyData: any): void
+  updateSettings(updatedSettings: Partial<SettingsData>): void
+}
+
+interface Window {
+  // Will only be defined when in an electron build
+  electron?: ElectronContext
+}


### PR DESCRIPTION
Security-relevant: Node integration was still enabled in electron build. Fixing that now!

Also changes the way IPC communication between the web view and the main thread happens. Can only send some whitelisted IPC messages from now on to increase security for the unlikely event that at some point a malicious player would be able to run code in the web view.