### PR TITLE
Show numeric keyboard for number input fields

### DIFF
--- a/src/base-styles.css
+++ b/src/base-styles.css
@@ -54,3 +54,9 @@ body {
   user-select: none;
   -webkit-user-select: none;
 }
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/src/components/Dialog/CustomTrustline.tsx
+++ b/src/components/Dialog/CustomTrustline.tsx
@@ -84,6 +84,7 @@ function CustomTrustlineDialog(props: Props) {
             margin="dense"
             name="trust-limit"
             value={limit}
+            type="number"
             onChange={event => setLimit(event.target.value)}
           />
           <DialogActionsBox>

--- a/src/components/Form/FormFields.tsx
+++ b/src/components/Form/FormFields.tsx
@@ -58,6 +58,7 @@ export const PriceInput = React.memo(function PriceInput(props: PriceInputProps)
         readOnly,
         ...textfieldProps.InputProps
       }}
+      type="number"
       style={{
         pointerEvents: props.readOnly ? "none" : undefined,
         ...textfieldProps.style

--- a/src/components/ManageSigners/ManageSignersForm.tsx
+++ b/src/components/ManageSigners/ManageSignersForm.tsx
@@ -171,6 +171,7 @@ function ManageSignersForm(props: Props) {
           value={weightThreshold}
           variant="outlined"
           style={isSmallScreen ? { width: "100%" } : {}}
+          type="number"
           InputProps={{
             endAdornment: <KeyWeightThresholdInfoAdornment text={weightThresholdExplanation} />
           }}

--- a/src/components/TradeAsset/TradePropertiesForm.tsx
+++ b/src/components/TradeAsset/TradePropertiesForm.tsx
@@ -157,6 +157,7 @@ function TradePropertiesForm(props: TradePropertiesFormProps) {
           label="Amount to spend"
           placeholder={`Max. ${formatBalance(props.sellingBalance)}`}
           onChange={event => props.onSetAmount(event.target.value)}
+          type="number"
           style={{ flexGrow: 1, flexShrink: 1 }}
           value={props.amount}
         />


### PR DESCRIPTION
- [x] Add `type="number"` to the `<TextField>`s that should only accept numeric input
- [x] Hide the up/down spin buttons which are shown by default for input fields with type `number`

Closes #580. 