### PR TITLE
Fix authentication requested again after QR-code scanner was opened

### DIFF
--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -17,7 +17,11 @@ let bioAuthAvailablePromise: Promise<boolean>
 let clientSecretPromise: Promise<string>
 let isBioAuthAvailable = false
 
-let lastAuthenticationTimestamp: number = 0
+let lastNativeInteractionTime: number = 0
+
+export function refreshLastNativeInteractionTime() {
+  lastNativeInteractionTime = Date.now()
+}
 
 const iframeReady = new Promise<void>(resolve => {
   const handler = (event: MessageEvent) => {
@@ -101,7 +105,7 @@ function authenticate(contentWindow: Window) {
     const clientSecret = await clientSecretPromise
     try {
       await bioAuthenticate(clientSecret)
-      lastAuthenticationTimestamp = Date.now()
+      refreshLastNativeInteractionTime()
     } catch (error) {
       // Just start over if auth fails - Block user interactions until auth is done
       return performAuth()
@@ -129,7 +133,7 @@ function hideHtmlSplashScreen(contentWindow: Window) {
 function onPause(contentWindow: Window) {
   contentWindow.postMessage("app:pause", "*")
 
-  if (isBioAuthEnabled()) {
+  if (isBioAuthEnabled() && Date.now() - lastNativeInteractionTime > 750) {
     showSplashScreenOnIOS()
     showHtmlSplashScreen(contentWindow)
   }
@@ -139,7 +143,7 @@ function onResume(contentWindow: Window) {
   contentWindow.postMessage("app:resume", "*")
 
   // Necessary because the 'use backup' option of the fingerprint dialog triggers onpause/onresume
-  if (isBioAuthEnabled() && Date.now() - lastAuthenticationTimestamp > 750) {
+  if (isBioAuthEnabled() && Date.now() - lastNativeInteractionTime > 750) {
     authenticate(contentWindow)
   }
 }

--- a/src/cordova/qr-reader.ts
+++ b/src/cordova/qr-reader.ts
@@ -1,12 +1,18 @@
 import { trackError } from "./error"
 import { events, commands, registerCommandHandler } from "./ipc"
+import { refreshLastNativeInteractionTime } from "./app.cordova"
 
 async function startQRReader(event: MessageEvent, contentWindow: Window) {
+  refreshLastNativeInteractionTime()
   cordova.plugins.barcodeScanner.scan(
     result => {
+      refreshLastNativeInteractionTime()
       contentWindow.postMessage({ eventType: events.qrcodeResultEvent, id: event.data.id, qrdata: result.text }, "*")
     },
-    trackError,
+    error => {
+      refreshLastNativeInteractionTime()
+      trackError(error)
+    },
     {
       preferFrontCamera: false, // iOS and Android
       showFlipCameraButton: true, // iOS and Android


### PR DESCRIPTION
- [x] Create a function to refresh the last native interaction timestamp and export it to make it usable in `qr-reader.ts`. 
- [x] Check the `lastNativeInteractionTime` in `onPause` to prevent showing the splash screen again after the QR-Reader has finished.

Closes #586. 