### PR TITLE
Implement update notification

### DIFF
--- a/electron-build.yml
+++ b/electron-build.yml
@@ -1,3 +1,4 @@
+# Don't change the appId! See <https://www.electron.build/configuration/nsis#guid-vs-application-name>
 appId: io.solarwallet.app
 productName: Solar Wallet
 copyright: Copyright © 2019 SatoshiPay Ltd

--- a/electron/lib/app.js
+++ b/electron/lib/app.js
@@ -1,7 +1,12 @@
 const { app, Menu } = require("electron")
 const { createAppMenu } = require("./menu")
 const { createMainWindow, getOpenWindows, trackWindow } = require("./window")
+
+// Needs to match the value in electron-build.yml
+app.setAppUserModelId("io.solarwallet.app")
+
 require("./storage")
+require("./updater")
 
 // Enable opening dev tools in production using keyboard shortcut
 require("electron-debug")({

--- a/electron/lib/updater.js
+++ b/electron/lib/updater.js
@@ -1,0 +1,53 @@
+const { Notification } = require("electron")
+const fetch = require("isomorphic-fetch")
+const open = require("opn")
+const pkg = require("../../package.json")
+
+const owner = "satoshipay"
+const repo = "solar"
+
+checkForUpdates().catch(console.error)
+
+async function checkForUpdates() {
+  const release = await fetchLatestRelease(owner, repo)
+  const releaseIsNewer = release.name.replace(/^v/, "") > pkg.version
+
+  console.debug(`Latest release: ${release.name}`)
+
+  const urlToOpen = selectURLToOpen(release)
+
+  if (releaseIsNewer && Notification.isSupported()) {
+    const notification = new Notification({
+      title: `New version ${release.name} of Solar available`,
+      subtitle: `Click to download the update.`
+    })
+    notification.on("click", () => open(urlToOpen))
+    notification.show()
+  }
+}
+
+async function fetchLatestRelease(owner, repo) {
+  const releaseResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`)
+
+  if (!releaseResponse.ok) {
+    throw new Error(
+      `Could not fetch latest release data from GitHub. ` + `Request failed with status ${releaseResponse.status}.`
+    )
+  }
+
+  return releaseResponse.json()
+}
+
+function selectURLToOpen(releaseData) {
+  const downloadURLs = releaseData.assets.map(asset => asset.browser_download_url)
+
+  if (process.platform === "darwin") {
+    const dmgURL = downloadURLs.find(url => url.match(/\.dmg$/i))
+    return dmgURL || releaseData.html_url
+  } else if (process.platform === "win32") {
+    const exeURL = downloadURLs.find(url => url.match(/\.exe$/i))
+    return exeURL || releaseData.html_url
+  } else {
+    return releaseData.html_url
+  }
+}


### PR DESCRIPTION
There are a lot of moving parts around the deployment right now and the default electron-builder / electron-updater setup seems a bit buggy. So this introduces a simple custom update checker that shows a notification that triggers the download of the latest release when clicked.

Kind-of fixes #173.