### PR TITLE
Fix application not working on iOS versions < 12

### DIFF
--- a/src/index.dev-android.njk
+++ b/src/index.dev-android.njk
@@ -30,11 +30,8 @@
     <script src="../cordova/platforms/android/platform_www/cordova.js"></script>
     <script>
       function onDeviceReady() {
-        if (window.navigator.platform.includes('Linux')) {
-          walletframe.src = "http://10.0.2.2:1234";
-        } else if (window.navigator.platform.includes('iPhone')) {
-          walletframe.src = "http://localhost:1234";
-        }
+        const walletframe = document.getElementById("walletframe")
+        walletframe.setAttribute("src", "http://10.0.2.2:1234");
       }
 
       document.addEventListener("deviceready", onDeviceReady, false);

--- a/src/index.dev-ios.njk
+++ b/src/index.dev-ios.njk
@@ -30,11 +30,8 @@
     <script src="../cordova/platforms/ios/platform_www/cordova.js"></script>
     <script>
       function onDeviceReady() {
-        if (window.navigator.platform.includes('Linux')) {
-          walletframe.src = "http://10.0.2.2:1234";
-        } else if (window.navigator.platform.includes('iPhone')) {
-          walletframe.src = "http://localhost:1234";
-        }
+        const walletframe = document.getElementById("walletframe")
+        walletframe.setAttribute("src", "http://localhost:1234");
 
         setTimeout(function() {
           // iPhone X iframe height fix

--- a/src/index.prod-android.njk
+++ b/src/index.prod-android.njk
@@ -41,8 +41,10 @@
       }
 
       function onDeviceReady() {
+        const walletframe = document.getElementById("walletframe")
+
         // Need to delay iframe initialization, so we have time to set up our event listeners first
-        walletframe.src = preloadLink.getAttribute("href");
+        walletframe.setAttribute("src", preloadLink.getAttribute("href"));
       }
 
       document.addEventListener("deviceready", onDeviceReady, false);

--- a/src/index.prod-ios.njk
+++ b/src/index.prod-ios.njk
@@ -41,8 +41,10 @@
       }
 
       function onDeviceReady() {
+        const walletframe = document.getElementById("walletframe")
+        
         // Need to delay iframe initialization, so we have time to set up our event listeners first
-        walletframe.src = preloadLink.getAttribute("href");
+        walletframe.setAttribute("src", preloadLink.getAttribute("href"));
 
         setTimeout(function() {
           // iPhone X iframe height fix


### PR DESCRIPTION
Fixed by accessing the walletframe element via `document.getElementById("walletframe")` and using `setAttribute()` to set the `src`-property of the iframe in mainframe scripts.