### PR TITLE
Handle 'Device is not secure' error

### DIFF
--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -153,7 +153,15 @@ function initializeClipboard(cordova: Cordova) {
 }
 
 function initializeStorage(contentWindow: Window) {
-  const initPromise = initSecureStorage()
+  const initPromise = initSecureStorage().catch(
+    (error): any => {
+      // Assume that it is a 'device not secure' error
+      alert(
+        "This application requires you to set a PIN or unlock pattern for your device.\n\nPlease retry after setting it up."
+      )
+      navigator.app.exitApp()
+    }
+  )
 
   // Set up event listener synchronously, so it's working as early as possible
   window.addEventListener("message", async event => {

--- a/types/cordova.d.ts
+++ b/types/cordova.d.ts
@@ -96,4 +96,7 @@ interface Navigator {
     hide(): void
     show(): void
   }
+  app: {
+    exitApp(): never
+  }
 }


### PR DESCRIPTION
Procedure:
1. Catch the error that is thrown in initialisation of the cordova secure storage if no lock screen is set up by the user and assume that it will always be a 'Device is not secure' error.
2. Show an alert window to the user telling him to set up a lock screen for his device.
3. Exit the application afterwards.

