### PR TITLE
Use local storage to store keys on web platform

### DIFF
--- a/src/platform/web/key-store.ts
+++ b/src/platform/web/key-store.ts
@@ -1,7 +1,7 @@
 import { createStore, KeysData } from "key-store"
 import { PrivateKeyData, PublicKeyData } from "../types"
 
-const initialKeys: KeysData<PublicKeyData> = {
+const standardInitialKeys: KeysData<PublicKeyData> = {
   "1": {
     metadata: {
       nonce: "19sHNxecdiik6chwGFgZVk9UJoG2k8B+",
@@ -46,7 +46,15 @@ const initialKeys: KeysData<PublicKeyData> = {
   }
 }
 
+function saveKeys(keysData: KeysData<PublicKeyData>) {
+  localStorage.setItem("solar:keys", JSON.stringify(keysData))
+}
+
 export default async function createKeyStore() {
+  const keys = localStorage.getItem("solar:keys")
+
+  const initialKeys = keys ? JSON.parse(keys) : standardInitialKeys
+
   // tslint:disable-next-line
-  return createStore<PrivateKeyData, PublicKeyData>(data => console.log("Key store update:", data), initialKeys)
+  return createStore<PrivateKeyData, PublicKeyData>(saveKeys, initialKeys)
 }

--- a/src/platform/web/key-store.ts
+++ b/src/platform/web/key-store.ts
@@ -1,7 +1,7 @@
 import { createStore, KeysData } from "key-store"
 import { PrivateKeyData, PublicKeyData } from "../types"
 
-const standardInitialKeys: KeysData<PublicKeyData> = {
+const defaultTestingKeys: KeysData<PublicKeyData> = {
   "1": {
     metadata: {
       nonce: "19sHNxecdiik6chwGFgZVk9UJoG2k8B+",
@@ -53,7 +53,7 @@ function saveKeys(keysData: KeysData<PublicKeyData>) {
 export default async function createKeyStore() {
   const keys = localStorage.getItem("solar:keys")
 
-  const initialKeys = keys ? JSON.parse(keys) : standardInitialKeys
+  const initialKeys = keys ? JSON.parse(keys) : defaultTestingKeys
 
   // tslint:disable-next-line
   return createStore<PrivateKeyData, PublicKeyData>(saveKeys, initialKeys)


### PR DESCRIPTION
Use the keys that are stored in local storage. If no keys are found default keys are used. 