### PR TITLE
Fix 'Use Backup' bug in fingerprint authentication on android

### DIFF
--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -17,6 +17,8 @@ let bioAuthAvailablePromise: Promise<boolean>
 let clientSecretPromise: Promise<string>
 let isBioAuthAvailable = false
 
+let lastAuthenticationTimestamp: number = 0
+
 const iframeReady = new Promise<void>(resolve => {
   const handler = (event: MessageEvent) => {
     if (event.data === "app:ready") {
@@ -90,6 +92,7 @@ function authenticate(contentWindow: Window) {
     const clientSecret = await clientSecretPromise
     try {
       await bioAuthenticate(clientSecret)
+      lastAuthenticationTimestamp = Date.now()
     } catch (error) {
       // Just start over if auth fails - Block user interactions until auth is done
       return performAuth()
@@ -126,7 +129,8 @@ function onPause(contentWindow: Window) {
 function onResume(contentWindow: Window) {
   contentWindow.postMessage("app:resume", "*")
 
-  if (isBioAuthAvailable) {
+  // Necessary because the 'use backup' option of the fingerprint dialog triggers onpause/onresume
+  if (isBioAuthAvailable && Date.now() - lastAuthenticationTimestamp > 750) {
     authenticate(contentWindow)
   }
 }


### PR DESCRIPTION
Fix bug where users would not be able to continue after using the 'Use Backup' option because the fingerprint authentication dialog would immediately show again afterwards.