### PR TITLE
Fix fingerprint authentication required after opening external url on android

### DIFF
--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -219,6 +219,7 @@ function setupLinkListener() {
 function openUrl(url: string) {
   SafariViewController.isAvailable(available => {
     if (available) {
+      refreshLastNativeInteractionTime()
       SafariViewController.show(
         {
           url,
@@ -226,7 +227,7 @@ function openUrl(url: string) {
           barColor: "#1c8fea",
           controlTintColor: "#ffffff"
         },
-        null,
+        () => refreshLastNativeInteractionTime(),
         null
       )
     }


### PR DESCRIPTION
Refresh the last native interaction time variable before opening and after returning from an external url to prevent showing the splash screen and requiring biometric authentication from the user.

Only necessary for android because the `onPause` and `onResume` events are not fired on iOS when opening the url.