### PR TITLE
Replace sdkversion numbers in build.gradle with required values

### DIFF
--- a/cordova/package.json
+++ b/cordova/package.json
@@ -47,7 +47,7 @@
     "prebuild:android": "NODE_ENV=production PLATFORM=android ../node_modules/.bin/parcel build ../src/index.prod-android.njk --out-dir ../dist --public-url=./ --detailed-report --no-source-maps --no-cache && ./scripts/create-config-from-template.sh prod android",
     "prebuild:ios": "NODE_ENV=production PLATFORM=ios ../node_modules/.bin/parcel build ../src/index.prod-ios.njk --out-dir ../dist --public-url=./ --detailed-report --no-source-maps --no-cache && ./scripts/create-config-from-template.sh prod ios",
     "build:android": "npm run prebuild:android && dotenv -- cordova build android",
-    "build:android:signed": "npm run prebuild:android && source ./scripts/signing-env-android.sh && dotenv -- cordova build android --release -- --keystore=$KEYSTORE_LOCATION --storePassword=$KEYSTORE_PASSWORD --alias=$SIGNINGKEY_ALIAS --password=$SIGNINGKEY_PASSWORD",
+    "build:android:signed": "npm run prebuild:android && source ./scripts/signing-env-android.sh && dotenv -- cordova build android --release -- --gradleArg=-PcdvMinSdkVersion=21 --gradleArg=-PcdvCompileSdkVersion=android-28 --keystore=$KEYSTORE_LOCATION --storePassword=$KEYSTORE_PASSWORD --alias=$SIGNINGKEY_ALIAS --password=$SIGNINGKEY_PASSWORD",
     "build:ios": "npm run prebuild:ios && cordova build ios --buildConfig=build.ios.json",
     "dev:android": "run-p dev:bundle:android dev:cordova:android",
     "dev:ios": "run-p dev:bundle:ios dev:cordova:ios",

--- a/cordova/scripts/patch-android-config.sh
+++ b/cordova/scripts/patch-android-config.sh
@@ -10,5 +10,19 @@ sedi () {
 sedi '/^.*<uses-sdk/d' ../platforms/android/CordovaLib/AndroidManifest.xml
 sedi '/^.*<uses-sdk/d' ../platforms/android/app/src/main/AndroidManifest.xml
 
-# substitute 3.3.0 with 3.3.2 in the line which contains 'com.android.tools.build:gradle'
-sedi '/com.android.tools.build:gradle/s/3.3.0/3.3.2/g' ../platforms/android/build.gradle
+sedi '18 a\ 
+<uses-sdk tools:overrideLibrary="org.apache.cordova"/> \
+' ../platforms/android/app/src/main/AndroidManifest.xml
+
+sedi 's/package="io.solarwallet"/package="io.solarwallet" xmlns:tools="http:\/\/schemas.android.com\/tools"/' ../platforms/android/app/src/main/AndroidManifest.xml
+
+sedi '170 a\ 
+targetSdkVersion 28 \
+' ../platforms/android/app/build.gradle
+sedi '171 a\ 
+minSdkVersion 21 \
+' ../platforms/android/app/build.gradle
+sedi '73 a\ 
+defaultConfig { \
+minSdkVersion 21 \
+}' ../platforms/android/CordovaLib/build.gradle


### PR DESCRIPTION
- [x] Add gradle arguments to android signing script 
- [x] Make `patch-android-config.sh` insert information about `minSdkVersion` and `targetSdkVersion ` to app/build.gradle + CordovaLib/build.gradle and adjust app-`AndroidManifest` to override settings settings from CordovaLib on conflict