### PR TITLE
Increase tx time bounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,8 +3865,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -4158,6 +4157,15 @@
       "requires": {
         "caniuse-lite": "^1.0.30000792",
         "electron-to-chromium": "^1.3.30"
+      }
+    },
+    "buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -5018,9 +5026,12 @@
       }
     },
     "crc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
-      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -9577,8 +9588,7 @@
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-      "dev": true
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -10221,9 +10231,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-xdr": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-1.1.0.tgz",
-      "integrity": "sha512-g2Q0ccis46I9IgyYhQDAC6P9vW9ceB0HW1UyzbVUPjr1Mpd63bbk3EjopTvjGbglCHO7Lx2ftcRzaXjKso95HA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-1.1.1.tgz",
+      "integrity": "sha512-csYOkKC78umSY2r3oDUONGH1ZcyTex7VlzpfmjKdzlNoeqFQtOA1rhBE9/e3mFNiO0Do65EVvyWx2jHHtRYPPg==",
       "requires": {
         "core-js": "^2.6.3",
         "cursor": "^0.1.5",
@@ -17351,16 +17361,16 @@
       "dev": true
     },
     "stellar-base": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-0.11.0.tgz",
-      "integrity": "sha512-D0FwWzDNnlLeybniBVEA+kJObtFdei+4C/aAoRn7uBbd0aMpRh5GrqKpWbzoLYkYCqdyBRzrzuEmB6MpO2oCpg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-0.12.0.tgz",
+      "integrity": "sha512-Q002doIAWIe3YXm6Y2W+ta4Yh8Yy9rGZC0WzuF5eZLc8mO+jj1FfamOMs+oE4jeGh/YvO0Y4Jfb9acFCatiQ7Q==",
       "requires": {
-        "base32.js": "~0.1.0",
+        "base32.js": "^0.1.0",
         "bignumber.js": "^4.0.0",
-        "crc": "3.5.0",
+        "crc": "^3.5.0",
         "ed25519": "0.0.4",
-        "js-xdr": "^1.1.0",
-        "lodash": "^4.17.10",
+        "js-xdr": "^1.1.1",
+        "lodash": "^4.17.11",
         "sha.js": "^2.3.6",
         "tweetnacl": "^1.0.0"
       }
@@ -17378,6 +17388,28 @@
         "stellar-base": "^0.11.0",
         "toml": "^2.3.0",
         "urijs": "1.19.1"
+      },
+      "dependencies": {
+        "crc": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+          "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
+        },
+        "stellar-base": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-0.11.0.tgz",
+          "integrity": "sha512-D0FwWzDNnlLeybniBVEA+kJObtFdei+4C/aAoRn7uBbd0aMpRh5GrqKpWbzoLYkYCqdyBRzrzuEmB6MpO2oCpg==",
+          "requires": {
+            "base32.js": "~0.1.0",
+            "bignumber.js": "^4.0.0",
+            "crc": "3.5.0",
+            "ed25519": "0.0.4",
+            "js-xdr": "^1.1.0",
+            "lodash": "^4.17.10",
+            "sha.js": "^2.3.6",
+            "tweetnacl": "^1.0.0"
+          }
+        }
       }
     },
     "storybook-addon-material-ui": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/react-qr-reader": "^2.1.1",
     "@types/react-router": "^4.4.3",
     "@types/react-router-dom": "^4.3.1",
+    "@types/stellar-base": "^0.10.2",
     "@types/stellar-sdk": "^0.11.1",
     "@types/storybook__react": "^3.0.7",
     "awesome-typescript-loader": "~3.5.0",
@@ -95,6 +96,7 @@
     "react-qr-reader": "^2.1.0",
     "react-router": "^4.4.0-beta.6",
     "react-router-dom": "^4.4.0-beta.6",
+    "stellar-base": "^0.12.0",
     "stellar-sdk": "^0.13.0"
   }
 }

--- a/src/components/Account/OfferList.tsx
+++ b/src/components/Account/OfferList.tsx
@@ -11,7 +11,7 @@ import BarChartIcon from "@material-ui/icons/BarChart"
 import CloseIcon from "@material-ui/icons/Close"
 import { Account } from "../../context/accounts"
 import { trackError } from "../../context/notifications"
-import { useAccountOffers, useHorizon } from "../../hooks"
+import { useAccountData, useAccountOffers, useHorizon, ObservedAccountData } from "../../hooks"
 import { createTransaction } from "../../lib/transaction"
 import { HorizontalLayout } from "../Layout/Box"
 import { List } from "../List"
@@ -21,6 +21,7 @@ import { SingleBalance } from "./AccountBalances"
 function createDismissalTransaction(
   horizon: Server,
   account: Account,
+  accountData: ObservedAccountData,
   offer: Server.OfferRecord
 ): Promise<Transaction> {
   return createTransaction(
@@ -33,7 +34,7 @@ function createDismissalTransaction(
         selling: offer.selling
       })
     ],
-    { horizon, walletAccount: account }
+    { accountData, horizon, walletAccount: account }
   )
 }
 
@@ -95,12 +96,13 @@ interface Props {
 }
 
 function OfferList(props: Props & { sendTransaction: (tx: Transaction) => Promise<void> }) {
+  const accountData = useAccountData(props.account.publicKey, props.account.testnet)
   const offers = useAccountOffers(props.account.publicKey, props.account.testnet)
   const horizon = useHorizon(props.account.testnet)
 
   const onCancel = async (offer: Server.OfferRecord) => {
     try {
-      const tx = await createDismissalTransaction(horizon, props.account, offer)
+      const tx = await createDismissalTransaction(horizon, props.account, accountData, offer)
       await props.sendTransaction(tx)
     } catch (error) {
       trackError(error)

--- a/src/components/Dialog/CustomTrustline.tsx
+++ b/src/components/Dialog/CustomTrustline.tsx
@@ -8,6 +8,7 @@ import TextField from "@material-ui/core/TextField"
 import VerifiedUserIcon from "@material-ui/icons/VerifiedUser"
 import { Account } from "../../context/accounts"
 import { trackError } from "../../context/notifications"
+import { useAccountData } from "../../hooks"
 import { createTransaction } from "../../lib/transaction"
 import { ActionButton, DialogActionsBox } from "./Generic"
 
@@ -26,6 +27,7 @@ function CustomTrustlineDialog(props: Props) {
   const [issuerPublicKey, setIssuerPublicKey] = React.useState("")
   const [limit, setLimit] = React.useState("")
   const [txCreationPending, setTxCreationPending] = React.useState(false)
+  const accountData = useAccountData(props.account.publicKey, props.account.testnet)
 
   const addAsset = async (asset: Asset, options: { limit?: string } = {}) => {
     try {
@@ -33,6 +35,7 @@ function CustomTrustlineDialog(props: Props) {
 
       setTxCreationPending(true)
       const transaction = await createTransaction(operations, {
+        accountData,
         horizon: props.horizon,
         walletAccount: props.account
       })

--- a/src/components/Dialog/ManageAssets.tsx
+++ b/src/components/Dialog/ManageAssets.tsx
@@ -7,6 +7,7 @@ import Typography from "@material-ui/core/Typography"
 import AddIcon from "@material-ui/icons/Add"
 import { Account, AccountsContext } from "../../context/accounts"
 import { trackError } from "../../context/notifications"
+import { useAccountData } from "../../hooks"
 import { createTransaction } from "../../lib/transaction"
 import TrustlineList from "../Account/TrustlineList"
 import { Box, HorizontalLayout } from "../Layout/Box"
@@ -29,11 +30,13 @@ interface Props {
 function ManageAssets(props: Props) {
   const [isCustomTrustlineDialogOpen, setCustomTrustlineDialogOpen] = React.useState(false)
   const [removalDialogAsset, setRemovalDialogAsset] = React.useState<Asset | null>(null)
+  const accountData = useAccountData(props.account.publicKey, props.account.testnet)
 
   const addAsset = async (asset: Asset, options: { limit?: string } = {}) => {
     try {
       const operations = [Operation.changeTrust({ asset, limit: options.limit })]
       const transaction = await createTransaction(operations, {
+        accountData,
         horizon: props.horizon,
         walletAccount: props.account
       })
@@ -72,6 +75,7 @@ function ManageAssets(props: Props) {
       />
       <RemoveTrustlineDialog
         account={props.account}
+        accountData={accountData}
         asset={removalDialogAsset || Asset.native()}
         open={removalDialogAsset !== null}
         onClose={() => setRemovalDialogAsset(null)}

--- a/src/components/Dialog/ManageSigners.tsx
+++ b/src/components/Dialog/ManageSigners.tsx
@@ -67,6 +67,7 @@ function ManageSignersDialog(props: Props) {
       }
 
       const tx = await createTransaction(operations, {
+        accountData: props.accountData,
         horizon: props.horizon,
         walletAccount: props.account
       })

--- a/src/components/Dialog/TradeAsset.tsx
+++ b/src/components/Dialog/TradeAsset.tsx
@@ -99,6 +99,7 @@ function TradeAsset(props: TradeAssetProps) {
         })
       ],
       {
+        accountData,
         horizon,
         walletAccount: props.account
       }

--- a/src/components/Form/CreatePayment.tsx
+++ b/src/components/Form/CreatePayment.tsx
@@ -66,7 +66,7 @@ interface AssetSelectorProps {
   style: React.CSSProperties
 }
 
-const AssetSelector = (props: AssetSelectorProps) => {
+function AssetSelector(props: AssetSelectorProps) {
   return (
     <FormControl>
       <Select onChange={event => props.onSelect(event.target.value)} style={props.style} value={props.selected}>
@@ -80,26 +80,45 @@ const AssetSelector = (props: AssetSelectorProps) => {
   )
 }
 
-interface PaymentCreationFormProps {
-  errors: PaymentCreationErrors
-  formValues: PaymentCreationValues
+interface Props {
+  balances: Horizon.BalanceLine[]
   trustedAssets: Asset[]
   txCreationPending?: boolean
-  setFormValue: (fieldName: keyof PaymentCreationValues, value: string) => void
   onCancel: () => void
-  onSubmit: () => void
+  onSubmit?: (formValues: PaymentCreationValues) => any
 }
 
-const PaymentCreationForm = (props: PaymentCreationFormProps) => {
-  const { errors, formValues, setFormValue, onCancel, onSubmit } = props
+function PaymentCreationForm(props: Props) {
+  const { onSubmit = () => undefined } = props
 
-  const handleSubmitEvent = (event: React.SyntheticEvent) => {
+  const [errors, setErrors] = React.useState<PaymentCreationErrors>({})
+  const [formValues, setFormValues] = React.useState<PaymentCreationValues>({
+    amount: "",
+    asset: "XLM",
+    destination: "",
+    memoType: "none",
+    memoValue: ""
+  })
+
+  const setFormValue = (fieldName: keyof PaymentCreationValues, value: string | null) => {
+    setFormValues({
+      ...formValues,
+      [fieldName]: value
+    })
+  }
+
+  const submit = (event: React.SyntheticEvent) => {
     event.preventDefault()
-    onSubmit()
+    const { errors, success } = validateFormValues(formValues, props.balances)
+    setErrors(errors)
+
+    if (success) {
+      onSubmit(formValues)
+    }
   }
 
   return (
-    <form onSubmit={handleSubmitEvent}>
+    <form onSubmit={submit}>
       <TextField
         error={Boolean(errors.destination)}
         label={errors.destination ? renderFormFieldError(errors.destination) : "Destination address"}
@@ -163,7 +182,7 @@ const PaymentCreationForm = (props: PaymentCreationFormProps) => {
         )}
       </Box>
       <DialogActionsBox spacing="large" style={{ marginTop: 64 }}>
-        <ActionButton onClick={onCancel}>Cancel</ActionButton>
+        <ActionButton onClick={props.onCancel}>Cancel</ActionButton>
         <ActionButton
           icon={<SendIcon style={{ fontSize: 16 }} />}
           loading={props.txCreationPending}
@@ -177,56 +196,4 @@ const PaymentCreationForm = (props: PaymentCreationFormProps) => {
   )
 }
 
-interface Props {
-  balances: Horizon.BalanceLine[]
-  trustedAssets: Asset[]
-  txCreationPending?: boolean
-  onCancel: () => void
-  onSubmit?: (formValues: PaymentCreationValues) => any
-}
-
-interface State {
-  errors: PaymentCreationErrors
-  formValues: PaymentCreationValues
-}
-
-class StatefulPaymentCreationForm extends React.Component<Props, State> {
-  state: State = {
-    errors: {},
-    formValues: {
-      amount: "",
-      asset: "XLM",
-      destination: "",
-      memoType: "none",
-      memoValue: ""
-    }
-  }
-
-  setFormValue = (fieldName: keyof PaymentCreationValues, value: string | null) => {
-    this.setState({
-      formValues: {
-        ...this.state.formValues,
-        [fieldName]: value
-      }
-    })
-  }
-
-  submit = () => {
-    const { onSubmit = () => undefined } = this.props
-
-    const { errors, success } = validateFormValues(this.state.formValues, this.props.balances)
-    this.setState({ errors })
-
-    if (success) {
-      onSubmit(this.state.formValues)
-    }
-  }
-
-  render() {
-    return (
-      <PaymentCreationForm {...this.props} {...this.state} onSubmit={this.submit} setFormValue={this.setFormValue} />
-    )
-  }
-}
-
-export default StatefulPaymentCreationForm
+export default PaymentCreationForm

--- a/src/components/Form/CreatePayment.tsx
+++ b/src/components/Form/CreatePayment.tsx
@@ -109,10 +109,10 @@ function PaymentCreationForm(props: Props) {
 
   const submit = (event: React.SyntheticEvent) => {
     event.preventDefault()
-    const { errors, success } = validateFormValues(formValues, props.balances)
-    setErrors(errors)
+    const validation = validateFormValues(formValues, props.balances)
+    setErrors(validation.errors)
 
-    if (success) {
+    if (validation.success) {
       onSubmit(formValues)
     }
   }


### PR DESCRIPTION
Makes `createTransaction()` select a timeout based on whether the source account is multi-signature or not. Includes cherry-picked `Turn CreatePaymentForm into functional component` commit from the SEP-6 withdrawal feature branch.

Sets the transaction timeout to `TimeoutInfinite` if it's a multi-sig account.

Fixes #428.