### PR TITLE
Disable text selection in some components

### DIFF
--- a/src/base-styles.css
+++ b/src/base-styles.css
@@ -16,23 +16,31 @@ body {
 }
 
 .iphone-notch-top-spacing {
-  padding-top: constant(safe-area-inset-top); /* iOS 11.0 */
-  padding-top: env(safe-area-inset-top); /* iOS 11.2 */
+  padding-top: constant(safe-area-inset-top);
+  /* iOS 11.0 */
+  padding-top: env(safe-area-inset-top);
+  /* iOS 11.2 */
 }
 
 .iphone-notch-left-spacing {
-  padding-left: constant(safe-area-inset-left); /* iOS 11.0 */
-  padding-left: env(safe-area-inset-left); /* iOS 11.2 */
+  padding-left: constant(safe-area-inset-left);
+  /* iOS 11.0 */
+  padding-left: env(safe-area-inset-left);
+  /* iOS 11.2 */
 }
 
 .iphone-notch-right-spacing {
-  padding-right: constant(safe-area-inset-right); /* iOS 11.0 */
-  padding-right: env(safe-area-inset-right); /* iOS 11.2 */
+  padding-right: constant(safe-area-inset-right);
+  /* iOS 11.0 */
+  padding-right: env(safe-area-inset-right);
+  /* iOS 11.2 */
 }
 
 .iphone-notch-bottom-spacing {
-  padding-bottom: constant(safe-area-inset-bottom); /* iOS 11.0 */
-  padding-bottom: env(safe-area-inset-bottom); /* iOS 11.2 */
+  padding-bottom: constant(safe-area-inset-bottom);
+  /* iOS 11.0 */
+  padding-bottom: env(safe-area-inset-bottom);
+  /* iOS 11.2 */
 }
 
 .mac-frameless-window-invisible-title-bar {
@@ -48,4 +56,9 @@ body {
   z-index: 1;
   -webkit-app-region: drag;
   -webkit-mask: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
+}
+
+*:not(input):not(textarea) {
+  user-select: none;
+  -webkit-user-select: none;
 }

--- a/src/base-styles.css
+++ b/src/base-styles.css
@@ -16,31 +16,23 @@ body {
 }
 
 .iphone-notch-top-spacing {
-  padding-top: constant(safe-area-inset-top);
-  /* iOS 11.0 */
-  padding-top: env(safe-area-inset-top);
-  /* iOS 11.2 */
+  padding-top: constant(safe-area-inset-top); /* iOS 11.0 */
+  padding-top: env(safe-area-inset-top); /* iOS 11.2 */
 }
 
 .iphone-notch-left-spacing {
-  padding-left: constant(safe-area-inset-left);
-  /* iOS 11.0 */
-  padding-left: env(safe-area-inset-left);
-  /* iOS 11.2 */
+  padding-left: constant(safe-area-inset-left); /* iOS 11.0 */
+  padding-left: env(safe-area-inset-left); /* iOS 11.2 */
 }
 
 .iphone-notch-right-spacing {
-  padding-right: constant(safe-area-inset-right);
-  /* iOS 11.0 */
-  padding-right: env(safe-area-inset-right);
-  /* iOS 11.2 */
+  padding-right: constant(safe-area-inset-right); /* iOS 11.0 */
+  padding-right: env(safe-area-inset-right); /* iOS 11.2 */
 }
 
 .iphone-notch-bottom-spacing {
-  padding-bottom: constant(safe-area-inset-bottom);
-  /* iOS 11.0 */
-  padding-bottom: env(safe-area-inset-bottom);
-  /* iOS 11.2 */
+  padding-bottom: constant(safe-area-inset-bottom); /* iOS 11.0 */
+  padding-bottom: env(safe-area-inset-bottom); /* iOS 11.2 */
 }
 
 .mac-frameless-window-invisible-title-bar {

--- a/src/components/PublicKey.tsx
+++ b/src/components/PublicKey.tsx
@@ -86,8 +86,14 @@ interface AddressProps {
 }
 
 export function Address(props: AddressProps) {
+  const style: React.CSSProperties = {
+    userSelect: "text",
+    WebkitUserSelect: "text",
+    ...props.style
+  }
+
   if (props.address.indexOf("*") > -1) {
-    return <span style={props.style}>{props.address}</span>
+    return <span style={style}>{props.address}</span>
   } else {
     const stellarAddress = queryReverseLookupCache(props.address)
 
@@ -96,7 +102,7 @@ export function Address(props: AddressProps) {
         props.variant === "full" ? stellarAddress : shortenName(stellarAddress, props.variant === "shorter" ? 8 : 14)
 
       return (
-        <span style={props.style}>
+        <span style={style}>
           {formattedStellarAddress} ({<PublicKey publicKey={props.address} variant="shorter" />})
         </span>
       )

--- a/src/components/PublicKey.tsx
+++ b/src/components/PublicKey.tsx
@@ -51,6 +51,8 @@ export function PublicKey(props: PublicKeyProps) {
     display: "inline",
     fontSize: "inherit",
     fontWeight: "bold",
+    userSelect: "text",
+    WebkitUserSelect: "text",
     whiteSpace: variant !== "full" ? "pre" : undefined,
     ...props.style
   }


### PR DESCRIPTION
- [x] Add css styling to disable `user-select` everywhere except for `input` and `textarea`
- [x] Add `user-select: "text"` attribute to `<PublicKey>` to re-enable text selection for public keys.

Closes #469.

Do we need to add an exception for `<Address>` components as well? I was not 100% sure, because they contain a `<PublicKey>` as well. (@andywer)