### PR TITLE
Basic app signing for mac & windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@ node_modules/
 storybook-static/
 .DS_Store
 Thumbs.db
+*.env
 *.sublime-project
 *.sublime-workspace
 *.log
+*.p12
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ To run the storybook:
 npm run storybook
 ```
 
+### Run dev server without electron
+
+```
+cd web/
+npm run dev
+```
+
 ### Production build
 
 ```
@@ -51,12 +58,15 @@ npm run build:win
 npm run build:linux
 ```
 
-### Run dev server without electron
+To sign the binaries, make sure you imported the code signing certificate into your keychain. Create a `signing.env` file with the following content:
 
 ```
-cd web/
-npm run dev
+CSC_NAME="SatoshiPay Ltd"   # or whatever the name of the certificate in your keychain is
 ```
+
+Signing should then happen automatically during the production build.
+
+Note: Application signing has only been tested on a Mac OS development machine so far.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "test": "tslint --project .",
     "prebuild:electron": "NODE_ENV=production parcel build ./src/index.prod.njk --detailed-report --no-cache --no-source-maps --public-url=./",
     "build:linux": "PLATFORM=linux npm run prebuild:electron && build --linux --x64 --config ./electron-build.yml",
-    "build:mac": "PLATFORM=darwin npm run prebuild:electron && build --mac --x64 --config ./electron-build.yml",
-    "build:win": "PLATFORM=win32 npm run prebuild:electron && build --win --ia32  --config ./electron-build.yml",
+    "build:mac": "PLATFORM=darwin npm run prebuild:electron && source ./signing.env && build --mac --x64 --config ./electron-build.yml",
+    "build:win": "PLATFORM=win32 npm run prebuild:electron && build --win --ia32 --config ./electron-build.yml && npm run sign:win",
     "dev": "run-p dev:bundle dev:app:delayed",
     "dev:app": "NODE_ENV=development run-electron -r ./electron/development .",
     "dev:app:delayed": "sleep 2 && run-s dev:app",
-    "dev:bundle": "NODE_ENV=development parcel watch ./src/index.dev.njk --hmr-hostname localhost --public-url=./"
+    "dev:bundle": "NODE_ENV=development parcel watch ./src/index.dev.njk --hmr-hostname localhost --public-url=./",
+    "sign:win": "source ./signing.env && codesign -s \"$CSC_NAME\" ./electron/dist/*$npm_package_version.exe"
   },
   "lint-staged": {
     "ignore": [


### PR DESCRIPTION
Not sure if signing the Mac DMG with the authenticode certificate will do the trick. Waiting for the Apple developer account. Keeping #351 open until then.