### PR TITLE
Add `?download=false` to downloading page URL

### DIFF
--- a/electron/lib/updater.js
+++ b/electron/lib/updater.js
@@ -22,7 +22,7 @@ async function checkForUpdates() {
       subtitle: `Click to download the update.`
     })
     notification.on("click", () => {
-      open("https://solarwallet.io/downloading")
+      open("https://solarwallet.io/downloading?download=false")
       open(urlToOpen)
     })
     notification.show()


### PR DESCRIPTION
Implements the less interesting part of #560.

@Marcel-Ebert 