### PR TITLE
Replace account renaming dialog

### DIFF
--- a/src/components/Account/AccountHeaderCard.tsx
+++ b/src/components/Account/AccountHeaderCard.tsx
@@ -15,7 +15,6 @@ import * as routes from "../../routes"
 import AccountDeletionDialog from "../Dialog/AccountDeletion"
 import ChangePasswordDialog from "../Dialog/ChangePassword"
 import ExportKeyDialog from "../Dialog/ExportKey"
-import RenameDialog from "../Dialog/Rename"
 import ButtonIconLabel from "../ButtonIconLabel"
 import AccountContextMenu from "./AccountContextMenu"
 import AccountTitle from "./AccountTitle"
@@ -46,13 +45,19 @@ function AccountHeaderCard(props: Props) {
   const settings = React.useContext(SettingsContext)
 
   const [openDialog, setOpenDialog] = React.useState<DialogID | null>(null)
+  const [isRenaming, setIsRenaming] = React.useState<boolean>(false)
+
   const accountData = useAccountData(props.account.publicKey, props.account.testnet)
   const isWidthMax500 = useMediaQuery("(max-width:500px)")
 
   const closeDialog = React.useCallback(() => setOpenDialog(null), [setOpenDialog])
-  const performRenaming = React.useCallback((newName: string) => props.onRenameAccount(props.account.id, newName), [
-    props.account.id
-  ])
+  const performRenaming = React.useCallback(
+    (newName: string) => {
+      props.onRenameAccount(props.account.id, newName)
+      setIsRenaming(false)
+    },
+    [props.account.id]
+  )
 
   const actions = React.useMemo(
     () => (
@@ -83,7 +88,7 @@ function AccountHeaderCard(props: Props) {
           onExport={() => setOpenDialog(DialogID.exportKey)}
           onManageAssets={props.onManageAssets}
           onManageSigners={props.onManageSigners}
-          onRename={() => setOpenDialog(DialogID.renameAccount)}
+          onRename={() => setIsRenaming(true)}
         >
           {({ onOpen }) => (
             <IconButton color="inherit" onClick={onOpen} style={{ marginRight: -16, fontSize: 32 }}>
@@ -107,7 +112,14 @@ function AccountHeaderCard(props: Props) {
       }}
     >
       <CardContent style={isSmallScreen ? { padding: 8 } : undefined}>
-        <AccountTitle account={props.account} accountData={accountData} actions={actions} />
+        <AccountTitle
+          account={props.account}
+          accountData={accountData}
+          actions={actions}
+          editable={isRenaming}
+          editableContent={props.account.name}
+          onEdit={performRenaming}
+        />
 
         {props.children}
 
@@ -147,18 +159,6 @@ function AccountHeaderCard(props: Props) {
           TransitionComponent={DialogSidewaysTransition}
         >
           <ExportKeyDialog account={props.account} onClose={closeDialog} />
-        </Dialog>
-        <Dialog
-          open={openDialog === DialogID.renameAccount}
-          onClose={closeDialog}
-          TransitionComponent={DialogTransition}
-        >
-          <RenameDialog
-            onClose={closeDialog}
-            performRenaming={performRenaming}
-            prevValue={props.account.name}
-            title="Rename account"
-          />
         </Dialog>
       </CardContent>
     </Card>

--- a/src/components/Account/AccountTitle.tsx
+++ b/src/components/Account/AccountTitle.tsx
@@ -53,6 +53,9 @@ interface AccountTitleProps {
   account: Account
   accountData: ObservedAccountData
   actions: React.ReactNode
+  editable: boolean
+  editableContent: string
+  onEdit: (newValue: string) => void
 }
 
 function AccountTitle(props: AccountTitleProps) {
@@ -61,6 +64,9 @@ function AccountTitle(props: AccountTitleProps) {
 
   return (
     <MainTitle
+      editable={props.editable}
+      editableContent={props.editableContent}
+      onEdit={props.onEdit}
       title={<span style={{ marginRight: 20 }}>{props.account.name}</span>}
       titleColor="inherit"
       onBack={onNavigateBack}

--- a/src/components/InlineEditField.tsx
+++ b/src/components/InlineEditField.tsx
@@ -53,9 +53,7 @@ function InlineEditField(props: InlineEditableProps) {
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "Escape") {
       event.preventDefault()
-      if (inputElement) {
-        inputElement.blur()
-      }
+      abortEditing()
     } else if (event.key === "Enter") {
       event.preventDefault()
       finishEditing()
@@ -67,6 +65,14 @@ function InlineEditField(props: InlineEditableProps) {
 
     if (props.selectOnFocus) {
       selectAll()
+    }
+  }
+
+  const abortEditing = () => {
+    setEditing(false)
+
+    if (props.onChange && props.editableContent) {
+      props.onChange(props.editableContent) // return original value
     }
   }
 

--- a/src/components/InlineEditField.tsx
+++ b/src/components/InlineEditField.tsx
@@ -1,0 +1,112 @@
+import * as React from "react"
+import { useEffect } from "react"
+import { TextField, Typography, PropTypes } from "@material-ui/core"
+import { OutlinedInputProps } from "@material-ui/core/OutlinedInput"
+
+export interface InlineEditableProps {
+  autofocus?: boolean
+  color?: PropTypes.Color
+  displayContent: React.ReactNode
+  editable?: boolean
+  disableEditOnClick?: boolean
+  editableContent?: string
+  onChange?: (newValue: string) => void
+  selectOnFocus?: boolean
+  style?: React.CSSProperties
+  textFieldInputProps?: Partial<OutlinedInputProps>
+}
+
+function InlineEditField(props: InlineEditableProps) {
+  const [editing, setEditing] = React.useState<boolean>(props.editable ? props.editable : false)
+  const [editedText, setEditedText] = React.useState<string>(props.editableContent ? props.editableContent : "")
+  const [inputElement, setInputElement] = React.useState<HTMLInputElement | null>(null)
+
+  useEffect(
+    () => {
+      if (props.autofocus && inputElement) {
+        inputElement.focus()
+        startEditing()
+      }
+    },
+    [inputElement]
+  )
+
+  useEffect(
+    () => {
+      if (props.editable) {
+        setEditing(props.editable)
+      }
+
+      if (editing && inputElement) {
+        startEditing()
+      }
+    },
+    [props.editable]
+  )
+
+  const selectAll = () => {
+    if (inputElement) {
+      inputElement.setSelectionRange(0, inputElement.value.length)
+    }
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault()
+      if (inputElement) {
+        inputElement.blur()
+      }
+    } else if (event.key === "Enter") {
+      event.preventDefault()
+      finishEditing()
+    }
+  }
+
+  const startEditing = () => {
+    setEditing(true)
+
+    if (props.selectOnFocus) {
+      selectAll()
+    }
+  }
+
+  const finishEditing = () => {
+    const newValue = inputElement && inputElement.value
+    setEditing(false)
+    if (newValue && props.onChange) {
+      props.onChange(newValue)
+    }
+  }
+
+  const onDisplayContentClick = () => {
+    if (!props.disableEditOnClick) {
+      startEditing()
+    }
+  }
+
+  const renderNormalComponent = () => {
+    return (
+      <Typography onFocus={startEditing} color={props.color} onClick={onDisplayContentClick} style={props.style}>
+        {props.displayContent}
+      </Typography>
+    )
+  }
+
+  const renderEditingComponent = () => {
+    return (
+      <TextField
+        color={props.color}
+        inputRef={input => setInputElement(input)}
+        InputProps={props.textFieldInputProps}
+        onBlur={finishEditing}
+        onChange={event => setEditedText(event.target.value)}
+        onKeyDown={handleKeyDown}
+        value={editedText}
+      />
+    )
+  }
+
+  return editing ? renderEditingComponent() : renderNormalComponent()
+}
+
+export default InlineEditField

--- a/src/components/MainTitle.tsx
+++ b/src/components/MainTitle.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 import IconButton from "@material-ui/core/IconButton"
-import Typography from "@material-ui/core/Typography"
 import ArrowBackIcon from "@material-ui/icons/ArrowBack"
+import { PropTypes } from "@material-ui/core"
 import { useIsMobile } from "../hooks"
 import { Box, HorizontalLayout } from "./Layout/Box"
-import { PropTypes } from "@material-ui/core"
+import InlineEditField from "./InlineEditField"
 
 interface BackButtonProps {
   onClick: () => void
@@ -27,6 +27,10 @@ const BackButton = (props: BackButtonProps) => {
 interface Props {
   actions?: React.ReactNode
   badges?: React.ReactNode
+  editable?: boolean
+  editableOnClick?: boolean
+  editableContent?: string
+  onEdit?: (newValue: string) => void
   hideBackButton?: boolean
   onBack: () => void
   style?: React.CSSProperties
@@ -57,9 +61,16 @@ function MainTitle(props: Props) {
         maxWidth="100%"
         order={isTitleOnSecondRow ? 4 : undefined}
       >
-        <Typography
-          variant="h5"
+        <InlineEditField
+          autofocus
+          selectOnFocus
           color={props.titleColor}
+          disableEditOnClick={!props.editableOnClick}
+          displayContent={props.title}
+          editable={props.editable}
+          editableContent={props.editableContent}
+          onChange={props.onEdit}
+          textFieldInputProps={{ style: { fontSize: 20, color: "white" } }}
           style={{
             flexGrow: 1,
             flexShrink: 1,
@@ -71,9 +82,7 @@ function MainTitle(props: Props) {
             whiteSpace: "nowrap",
             ...props.titleStyle
           }}
-        >
-          {props.title}
-        </Typography>
+        />
         {props.badges}
       </HorizontalLayout>
       <Box grow style={{ textAlign: "right" }}>


### PR DESCRIPTION
- Add `<InlineEditField>` component
- Use the `<InlineEditField>` instead of the `<Typography>` component in `<MainTitle>`
- Change the flow of the account renaming process so that on select of "Rename" in the account context menu no dialog opens but the `<InlineEditField>` will switch to edit mode and change the account name after the user has finished editing (by hitting "Enter" or clicking somewhere else)

Closes #246.