### PR TITLE
Optimize UI for iPhone5 / tiny screens

### DIFF
--- a/src/components/Account/OfferList.tsx
+++ b/src/components/Account/OfferList.tsx
@@ -11,7 +11,14 @@ import BarChartIcon from "@material-ui/icons/BarChart"
 import CloseIcon from "@material-ui/icons/Close"
 import { Account } from "../../context/accounts"
 import { trackError } from "../../context/notifications"
-import { useAccountData, useAccountOffers, useHorizon, ObservedAccountData } from "../../hooks"
+import {
+  useAccountData,
+  useAccountOffers,
+  useHorizon,
+  ObservedAccountData,
+  useIsMobile,
+  useIsSmallMobile
+} from "../../hooks"
 import { createTransaction } from "../../lib/transaction"
 import { HorizontalLayout } from "../Layout/Box"
 import { List } from "../List"
@@ -47,45 +54,60 @@ interface OfferListItemProps {
 
 function OfferListItem(props: OfferListItemProps) {
   const [hovering, setHoveringStatus] = React.useState(false)
+  const isSmallScreen = useIsMobile()
+  const isTinyScreen = useIsSmallMobile()
+
   return (
     <ListItem
       onMouseEnter={() => setHoveringStatus(true)}
       onMouseLeave={() => setHoveringStatus(false)}
       style={props.style}
     >
-      <ListItemIcon>
-        <BarChartIcon />
-      </ListItemIcon>
-      <ListItemText
-        primary={
-          <span style={{ fontWeight: "bold" }}>
-            Sell&nbsp;&nbsp;
-            <SingleBalance assetCode={props.offer.selling.code} balance={props.offer.amount} inline />
-            &nbsp;&nbsp;for&nbsp;&nbsp;
-            <SingleBalance
-              assetCode={props.offer.buying.code}
-              balance={String(BigNumber(props.offer.amount).mul(props.offer.price))}
+      <HorizontalLayout alignItems="center" grow={1} wrap={"wrap"}>
+        <HorizontalLayout>
+          <ListItemIcon>
+            <BarChartIcon />
+          </ListItemIcon>
+          <ListItemText
+            style={{ paddingLeft: isTinyScreen ? 0 : undefined }}
+            primary={
+              <span
+                style={{ fontWeight: "bold", fontSize: isTinyScreen ? "0.8rem" : isSmallScreen ? "1.0rem" : undefined }}
+              >
+                Sell&nbsp;&nbsp;
+                <SingleBalance assetCode={props.offer.selling.code} balance={props.offer.amount} inline />
+                &nbsp;&nbsp;for&nbsp;&nbsp;
+                <SingleBalance
+                  assetCode={props.offer.buying.code}
+                  balance={String(BigNumber(props.offer.amount).mul(props.offer.price))}
+                  inline
+                />
+              </span>
+            }
+          />
+        </HorizontalLayout>
+        {hovering ? (
+          <Button onClick={props.onCancel} color="inherit" variant="contained">
+            Cancel&nbsp;
+            <CloseIcon style={{ fontSize: "140%" }} />
+          </Button>
+        ) : (
+          <ListItemText primaryTypographyProps={{ align: "right" }} style={{ flexShrink: 0 }}>
+            <HorizontalLayout
+              grow={1}
+              alignItems="center"
               inline
-            />
-          </span>
-        }
-      />
-      {hovering ? (
-        <Button onClick={props.onCancel} color="inherit" variant="contained">
-          Cancel&nbsp;
-          <CloseIcon style={{ fontSize: "140%" }} />
-        </Button>
-      ) : (
-        <ListItemText primaryTypographyProps={{ align: "right" }} style={{ flexShrink: 0 }}>
-          <HorizontalLayout alignItems="center" inline style={{ fontSize: "1.6rem" }}>
-            <b>{props.offer.selling.code}</b>
-            &nbsp;
-            <ArrowRightIcon style={{ fontSize: "150%" }} />
-            &nbsp;
-            <b>{props.offer.buying.code}</b>
-          </HorizontalLayout>
-        </ListItemText>
-      )}
+              style={{ fontSize: isTinyScreen ? "1.1rem" : isSmallScreen ? "1.3rem" : "1.6rem" }}
+            >
+              <b>{props.offer.selling.code}</b>
+              &nbsp;
+              <ArrowRightIcon style={{ fontSize: "150%" }} />
+              &nbsp;
+              <b>{props.offer.buying.code}</b>
+            </HorizontalLayout>
+          </ListItemText>
+        )}
+      </HorizontalLayout>
     </ListItem>
   )
 }

--- a/src/components/Account/OfferList.tsx
+++ b/src/components/Account/OfferList.tsx
@@ -11,14 +11,7 @@ import BarChartIcon from "@material-ui/icons/BarChart"
 import CloseIcon from "@material-ui/icons/Close"
 import { Account } from "../../context/accounts"
 import { trackError } from "../../context/notifications"
-import {
-  useAccountData,
-  useAccountOffers,
-  useHorizon,
-  ObservedAccountData,
-  useIsMobile,
-  useIsSmallMobile
-} from "../../hooks"
+import { useAccountData, useAccountOffers, useHorizon, ObservedAccountData } from "../../hooks"
 import { createTransaction } from "../../lib/transaction"
 import { HorizontalLayout } from "../Layout/Box"
 import { List } from "../List"
@@ -54,60 +47,45 @@ interface OfferListItemProps {
 
 function OfferListItem(props: OfferListItemProps) {
   const [hovering, setHoveringStatus] = React.useState(false)
-  const isSmallScreen = useIsMobile()
-  const isTinyScreen = useIsSmallMobile()
-
   return (
     <ListItem
       onMouseEnter={() => setHoveringStatus(true)}
       onMouseLeave={() => setHoveringStatus(false)}
       style={props.style}
     >
-      <HorizontalLayout alignItems="center" grow={1} wrap={"wrap"}>
-        <HorizontalLayout>
-          <ListItemIcon>
-            <BarChartIcon />
-          </ListItemIcon>
-          <ListItemText
-            style={{ paddingLeft: isTinyScreen ? 0 : undefined }}
-            primary={
-              <span
-                style={{ fontWeight: "bold", fontSize: isTinyScreen ? "0.8rem" : isSmallScreen ? "1.0rem" : undefined }}
-              >
-                Sell&nbsp;&nbsp;
-                <SingleBalance assetCode={props.offer.selling.code} balance={props.offer.amount} inline />
-                &nbsp;&nbsp;for&nbsp;&nbsp;
-                <SingleBalance
-                  assetCode={props.offer.buying.code}
-                  balance={String(BigNumber(props.offer.amount).mul(props.offer.price))}
-                  inline
-                />
-              </span>
-            }
-          />
-        </HorizontalLayout>
-        {hovering ? (
-          <Button onClick={props.onCancel} color="inherit" variant="contained">
-            Cancel&nbsp;
-            <CloseIcon style={{ fontSize: "140%" }} />
-          </Button>
-        ) : (
-          <ListItemText primaryTypographyProps={{ align: "right" }} style={{ flexShrink: 0 }}>
-            <HorizontalLayout
-              grow={1}
-              alignItems="center"
+      <ListItemIcon>
+        <BarChartIcon />
+      </ListItemIcon>
+      <ListItemText
+        primary={
+          <span style={{ fontWeight: "bold" }}>
+            Sell&nbsp;&nbsp;
+            <SingleBalance assetCode={props.offer.selling.code} balance={props.offer.amount} inline />
+            &nbsp;&nbsp;for&nbsp;&nbsp;
+            <SingleBalance
+              assetCode={props.offer.buying.code}
+              balance={String(BigNumber(props.offer.amount).mul(props.offer.price))}
               inline
-              style={{ fontSize: isTinyScreen ? "1.1rem" : isSmallScreen ? "1.3rem" : "1.6rem" }}
-            >
-              <b>{props.offer.selling.code}</b>
-              &nbsp;
-              <ArrowRightIcon style={{ fontSize: "150%" }} />
-              &nbsp;
-              <b>{props.offer.buying.code}</b>
-            </HorizontalLayout>
-          </ListItemText>
-        )}
-      </HorizontalLayout>
+            />
+          </span>
+        }
+      />
+      {hovering ? (
+        <Button onClick={props.onCancel} color="inherit" variant="contained">
+          Cancel&nbsp;
+          <CloseIcon style={{ fontSize: "140%" }} />
+        </Button>
+      ) : (
+        <ListItemText primaryTypographyProps={{ align: "right" }} style={{ flexShrink: 0 }}>
+          <HorizontalLayout alignItems="center" inline style={{ fontSize: "1.6rem" }}>
+            <b>{props.offer.selling.code}</b>
+            &nbsp;
+            <ArrowRightIcon style={{ fontSize: "150%" }} />
+            &nbsp;
+            <b>{props.offer.buying.code}</b>
+          </HorizontalLayout>
+        </ListItemText>
+      )}
     </ListItem>
   )
 }

--- a/src/components/Account/TrustlineList.tsx
+++ b/src/components/Account/TrustlineList.tsx
@@ -11,7 +11,7 @@ import CheckIcon from "@material-ui/icons/CheckCircle"
 import RemoveIcon from "@material-ui/icons/Close"
 import UncheckedIcon from "@material-ui/icons/RadioButtonUnchecked"
 import { Account } from "../../context/accounts"
-import { useIsMobile, useAccountData } from "../../hooks"
+import { useAccountData, useIsMobile, useIsSmallMobile } from "../../hooks"
 import { mainnet as mainnetPopularAssets, testnet as testnetPopularAssets } from "../../lib/popularAssets"
 import { trustlineLimitEqualsUnlimited } from "../../lib/stellar"
 import SpaciousList from "../List/SpaciousList"
@@ -50,6 +50,7 @@ function TrustedAsset(props: TrustedAssetProps) {
   const { account, balance } = props
   const [hovering, setHovering] = React.useState(false)
   const isSmallScreen = useIsMobile()
+  const isTinyScreen = useIsSmallMobile()
 
   return (
     <ListItem onMouseEnter={() => setHovering(true)} onMouseLeave={() => setHovering(false)}>
@@ -68,7 +69,9 @@ function TrustedAsset(props: TrustedAssetProps) {
           <SingleBalance
             assetCode=""
             balance={balance.balance}
-            style={isSmallScreen ? { fontSize: "1.1rem" } : { fontSize: "1.6rem" }}
+            style={
+              isTinyScreen ? { fontSize: "0.9rem" } : isSmallScreen ? { fontSize: "1.1rem" } : { fontSize: "1.6rem" }
+            }
           />
         )}
       </ListItemText>
@@ -137,6 +140,7 @@ interface Props {
 function TrustlineList(props: Props) {
   const accountData = useAccountData(props.account.publicKey, props.account.testnet)
   const isSmallScreen = useIsMobile()
+  const isTinyScreen = useIsSmallMobile()
 
   const isAssetAlreadyAdded = (asset: Asset) => {
     return accountData.balances.some(
@@ -161,7 +165,9 @@ function TrustlineList(props: Props) {
           <SingleBalance
             assetCode=""
             balance={xlmBalance ? xlmBalance.balance : "0.00"}
-            style={isSmallScreen ? { fontSize: "1.1rem" } : { fontSize: "1.6rem" }}
+            style={
+              isTinyScreen ? { fontSize: "0.9rem" } : isSmallScreen ? { fontSize: "1.1rem" } : { fontSize: "1.6rem" }
+            }
           />
         </ListItemText>
         <ListItemSecondaryAction />

--- a/src/components/Account/TrustlineList.tsx
+++ b/src/components/Account/TrustlineList.tsx
@@ -52,6 +52,8 @@ function TrustedAsset(props: TrustedAssetProps) {
   const isSmallScreen = useIsMobile()
   const isTinyScreen = useIsSmallMobile()
 
+  const fontSize = isTinyScreen ? "0.9rem" : isSmallScreen ? "1.1rem" : "1.6rem"
+
   return (
     <ListItem onMouseEnter={() => setHovering(true)} onMouseLeave={() => setHovering(false)}>
       <ListItemIcon style={{ color: "inherit" }}>
@@ -66,13 +68,7 @@ function TrustedAsset(props: TrustedAssetProps) {
         {hovering && props.hoverActions ? (
           props.hoverActions
         ) : (
-          <SingleBalance
-            assetCode=""
-            balance={balance.balance}
-            style={
-              isTinyScreen ? { fontSize: "0.9rem" } : isSmallScreen ? { fontSize: "1.1rem" } : { fontSize: "1.6rem" }
-            }
-          />
+          <SingleBalance assetCode="" balance={balance.balance} style={{ fontSize }} />
         )}
       </ListItemText>
       <ListItemSecondaryAction>
@@ -154,6 +150,8 @@ function TrustlineList(props: Props) {
 
   const xlmBalance = accountData.balances.find(balance => balance.asset_type === "native")
 
+  const fontSize = isTinyScreen ? "0.9rem" : isSmallScreen ? "1.1rem" : "1.6rem"
+
   return (
     <SpaciousList fitHorizontal>
       <ListItem>
@@ -162,13 +160,7 @@ function TrustlineList(props: Props) {
         </ListItemIcon>
         <ListItemText inset primary="XLM" secondary="Stellar Lumens" />
         <ListItemText primaryTypographyProps={{ align: "right" }} style={{ flexShrink: 0 }}>
-          <SingleBalance
-            assetCode=""
-            balance={xlmBalance ? xlmBalance.balance : "0.00"}
-            style={
-              isTinyScreen ? { fontSize: "0.9rem" } : isSmallScreen ? { fontSize: "1.1rem" } : { fontSize: "1.6rem" }
-            }
-          />
+          <SingleBalance assetCode="" balance={xlmBalance ? xlmBalance.balance : "0.00"} style={{ fontSize }} />
         </ListItemText>
         <ListItemSecondaryAction />
       </ListItem>

--- a/src/components/Dialog/Generic.tsx
+++ b/src/components/Dialog/Generic.tsx
@@ -6,6 +6,7 @@ import DialogContent from "@material-ui/core/DialogContent"
 import DialogTitle from "@material-ui/core/DialogTitle"
 import Slide from "@material-ui/core/Slide"
 import Typography from "@material-ui/core/Typography"
+import { useIsSmallMobile } from "../../hooks"
 import { HorizontalMargin } from "../Layout/Spacing"
 import ButtonIconLabel from "../ButtonIconLabel"
 
@@ -38,6 +39,8 @@ interface ActionButtonProps {
 
 export function ActionButton(props: ActionButtonProps) {
   const { type = "secondary" } = props
+  const isTinyScreen = useIsSmallMobile()
+
   return (
     <Button
       autoFocus={props.autoFocus}
@@ -45,7 +48,7 @@ export function ActionButton(props: ActionButtonProps) {
       disabled={props.disabled}
       onClick={props.onClick}
       style={{
-        padding: "10px 20px",
+        padding: isTinyScreen ? "2px 8px" : "10px 20px",
         ...props.style
       }}
       type={type === "submit" ? "submit" : undefined}

--- a/src/components/Dialog/Rename.tsx
+++ b/src/components/Dialog/Rename.tsx
@@ -4,9 +4,9 @@ import DialogTitle from "@material-ui/core/DialogTitle"
 import TextField from "@material-ui/core/TextField"
 import EditIcon from "@material-ui/icons/Edit"
 import { trackError } from "../../context/notifications"
+import { useIsMobile } from "../../hooks"
 import CloseButton from "./CloseButton"
 import { ActionButton, DialogActionsBox } from "./Generic"
-import { useIsSmallMobile, useIsMobile } from "../../hooks"
 
 interface Props {
   onClose: () => void
@@ -18,7 +18,6 @@ interface Props {
 function RenameDialog(props: Props) {
   const [newName, setNewName] = React.useState(props.prevValue)
   const isSmallScreen = useIsMobile()
-  const isTinyScreen = useIsSmallMobile()
 
   const handleInput = (event: React.SyntheticEvent) => {
     setNewName((event.target as HTMLInputElement).value)
@@ -37,10 +36,7 @@ function RenameDialog(props: Props) {
       <CloseButton onClick={props.onClose} />
       <DialogTitle>{props.title}</DialogTitle>
       <DialogContent>
-        <form
-          style={isTinyScreen ? { minWidth: 120 } : isSmallScreen ? { minWidth: 250 } : { minWidth: 400 }}
-          onSubmit={handleSubmit}
-        >
+        <form style={{ minWidth: isSmallScreen ? 120 : 400 }} onSubmit={handleSubmit}>
           <TextField
             autoFocus={process.env.PLATFORM !== "ios"}
             fullWidth

--- a/src/components/Dialog/Rename.tsx
+++ b/src/components/Dialog/Rename.tsx
@@ -2,11 +2,11 @@ import React from "react"
 import DialogContent from "@material-ui/core/DialogContent"
 import DialogTitle from "@material-ui/core/DialogTitle"
 import TextField from "@material-ui/core/TextField"
-import { unstable_useMediaQuery as useMediaQuery } from "@material-ui/core/useMediaQuery"
 import EditIcon from "@material-ui/icons/Edit"
 import { trackError } from "../../context/notifications"
 import CloseButton from "./CloseButton"
 import { ActionButton, DialogActionsBox } from "./Generic"
+import { useIsSmallMobile, useIsMobile } from "../../hooks"
 
 interface Props {
   onClose: () => void
@@ -17,7 +17,8 @@ interface Props {
 
 function RenameDialog(props: Props) {
   const [newName, setNewName] = React.useState(props.prevValue)
-  const isWidthMax500 = useMediaQuery("(max-width:500px)")
+  const isSmallScreen = useIsMobile()
+  const isTinyScreen = useIsSmallMobile()
 
   const handleInput = (event: React.SyntheticEvent) => {
     setNewName((event.target as HTMLInputElement).value)
@@ -36,7 +37,10 @@ function RenameDialog(props: Props) {
       <CloseButton onClick={props.onClose} />
       <DialogTitle>{props.title}</DialogTitle>
       <DialogContent>
-        <form style={isWidthMax500 ? { minWidth: 200 } : { minWidth: 300 }} onSubmit={handleSubmit}>
+        <form
+          style={isTinyScreen ? { minWidth: 120 } : isSmallScreen ? { minWidth: 250 } : { minWidth: 400 }}
+          onSubmit={handleSubmit}
+        >
           <TextField
             autoFocus={process.env.PLATFORM !== "ios"}
             fullWidth

--- a/src/components/Form/CreateAccount.tsx
+++ b/src/components/Form/CreateAccount.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { unstable_useMediaQuery as useMediaQuery } from "@material-ui/core/useMediaQuery"
 import Button from "@material-ui/core/Button"
 import InputAdornment from "@material-ui/core/InputAdornment"
 import TextField from "@material-ui/core/TextField"
@@ -10,7 +9,7 @@ import EditIcon from "@material-ui/icons/Edit"
 import { Keypair } from "stellar-sdk"
 import { Account } from "../../context/accounts"
 import { trackError } from "../../context/notifications"
-import { useIsMobile } from "../../hooks"
+import { useIsMobile, useIsSmallMobile } from "../../hooks"
 import { renderFormFieldError } from "../../lib/errors"
 import QRImportDialog from "../Dialog/QRImport"
 import QRCodeIcon from "../Icon/QRCode"
@@ -77,12 +76,12 @@ interface AccountCreationFormProps {
 const AccountCreationForm = (props: AccountCreationFormProps) => {
   const { errors, formValues, setFormValue } = props
   const isSmallScreen = useIsMobile()
-  const isWidthMax400 = useMediaQuery("(max-width:400px)")
+  const isTinyScreen = useIsSmallMobile()
   const primaryButtonLabel = formValues.createNewKey
-    ? isWidthMax400
+    ? isTinyScreen
       ? "Create"
       : "Create Account"
-    : isWidthMax400
+    : isTinyScreen
       ? "Import"
       : "Import Account"
   return (
@@ -105,10 +104,10 @@ const AccountCreationForm = (props: AccountCreationFormProps) => {
                 </InputAdornment>
               ),
               style: {
-                fontSize: "1.5rem"
+                fontSize: isTinyScreen ? "1.3rem" : "1.5rem"
               }
             }}
-            style={{ minWidth: 300, maxWidth: "70%", margin: 0, paddingLeft: 12 }}
+            style={{ minWidth: isTinyScreen ? 230 : 300, maxWidth: "70%", margin: 0, paddingLeft: 12 }}
           />
         </Box>
         <ToggleSection
@@ -146,7 +145,7 @@ const AccountCreationForm = (props: AccountCreationFormProps) => {
                   flex: "1 0 0",
                   marginLeft: isSmallScreen ? 6 : 16,
                   marginRight: isSmallScreen ? 6 : 16,
-                  minWidth: 250
+                  minWidth: isTinyScreen ? 150 : 250
                 }}
                 type="password"
                 value={formValues.password}
@@ -163,7 +162,7 @@ const AccountCreationForm = (props: AccountCreationFormProps) => {
                   flex: "1 0 0",
                   marginLeft: isSmallScreen ? 6 : 16,
                   marginRight: isSmallScreen ? 6 : 16,
-                  minWidth: 250
+                  minWidth: isTinyScreen ? 150 : 250
                 }}
                 type="password"
                 value={formValues.passwordRepeat}

--- a/src/components/ManageSigners/NewSignerForm.tsx
+++ b/src/components/ManageSigners/NewSignerForm.tsx
@@ -7,6 +7,7 @@ import TextField from "@material-ui/core/TextField"
 import CheckIcon from "@material-ui/icons/Check"
 import CloseIcon from "@material-ui/icons/Close"
 import PersonAddIcon from "@material-ui/icons/PersonAdd"
+import { useIsSmallMobile, useIsMobile } from "../../hooks"
 import { HorizontalLayout } from "../Layout/Box"
 
 interface FormValues {
@@ -28,6 +29,9 @@ interface Props {
 }
 
 function NewSignerForm(props: Props) {
+  const isSmallScreen = useIsMobile()
+  const isTinyScreen = useIsSmallMobile()
+
   return (
     <ListItem>
       <ListItemIcon>
@@ -39,20 +43,24 @@ function NewSignerForm(props: Props) {
             autoFocus={process.env.PLATFORM !== "ios"}
             error={!!props.errors.publicKey}
             label={props.errors.publicKey ? props.errors.publicKey.message : "Public Key or Stellar Address"}
-            placeholder="GABCDEFGHIJK... or alice*example.org"
+            placeholder={isSmallScreen ? "GABCDEFGHIJK..." : "GABCDEFGHIJK... or alice*example.org"}
             onChange={event => props.onUpdate({ publicKey: event.target.value })}
             style={{ flexGrow: 1 }}
+            InputProps={isTinyScreen ? { style: { fontSize: "0.8rem" } } : undefined}
             value={props.values.publicKey}
           />
         </HorizontalLayout>
       </ListItemText>
-      <ListItemIcon style={{ marginRight: 8 }}>
+      <ListItemIcon style={isTinyScreen ? { padding: 0, margin: 0 } : { marginRight: 8 }}>
         <IconButton onClick={props.onSubmit}>
           <CheckIcon />
         </IconButton>
       </ListItemIcon>
       <ListItemIcon>
-        <IconButton onClick={props.onCancel} style={{ marginRight: -24 }}>
+        <IconButton
+          onClick={props.onCancel}
+          style={isTinyScreen ? { padding: 0, marginRight: -24 } : { marginRight: -24 }}
+        >
           <CloseIcon />
         </IconButton>
       </ListItemIcon>

--- a/src/components/ManageSigners/NewSignerForm.tsx
+++ b/src/components/ManageSigners/NewSignerForm.tsx
@@ -43,7 +43,7 @@ function NewSignerForm(props: Props) {
             autoFocus={process.env.PLATFORM !== "ios"}
             error={!!props.errors.publicKey}
             label={props.errors.publicKey ? props.errors.publicKey.message : "Public Key or Stellar Address"}
-            placeholder={isSmallScreen ? "GABCDEFGHIJK..." : "GABCDEFGHIJK... or alice*example.org"}
+            placeholder={isSmallScreen ? "GABC… or address" : "GABCDEFGHIJK… or alice*example.org"}
             onChange={event => props.onUpdate({ publicKey: event.target.value })}
             style={{ flexGrow: 1 }}
             InputProps={isTinyScreen ? { style: { fontSize: "0.8rem" } } : undefined}

--- a/src/components/TradeAsset/TradingForm.tsx
+++ b/src/components/TradeAsset/TradingForm.tsx
@@ -1,7 +1,7 @@
 import BigNumber from "big.js"
 import React from "react"
 import { Asset, AssetType, Horizon } from "stellar-sdk"
-import { useOrderbook } from "../../hooks"
+import { useOrderbook, useIsSmallMobile } from "../../hooks"
 import { calculateSpread } from "../../lib/orderbook"
 import { Box, HorizontalLayout, VerticalLayout } from "../Layout/Box"
 import { warningColor } from "../../theme"
@@ -39,6 +39,7 @@ interface Props {
 function TradingForm(props: Props) {
   const DialogActions = props.DialogActions
   const tradePair = useOrderbook(props.selling, props.buying, props.testnet)
+  const isTinyScreen = useIsSmallMobile()
 
   const [amountString, setAmountString] = React.useState("")
   const [manualPriceString, setManualPriceString] = React.useState("")
@@ -82,7 +83,14 @@ function TradingForm(props: Props) {
             style={{ justifySelf: "flex-end" }}
           />
         </VerticalLayout>
-        <VerticalLayout alignItems="stretch" basis="40%" grow={1} shrink={1} margin="16px 24px 8px" minWidth={320}>
+        <VerticalLayout
+          alignItems="stretch"
+          basis="40%"
+          grow={1}
+          shrink={1}
+          margin="16px 24px 8px"
+          minWidth={isTinyScreen ? 250 : 320}
+        >
           <Explanation />
         </VerticalLayout>
       </HorizontalLayout>

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -21,6 +21,8 @@ export { ObservedAccountData, ObservedRecentTxs, ObservedTradingPair }
 
 export const useIsMobile = () => useMediaQuery("(max-width:600px)")
 
+export const useIsSmallMobile = () => useMediaQuery("(max-width:400px)")
+
 // TODO: Should probably be stored in context
 const horizonLivenet = new Server("https://stellar-horizon.satoshipay.io/")
 const horizonTestnet = new Server("https://stellar-horizon-testnet.satoshipay.io/")

--- a/src/pages/create-account.tsx
+++ b/src/pages/create-account.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Keypair } from "stellar-sdk"
-import { useRouter } from "../hooks"
+import { useRouter, useIsSmallMobile } from "../hooks"
 import * as routes from "../routes"
 import { Section } from "../components/Layout/Page"
 import AccountCreationForm, { AccountCreationValues } from "../components/Form/CreateAccount"
@@ -10,6 +10,7 @@ import { trackError } from "../context/notifications"
 function CreateAccountPage(props: { testnet: boolean }) {
   const { accounts, createAccount } = React.useContext(AccountsContext)
   const router = useRouter()
+  const isTinyScreen = useIsSmallMobile()
 
   const onCreateAccount = async (formValues: AccountCreationValues) => {
     try {
@@ -28,7 +29,7 @@ function CreateAccountPage(props: { testnet: boolean }) {
   const onClose = () => router.history.push(routes.allAccounts())
 
   return (
-    <Section top bottom pageInset>
+    <Section top bottom pageInset={!isTinyScreen}>
       <AccountCreationForm accounts={accounts} onCancel={onClose} onSubmit={onCreateAccount} testnet={props.testnet} />
     </Section>
   )

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -92,6 +92,16 @@ const theme = createMuiTheme({
         }
       }
     },
+    MuiInputLabel: {
+      formControl: {
+        [breakpoints.down(600)]: {
+          fontSize: "0.85rem"
+        },
+        [breakpoints.down(400)]: {
+          fontSize: "0.75rem"
+        }
+      }
+    },
     MuiLinearProgress: {
       colorPrimary: {
         backgroundColor: lightBlue["100"]

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -92,6 +92,16 @@ const theme = createMuiTheme({
         }
       }
     },
+    MuiInputBase: {
+      root: {
+        [breakpoints.down(600)]: {
+          fontSize: "0.9rem"
+        },
+        [breakpoints.down(400)]: {
+          fontSize: "0.8rem"
+        }
+      }
+    },
     MuiInputLabel: {
       formControl: {
         [breakpoints.down(600)]: {


### PR DESCRIPTION
- [x] Add `useIsSmallMobile()` hook 
- [x] Reduce font-size of `MuiInputLabel` based on screen width
- [x] Adjust styles of `<RenameDialog>`, `<ActionButton>`, `<AccountCreationForm>`, `<NewSignerForm>` and `<Explanation>` to support tiny screens

Closes #506. 