### PR TITLE
Fix 'Confirm-No-Password' dialog shown before validation of form values

### DIFF
--- a/src/components/Form/CreateAccount.tsx
+++ b/src/components/Form/CreateAccount.tsx
@@ -79,8 +79,6 @@ interface AccountCreationFormProps {
 
 function AccountCreationForm(props: AccountCreationFormProps) {
   const { errors, formValues, setFormValue } = props
-  const [pendingConfirmation, setPendingConfirmation] = React.useState<boolean>(false)
-
   const isSmallScreen = useIsMobile()
   const isTinyScreen = useIsSmallMobile()
   const primaryButtonLabel = formValues.createNewKey
@@ -94,23 +92,6 @@ function AccountCreationForm(props: AccountCreationFormProps) {
   const onQRImport = (key: string) => {
     setFormValue("privateKey", key)
     setFormValue("createNewKey", false)
-  }
-
-  const onConfirmNoPasswordProtection = () => {
-    if (!pendingConfirmation) return
-
-    props.onSubmit()
-    setPendingConfirmation(false)
-  }
-
-  const onSubmit = (event: React.SyntheticEvent) => {
-    event.preventDefault()
-
-    if (!props.testnet && !formValues.setPassword) {
-      setPendingConfirmation(true)
-    } else {
-      props.onSubmit()
-    }
   }
 
   return (
@@ -231,25 +212,10 @@ function AccountCreationForm(props: AccountCreationFormProps) {
         </ToggleSection>
         <DialogActionsBox desktopStyle={{ marginTop: 64 }}>
           <CloseButton onClick={props.onCancel} />
-          <ActionButton icon={<CheckIcon />} onClick={onSubmit} type="primary">
+          <ActionButton icon={<CheckIcon />} onClick={props.onSubmit} type="primary">
             {primaryButtonLabel}
           </ActionButton>
         </DialogActionsBox>
-        <ConfirmDialog
-          cancelButton={<ActionButton onClick={() => setPendingConfirmation(false)}>Cancel</ActionButton>}
-          confirmButton={
-            <ActionButton onClick={onConfirmNoPasswordProtection} type="primary">
-              Confirm
-            </ActionButton>
-          }
-          onClose={() => setPendingConfirmation(false)}
-          open={pendingConfirmation}
-          title="Continue without password"
-        >
-          You are about to create an account without password protection. Anyone that has access to your device will
-          have access to your account funds. <br /> <br />
-          Are you sure you want to continue without setting up a password?
-        </ConfirmDialog>
       </VerticalLayout>
     </form>
   )
@@ -265,6 +231,7 @@ interface Props {
 function StatefulAccountCreationForm(props: Props) {
   const defaultAccountName = React.useMemo(() => getNewAccountName(props.accounts, props.testnet), [])
   const [errors, setErrors] = React.useState<AccountCreationErrors>({})
+  const [pendingConfirmation, setPendingConfirmation] = React.useState<boolean>(false)
   const [formValues, setFormValues] = React.useState<AccountCreationValues>({
     name: defaultAccountName,
     password: "",
@@ -284,26 +251,57 @@ function StatefulAccountCreationForm(props: Props) {
     }))
   }
 
-  const submit = () => {
+  const validate = () => {
     const validation = validateFormValues(formValues, props.accounts)
     setErrors(validation.errors)
 
-    const privateKey = formValues.createNewKey ? Keypair.random().secret() : formValues.privateKey
-
     if (validation.success) {
-      props.onSubmit({ ...formValues, privateKey })
+      if (!props.testnet && !formValues.setPassword) {
+        setPendingConfirmation(true)
+      } else {
+        submit()
+      }
     }
   }
 
+  const submit = () => {
+    const privateKey = formValues.createNewKey ? Keypair.random().secret() : formValues.privateKey
+    props.onSubmit({ ...formValues, privateKey })
+  }
+
+  const onConfirmNoPasswordProtection = () => {
+    if (!pendingConfirmation) return
+
+    submit()
+    setPendingConfirmation(false)
+  }
+
   return (
-    <AccountCreationForm
-      errors={errors}
-      formValues={formValues}
-      testnet={props.testnet}
-      onCancel={props.onCancel}
-      onSubmit={submit}
-      setFormValue={setFormValue}
-    />
+    <>
+      <AccountCreationForm
+        errors={errors}
+        formValues={formValues}
+        testnet={props.testnet}
+        onCancel={props.onCancel}
+        onSubmit={validate}
+        setFormValue={setFormValue}
+      />
+      <ConfirmDialog
+        cancelButton={<ActionButton onClick={() => setPendingConfirmation(false)}>Cancel</ActionButton>}
+        confirmButton={
+          <ActionButton onClick={onConfirmNoPasswordProtection} type="primary">
+            Confirm
+          </ActionButton>
+        }
+        onClose={() => setPendingConfirmation(false)}
+        open={pendingConfirmation}
+        title="Continue without password"
+      >
+        You are about to create an account without password protection. Anyone that has access to your device will have
+        access to your account funds. <br /> <br />
+        Are you sure you want to continue without setting up a password?
+      </ConfirmDialog>
+    </>
   )
 }
 


### PR DESCRIPTION
Fixes a bug where the confirmation dialog for creating a new account on mainnet without password protection was shown before the form values are validated.