### PR TITLE
Sign with local certificate file to fix Windows installer signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ Thumbs.db
 *.sublime-project
 *.sublime-workspace
 *.log
-*.p12
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -58,19 +58,17 @@ npm run build:win
 npm run build:linux
 ```
 
-To sign the binaries, make sure you imported the code signing certificate into your keychain. Create a `signing.env` file with the following content:
+To sign the binaries, make sure you have the code signing certificate on your local filesystem as a `.p12` file and have the password for it. Make sure not to save the certificate in the Solar directory to make sure it cannot accidentally be bundled into the app installer!
+
+You can create a `signing.env` file to set the CSC_LINK variable:
 
 ```
-CSC_NAME="SatoshiPay Ltd"   # or whatever the name of the certificate in your keychain is
+CSC_LINK=~/secret-certificates/SatoshiPayLtd.p12   # point to your local certificate file
 ```
 
-Signing should then happen automatically during the production build.
+Now run `npm run build:*:signed` to create a signed application build.
 
-To check the signature, run:
-
-```
-codesign -dv --verbose=4 ./electron/dist/<file>
-```
+To check the Mac DMG signature, run `codesign -dv --verbose=4 ./electron/dist/<file>`. To verify the Windows installer signature, you can upload the file to `virustotal.com`.
 
 Note: Application signing has only been tested on a Mac OS development machine so far.
 

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "test": "tslint --project .",
     "prebuild:electron": "NODE_ENV=production parcel build ./src/index.prod.njk --detailed-report --no-cache --no-source-maps --public-url=./",
     "build:linux": "PLATFORM=linux npm run prebuild:electron && build --linux --x64 --config ./electron-build.yml",
-    "build:mac": "PLATFORM=darwin npm run prebuild:electron && source ./signing.env && build --mac --x64 --config ./electron-build.yml",
-    "build:win": "PLATFORM=win32 npm run prebuild:electron && build --win --ia32 --config ./electron-build.yml && npm run sign:win",
+    "build:mac": "PLATFORM=darwin npm run prebuild:electron && build --mac --x64 --config ./electron-build.yml",
+    "build:mac:signed": "source ./scripts/signing-env.sh && npm run build:mac -- -c.forceCodeSigning=true",
+    "build:win": "PLATFORM=win32 npm run prebuild:electron && build --win --ia32 --config ./electron-build.yml",
+    "build:win:signed": "source ./scripts/signing-env.sh && npm run build:win -- -c.forceCodeSigning=true",
     "dev": "run-p dev:bundle dev:app:delayed",
     "dev:app": "NODE_ENV=development run-electron -r ./electron/development .",
     "dev:app:delayed": "sleep 2 && run-s dev:app",
-    "dev:bundle": "NODE_ENV=development parcel watch ./src/index.dev.njk --hmr-hostname localhost --public-url=./",
-    "sign:win": "source ./signing.env && codesign -s \"$CSC_NAME\" ./electron/dist/*$npm_package_version.exe"
+    "dev:bundle": "NODE_ENV=development parcel watch ./src/index.dev.njk --hmr-hostname localhost --public-url=./"
   },
   "lint-staged": {
     "ignore": [

--- a/scripts/signing-env.sh
+++ b/scripts/signing-env.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -f ./signing.env ]; then
+  echo "Loading signing config from signing.env..."
+  source ./signing.env
+fi
+
+echo "Code Signing Password: "
+read -s CSC_KEY_PASSWORD
+
+export CSC_LINK
+export CSC_KEY_PASSWORD


### PR DESCRIPTION
See #351 (will stay open until Mac DMG signing has been confirmed to work).