### PR TITLE
Set color for android statusbar

### DIFF
--- a/cordova/package-lock.json
+++ b/cordova/package-lock.json
@@ -787,6 +787,11 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-splashscreen/-/cordova-plugin-splashscreen-5.0.2.tgz",
       "integrity": "sha1-dH509W4gHNWFvGLRS8oZ9oZ/8e0="
     },
+    "cordova-plugin-statusbar": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-statusbar/-/cordova-plugin-statusbar-2.4.2.tgz",
+      "integrity": "sha1-/B+9wNjXAzp+jh8ff/FnrJvU+vY="
+    },
     "cordova-plugin-whitelist": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.3.3.tgz",

--- a/cordova/package.json
+++ b/cordova/package.json
@@ -65,7 +65,7 @@
     "dev:ios": "run-p dev:bundle:ios dev:cordova:ios",
     "dev:bundle:android": "PLATFORM=android NODE_ENV=development ../node_modules/.bin/parcel serve ../src/index.dev.njk -p 1234 --out-dir ../dist",
     "dev:bundle:ios": "PLATFORM=ios NODE_ENV=development ../node_modules/.bin/parcel serve ../src/index.dev.njk -p 1234 --out-dir ../dist",
-    "dev:cordova:android": "../node_modules/.bin/parcel build ../src/index.dev-android.njk --out-dir ../dist --public-url=./ && ./scripts/create-config-from-template.sh dev android && dotenv -- cordova build android",
-    "dev:cordova:ios": "../node_modules/.bin/parcel build ../src/index.dev-ios.njk --out-dir ../dist --public-url=./ && ./scripts/create-config-from-template.sh dev ios && cordova build ios --buildConfig=build.ios.json"
+    "dev:cordova:android": "PLATFORM=android ../node_modules/.bin/parcel build ../src/index.dev-android.njk --out-dir ../dist --public-url=./ && ./scripts/create-config-from-template.sh dev android && dotenv -- cordova build android",
+    "dev:cordova:ios": "PLATFORM=ios ../node_modules/.bin/parcel build ../src/index.dev-ios.njk --out-dir ../dist --public-url=./ && ./scripts/create-config-from-template.sh dev ios && cordova build ios --buildConfig=build.ios.json"
   }
 }

--- a/cordova/package.json
+++ b/cordova/package.json
@@ -24,7 +24,8 @@
       "cordova-plugin-safariviewcontroller": {},
       "cordova-plugin-fingerprint-aio": {
         "FACEID_USAGE_DESCRIPTION": "Unlock Solar…"
-      }
+      },
+      "cordova-plugin-statusbar": {}
     }
   },
   "dependencies": {
@@ -40,6 +41,7 @@
     "cordova-plugin-safariviewcontroller": "^1.6.0",
     "cordova-plugin-secure-storage": "^3.0.1",
     "cordova-plugin-splashscreen": "^5.0.2",
+    "cordova-plugin-statusbar": "^2.4.2",
     "cordova-plugin-whitelist": "^1.3.3",
     "cordova-plugin-wkwebview-engine": "^1.1.4",
     "phonegap-plugin-barcodescanner": "^8.0.1"

--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -10,7 +10,9 @@ import { getCurrentSettings, initSecureStorage, storeKeys } from "./storage"
 import { bioAuthenticate, isBiometricAuthAvailable } from "./bio-auth"
 
 const iframe = document.getElementById("walletframe") as HTMLIFrameElement
-const showSplashScreenOnIOS = () => (process.env.PLATFORM === "ios" ? navigator.splashscreen.show() : undefined)
+const showSplashScreenOnIOS = () => (cordova.platformId === "ios" ? navigator.splashscreen.show() : undefined)
+const setStatusbarColor = () =>
+  cordova.platformId === "android" ? StatusBar.backgroundColorByHexString("#D601a4ed") : undefined
 
 let bioAuthInProgress: Promise<void> | undefined
 let bioAuthAvailablePromise: Promise<boolean>
@@ -52,6 +54,7 @@ function onDeviceReady() {
   initializeIPhoneNotchFix()
 
   setupLinkListener()
+  setStatusbarColor()
 
   document.addEventListener("backbutton", () => contentWindow.postMessage("app:backbutton", "*"), false)
   document.addEventListener("pause", () => onPause(contentWindow), false)

--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -10,9 +10,9 @@ import { getCurrentSettings, initSecureStorage, storeKeys } from "./storage"
 import { bioAuthenticate, isBiometricAuthAvailable } from "./bio-auth"
 
 const iframe = document.getElementById("walletframe") as HTMLIFrameElement
-const showSplashScreenOnIOS = () => (cordova.platformId === "ios" ? navigator.splashscreen.show() : undefined)
+const showSplashScreenOnIOS = () => (process.env.PLATFORM === "ios" ? navigator.splashscreen.show() : undefined)
 const setStatusbarColor = () =>
-  cordova.platformId === "android" ? StatusBar.backgroundColorByHexString("#D601a4ed") : undefined
+  process.env.PLATFORM === "android" ? StatusBar.backgroundColorByHexString("#D601a4ed") : undefined
 
 let bioAuthInProgress: Promise<void> | undefined
 let bioAuthAvailablePromise: Promise<boolean>

--- a/types/cordova.d.ts
+++ b/types/cordova.d.ts
@@ -100,3 +100,21 @@ interface Navigator {
     exitApp(): never
   }
 }
+
+interface Window {
+  StatusBar: StatusBar
+}
+interface StatusBar {
+  overlaysWebView: (isOverlay: boolean) => void
+  styleDefault: () => void
+  styleLightContent: () => void
+  styleBlackTranslucent: () => void
+  styleBlackOpaque: () => void
+  backgroundColorByName: (color: string) => void
+  backgroundColorByHexString: (color: string) => void
+  hide: () => void
+  show: () => void
+  isVisible: boolean
+}
+
+declare var StatusBar: StatusBar


### PR DESCRIPTION
- [x] Add 'cordova-plugin-statusbar'
- [x] Set custom color for android statusbar on app start in `app.cordova.ts`
- [x] Change the color of the text (clock and battery) in the ios statusbar from black to white  

~~Note: I replaced `process.env.PLATFORM` with `cordova.platformId` because the environment variable is undefined when running the `dev`-builds (`npm run dev:android` and `npm run dev:ios`). It is however set when running `npm run build:android` and `npm run build:ios`. But to make it work in both variants I decided to change it this way.~~

Closes #570. 