### PR TITLE
Test biometric authentication before enabling

### DIFF
--- a/src/context/settings.tsx
+++ b/src/context/settings.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import testBiometricAuth from "../platform/cordova/test-bio-auth"
+import { testBiometricAuth } from "../platform/cordova/bio-auth"
 import {
   loadIgnoredSignatureRequestHashes,
   loadSettings,
@@ -95,11 +95,13 @@ export function SettingsProvider(props: Props) {
   const toggleTestnet = () => updateSettings({ testnet: !settings.testnet })
 
   const toggleBiometricLock = () => {
-    if (!settings.biometricLock) {
-      testBiometricAuth().then(() => updateSettings({ biometricLock: true }))
-    } else {
-      updateSettings({ biometricLock: false })
-    }
+    const message = settings.biometricLock
+      ? "Unlock your device to disable the auto-lock."
+      : "Unlock your device once to enable the feature."
+
+    testBiometricAuth(message)
+      .then(() => updateSettings({ biometricLock: !settings.biometricLock }))
+      .catch(trackError)
   }
 
   const contextValue: ContextType = {

--- a/src/context/settings.tsx
+++ b/src/context/settings.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import testBiometricAuth from "../platform/cordova/test-bio-auth"
 import {
   loadIgnoredSignatureRequestHashes,
   loadSettings,
@@ -90,9 +91,16 @@ export function SettingsProvider(props: Props) {
   }
 
   const confirmToC = () => updateSettings({ agreedToTermsAt: new Date().toISOString() })
-  const toggleBiometricLock = () => updateSettings({ biometricLock: !settings.biometricLock })
   const toggleMultiSignature = () => updateSettings({ multisignature: !settings.multisignature })
   const toggleTestnet = () => updateSettings({ testnet: !settings.testnet })
+
+  const toggleBiometricLock = () => {
+    if (!settings.biometricLock) {
+      testBiometricAuth().then(() => updateSettings({ biometricLock: true }))
+    } else {
+      updateSettings({ biometricLock: false })
+    }
+  }
 
   const contextValue: ContextType = {
     agreedToTermsAt: settings.agreedToTermsAt,

--- a/src/cordova/ipc.ts
+++ b/src/cordova/ipc.ts
@@ -15,6 +15,8 @@ export const commands = {
   readIgnoredSignatureRequestsCommand: "storage:ignoredSignatureRequests:read",
   storeIgnoredSignatureRequestsCommand: "storage:ignoredSignatureRequests:store",
 
+  testBioAuthCommand: "test:auth",
+
   openLink: "link:open",
 
   copyToClipboard: "clipboard:write",
@@ -32,6 +34,8 @@ export const events = {
   settingsStoredEvent: "storage:settings:stored",
   ignoredSignatureRequestsResponseEvent: "storage:ignoredSignatureRequests",
   storedIgnoredSignatureRequestsEvent: "storage:ignoredSignatureRequests:stored",
+
+  testBioAuthResponseEvent: "test:auth:result",
 
   qrcodeResultEvent: "qr-code:result",
 

--- a/src/platform/cordova/bio-auth.ts
+++ b/src/platform/cordova/bio-auth.ts
@@ -1,9 +1,9 @@
 import { commands } from "../../cordova/ipc"
 import { sendCommand } from "./message-handler"
 
-function testBiometricAuth() {
+export function testBiometricAuth(message: string) {
   return new Promise<void>(async (resolve, reject) => {
-    if (showConfirmationPrompt()) {
+    if (window.confirm(message)) {
       const event = await sendCommand(commands.testBioAuthCommand)
       if (event.data.error) {
         reject(event.data.error)
@@ -15,9 +15,3 @@ function testBiometricAuth() {
     }
   })
 }
-
-function showConfirmationPrompt() {
-  return window.confirm("Unlock your device once to enable the feature.")
-}
-
-export default testBiometricAuth

--- a/src/platform/cordova/test-bio-auth.ts
+++ b/src/platform/cordova/test-bio-auth.ts
@@ -1,0 +1,23 @@
+import { commands } from "../../cordova/ipc"
+import { sendCommand } from "./message-handler"
+
+function testBiometricAuth() {
+  return new Promise<void>(async (resolve, reject) => {
+    if (showConfirmationPrompt()) {
+      const event = await sendCommand(commands.testBioAuthCommand)
+      if (event.data.error) {
+        reject(event.data.error)
+      } else {
+        resolve()
+      }
+    } else {
+      reject("Confirmation dismissed by user.")
+    }
+  })
+}
+
+function showConfirmationPrompt() {
+  return window.confirm("Unlock your device once to enable the feature.")
+}
+
+export default testBiometricAuth


### PR DESCRIPTION
- [x] Add new command (`testBioAuthCommand`) to signal that bio authentication should be triggered
- [x] Add new event (`testBioAuthResponseEvent`) 
- [x] The response message uses the new event and contains an error if authentication failed or no error if authentication was successful
- [x] Only enable the biometric lock flag if the biometric authentication test succeeded

Closes #604.