### PR TITLE
Disable "trade" button in unactivated accounts

### DIFF
--- a/src/components/Account/AccountHeaderCard.tsx
+++ b/src/components/Account/AccountHeaderCard.tsx
@@ -108,6 +108,7 @@ function AccountHeaderCard(props: Props) {
           <Box grow style={{ textAlign: "right" }}>
             <Button
               color="secondary"
+              disabled={!accountData.activated}
               onClick={() => router.history.push(routes.tradeAsset(props.account.id))}
               style={{ marginRight: 8 }}
               variant="outlined"

--- a/src/components/Account/AccountHeaderCard.tsx
+++ b/src/components/Account/AccountHeaderCard.tsx
@@ -107,8 +107,9 @@ function AccountHeaderCard(props: Props) {
           </HorizontalLayout>
           <Box grow style={{ textAlign: "right" }}>
             <Button
+              color="secondary"
               onClick={() => router.history.push(routes.tradeAsset(props.account.id))}
-              style={{ borderColor: "rgba(255, 255, 255, 0.9)", color: "white", marginRight: 8 }}
+              style={{ marginRight: 8 }}
               variant="outlined"
             >
               <ButtonIconLabel label="Trade">

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -40,6 +40,13 @@ const theme = createMuiTheme({
       flatPrimary: {
         color: brandColor.dark
       },
+      outlinedSecondary: {
+        borderColor: "rgba(255, 255, 255, 0.87)",
+        color: "white",
+        "&:hover": {
+          borderColor: "white"
+        }
+      },
       raisedPrimary: {}
     },
     MuiFormLabel: {


### PR DESCRIPTION
Fixes #438.

Also comes with a very small theming change: The unused *outlined secondary* button style is now used for those white buttons on brand-colored surfaces.
