### PR TITLE
Fix floating buttons covering content in DEX-view on mobile

### DIFF
--- a/src/components/TradeAsset/TradingForm.tsx
+++ b/src/components/TradeAsset/TradingForm.tsx
@@ -53,6 +53,15 @@ function TradingForm(props: Props) {
   const price = worstPriceOfBestMatches || manualPrice || 0
   const { relativeSpread } = calculateSpread(tradePair.asks, tradePair.bids)
 
+  const dialogActions = (
+    <DialogActions
+      amount={amount}
+      disabled={amountString === "" || isDisabled(amount, price, Number.parseFloat(props.sellingBalance))}
+      price={price}
+      style={{ justifySelf: "flex-end" }}
+    />
+  )
+
   return (
     <VerticalLayout>
       <HorizontalLayout shrink={0} justifyContent="space-between" margin="0 -24px" wrap="wrap">
@@ -77,14 +86,7 @@ function TradingForm(props: Props) {
             </Box>
           ) : null}
           <div style={{ flexGrow: 1 }} />
-          {isSmallScreen ? null : (
-            <DialogActions
-              amount={amount}
-              disabled={amountString === "" || isDisabled(amount, price, Number.parseFloat(props.sellingBalance))}
-              price={price}
-              style={{ justifySelf: "flex-end" }}
-            />
-          )}
+          {isSmallScreen ? null : dialogActions}
         </VerticalLayout>
         <VerticalLayout
           alignItems="stretch"
@@ -95,14 +97,7 @@ function TradingForm(props: Props) {
           minWidth={isTinyScreen ? 250 : 320}
         >
           <Explanation />
-          {isSmallScreen ? (
-            <DialogActions
-              amount={amount}
-              disabled={amountString === "" || isDisabled(amount, price, Number.parseFloat(props.sellingBalance))}
-              price={price}
-              style={{ justifySelf: "flex-end" }}
-            />
-          ) : null}
+          {isSmallScreen ? dialogActions : null}
         </VerticalLayout>
       </HorizontalLayout>
     </VerticalLayout>

--- a/src/components/TradeAsset/TradingForm.tsx
+++ b/src/components/TradeAsset/TradingForm.tsx
@@ -1,7 +1,7 @@
 import BigNumber from "big.js"
 import React from "react"
 import { Asset, AssetType, Horizon } from "stellar-sdk"
-import { useOrderbook, useIsSmallMobile } from "../../hooks"
+import { useOrderbook, useIsMobile, useIsSmallMobile } from "../../hooks"
 import { calculateSpread } from "../../lib/orderbook"
 import { Box, HorizontalLayout, VerticalLayout } from "../Layout/Box"
 import { warningColor } from "../../theme"
@@ -39,6 +39,7 @@ interface Props {
 function TradingForm(props: Props) {
   const DialogActions = props.DialogActions
   const tradePair = useOrderbook(props.selling, props.buying, props.testnet)
+  const isSmallScreen = useIsMobile()
   const isTinyScreen = useIsSmallMobile()
 
   const [amountString, setAmountString] = React.useState("")
@@ -76,12 +77,14 @@ function TradingForm(props: Props) {
             </Box>
           ) : null}
           <div style={{ flexGrow: 1 }} />
-          <DialogActions
-            amount={amount}
-            disabled={amountString === "" || isDisabled(amount, price, Number.parseFloat(props.sellingBalance))}
-            price={price}
-            style={{ justifySelf: "flex-end" }}
-          />
+          {isSmallScreen ? null : (
+            <DialogActions
+              amount={amount}
+              disabled={amountString === "" || isDisabled(amount, price, Number.parseFloat(props.sellingBalance))}
+              price={price}
+              style={{ justifySelf: "flex-end" }}
+            />
+          )}
         </VerticalLayout>
         <VerticalLayout
           alignItems="stretch"
@@ -92,6 +95,14 @@ function TradingForm(props: Props) {
           minWidth={isTinyScreen ? 250 : 320}
         >
           <Explanation />
+          {isSmallScreen ? (
+            <DialogActions
+              amount={amount}
+              disabled={amountString === "" || isDisabled(amount, price, Number.parseFloat(props.sellingBalance))}
+              price={price}
+              style={{ justifySelf: "flex-end" }}
+            />
+          ) : null}
         </VerticalLayout>
       </HorizontalLayout>
     </VerticalLayout>

--- a/src/components/TradeAsset/TradingForm.tsx
+++ b/src/components/TradeAsset/TradingForm.tsx
@@ -85,7 +85,7 @@ function TradingForm(props: Props) {
               %) between buying and selling price. Converting the funds back might be expensive.
             </Box>
           ) : null}
-          <div style={{ flexGrow: 1 }} />
+          <div style={{ flexGrow: 1, maxHeight: 50 }} />
           {isSmallScreen ? null : dialogActions}
         </VerticalLayout>
         <VerticalLayout
@@ -93,7 +93,7 @@ function TradingForm(props: Props) {
           basis="40%"
           grow={1}
           shrink={1}
-          margin="16px 24px 8px"
+          margin="16px 24px 0"
           minWidth={isTinyScreen ? 250 : 320}
         >
           <Explanation />


### PR DESCRIPTION
- [x] Render the `<DialogActions>` below the `<Explanation>` in DEX dialog on mobile / small screens

Closes #546.