### PR TITLE
Restrict IPC message handling on mobile

### DIFF
--- a/src/cordova/ipc.ts
+++ b/src/cordova/ipc.ts
@@ -35,7 +35,7 @@ export const events = {
 let commandHandlers: CommandHandlers = {}
 
 export function handleMessageEvent(event: Event, contentWindow: Window, secureStorage: CordovaSecureStorage) {
-  if (!(event instanceof MessageEvent)) {
+  if (!(event instanceof MessageEvent) || event.source !== contentWindow) {
     return
   }
 

--- a/src/platform/cordova/message-handler.ts
+++ b/src/platform/cordova/message-handler.ts
@@ -5,7 +5,7 @@ export function sendCommand(commandType: string, data?: any) {
 
   const responsePromise = new Promise<MessageEvent>(resolve => {
     window.addEventListener("message", event => {
-      if (event instanceof MessageEvent) {
+      if (event instanceof MessageEvent && event.source === window.parent) {
         if (event.data.id === id) {
           resolve(event)
         }


### PR DESCRIPTION
- [x] Add check for source before handling `MessageEvent` to mainframe
- [x] Add check for source before handling `MessageEvent` to iframe

Closes #500. 