### PR TITLE
Fix "Trade" button appearing clickable when disabled

### DIFF
--- a/src/components/Account/AccountHeaderCard.tsx
+++ b/src/components/Account/AccountHeaderCard.tsx
@@ -62,7 +62,7 @@ function AccountHeaderCard(props: Props) {
           onClick={() => router.history.push(routes.tradeAsset(props.account.id))}
           style={{
             borderColor: "rgba(255, 255, 255, 0.9)",
-            color: "white",
+            color: accountData.activated ? "white" : undefined,
             padding: "0 12px",
             marginRight: isSmallScreen ? 0 : 8,
             minHeight: 36


### PR DESCRIPTION
The `color` attribute has to be undefined when the button is disabled because otherwise it overrides the color which is applied by material-ui.

Closes #588. 