### PR TITLE
Adjust transaction confirmation UI 

### DIFF
--- a/src/components/Dialog/TransactionConfirmation.tsx
+++ b/src/components/Dialog/TransactionConfirmation.tsx
@@ -50,7 +50,6 @@ function TxConfirmationDialog(props: TxConfirmationDialogProps) {
                 account={props.account}
                 disabled={props.disabled}
                 onConfirm={formValues => props.onSubmitTransaction(props.transaction as Transaction, formValues)}
-                onCancel={props.onClose}
                 passwordError={props.passwordError}
                 signatureRequest={props.signatureRequest}
                 transaction={props.transaction}

--- a/src/components/Dialog/TransactionConfirmation.tsx
+++ b/src/components/Dialog/TransactionConfirmation.tsx
@@ -36,7 +36,13 @@ function TxConfirmationDialog(props: TxConfirmationDialogProps) {
   const isSmallScreen = useIsMobile()
 
   return (
-    <Dialog open={props.open} fullScreen onClose={props.onClose} maxWidth="lg" TransitionComponent={Transition}>
+    <Dialog
+      open={props.open}
+      fullScreen={isSmallScreen}
+      onClose={props.onClose}
+      maxWidth="lg"
+      TransitionComponent={Transition}
+    >
       <ErrorBoundary>
         <Box padding="24px 36px" overflow="auto">
           <MainTitle
@@ -48,7 +54,7 @@ function TxConfirmationDialog(props: TxConfirmationDialogProps) {
             onBack={props.onClose}
           />
           {props.transaction ? (
-            <Box margin="8px 0 0">
+            <Box margin="12px auto 0" style={isSmallScreen ? { width: "fit-content" } : {}} textAlign="center">
               <TxConfirmationForm
                 account={props.account}
                 disabled={props.disabled}

--- a/src/components/Dialog/TransactionConfirmation.tsx
+++ b/src/components/Dialog/TransactionConfirmation.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 import Dialog from "@material-ui/core/Dialog"
 import Slide from "@material-ui/core/Slide"
-import Typography from "@material-ui/core/Typography"
 import { Operation, Transaction } from "stellar-sdk"
 import { Account } from "../../context/accounts"
 import { SignatureRequest } from "../../lib/multisig-service"
 import ErrorBoundary from "../ErrorBoundary"
 import TxConfirmationForm from "../Form/TxConfirmation"
 import { Box } from "../Layout/Box"
+import MainTitle from "../MainTitle"
 import TestnetBadge from "./TestnetBadge"
 
 const isPaymentOperation = (operation: Operation) => ["createAccount", "payment"].indexOf(operation.type) > -1
@@ -33,12 +33,17 @@ function TxConfirmationDialog(props: TxConfirmationDialogProps) {
       : "Confirm Transaction"
 
   return (
-    <Dialog open={props.open} onClose={props.onClose} maxWidth="lg" TransitionComponent={Transition}>
+    <Dialog open={props.open} fullScreen onClose={props.onClose} maxWidth="lg" TransitionComponent={Transition}>
       <ErrorBoundary>
         <Box padding="24px 36px" overflow="auto">
-          <Typography variant="h5" component="h2">
-            {title} {props.account.testnet ? <TestnetBadge style={{ marginLeft: 8 }} /> : null}
-          </Typography>
+          <MainTitle
+            title={
+              <span>
+                {title} {props.account.testnet ? <TestnetBadge style={{ marginLeft: 8 }} /> : null}
+              </span>
+            }
+            onBack={props.onClose}
+          />
           {props.transaction ? (
             <Box margin="8px 0 0">
               <TxConfirmationForm

--- a/src/components/Dialog/TransactionConfirmation.tsx
+++ b/src/components/Dialog/TransactionConfirmation.tsx
@@ -4,6 +4,7 @@ import Slide from "@material-ui/core/Slide"
 import { Operation, Transaction } from "stellar-sdk"
 import { Account } from "../../context/accounts"
 import { SignatureRequest } from "../../lib/multisig-service"
+import { useIsMobile } from "../../hooks"
 import ErrorBoundary from "../ErrorBoundary"
 import TxConfirmationForm from "../Form/TxConfirmation"
 import { Box } from "../Layout/Box"
@@ -32,13 +33,15 @@ function TxConfirmationDialog(props: TxConfirmationDialogProps) {
       ? "Confirm Payment"
       : "Confirm Transaction"
 
+  const isSmallScreen = useIsMobile()
+
   return (
     <Dialog open={props.open} fullScreen onClose={props.onClose} maxWidth="lg" TransitionComponent={Transition}>
       <ErrorBoundary>
         <Box padding="24px 36px" overflow="auto">
           <MainTitle
             title={
-              <span>
+              <span style={isSmallScreen ? { fontSize: 18 } : undefined}>
                 {title} {props.account.testnet ? <TestnetBadge style={{ marginLeft: 8 }} /> : null}
               </span>
             }

--- a/src/components/Form/TxConfirmation.tsx
+++ b/src/components/Form/TxConfirmation.tsx
@@ -22,11 +22,10 @@ interface Props {
   signatureRequest?: SignatureRequest
   transaction: Transaction
   onConfirm?: (formValues: FormValues) => any
-  onCancel?: () => any
 }
 
 function TxConfirmationForm(props: Props) {
-  const { onCancel = () => undefined, onConfirm = () => undefined } = props
+  const { onConfirm = () => undefined } = props
 
   const [errors, setErrors] = React.useState<Partial<FormErrors>>({})
   const [formValues, setFormValues] = React.useState<FormValues>({ password: null })
@@ -82,7 +81,6 @@ function TxConfirmationForm(props: Props) {
           />
         ) : null}
         <DialogActionsBox style={{ justifyContent: "center" }}>
-          <ActionButton onClick={onCancel}>Cancel</ActionButton>
           {props.disabled ? null : (
             <ActionButton icon={<CheckIcon />} onClick={() => undefined} type="submit">
               Confirm

--- a/src/components/TransactionSummary/Transaction.tsx
+++ b/src/components/TransactionSummary/Transaction.tsx
@@ -11,6 +11,7 @@ import WarningIcon from "@material-ui/icons/Warning"
 import { Account } from "../../context/accounts"
 import { getSignerKey, signatureMatchesPublicKey } from "../../lib/stellar"
 import { ObservedAccountData } from "../../subscriptions"
+import { useIsMobile } from "../../hooks"
 import { warningColor } from "../../theme"
 import { SingleBalance } from "../Account/AccountBalances"
 import { HorizontalLayout } from "../Layout/Box"
@@ -113,12 +114,18 @@ export function Signers(props: {
 }
 
 export function SourceAccount(props: { transaction: Transaction; style?: React.CSSProperties }) {
+  const isSmallScreen = useIsMobile()
+
   return (
     <ListItem
       heading="Source Account"
       primaryText={
         <MetaDetails>
-          <Address address={props.transaction.source} style={{ fontWeight: "normal" }} variant="full" />
+          <Address
+            address={props.transaction.source}
+            style={{ fontWeight: "normal" }}
+            variant={isSmallScreen ? "short" : "full"}
+          />
         </MetaDetails>
       }
       style={props.style}

--- a/src/components/TransactionSummary/Transaction.tsx
+++ b/src/components/TransactionSummary/Transaction.tsx
@@ -61,6 +61,8 @@ const Signer = React.memo(function Signer(props: {
   signer: Horizon.AccountSigner | { key: string; weight: number }
   transaction: Transaction
 }) {
+  const isSmallScreen = useIsMobile()
+
   return (
     <HorizontalLayout alignItems="center">
       <>
@@ -69,7 +71,7 @@ const Signer = React.memo(function Signer(props: {
           <Address
             address={getSignerKey(props.signer)}
             style={{ display: "inline-block", fontWeight: "normal", minWidth: 480 }}
-            variant="full"
+            variant={isSmallScreen ? "short" : "full"}
           />
         </div>
       </>


### PR DESCRIPTION
Related to #385. 

- [x] Make tx confirmation dialog fullscreen on both desktop+mobile
- [x] Use `<MainTitle>` component
- [x] Reduce font size of title on smaller screens
- [x] Use small variant of `<Address>` in `<Signer>` and `<SourceAccount>` on smaller screens