### PR TITLE
Improve order creation tx label in tx history

### DIFF
--- a/src/components/Account/TransactionList.tsx
+++ b/src/components/Account/TransactionList.tsx
@@ -61,8 +61,7 @@ function OfferDescription(props: {
   }
 
   if (offerId === "0") {
-    // Offer creation
-    prefix = ""
+    prefix = "Create offer: "
   } else if (amount.eq(0)) {
     prefix = "Delete offer: "
   } else {


### PR DESCRIPTION
Background: Highlight that we are *creating an order*. It wasn't necessarily executed.