### PR TITLE
Allow account list cards to grow vertically

### DIFF
--- a/src/components/AccountList.tsx
+++ b/src/components/AccountList.tsx
@@ -96,7 +96,7 @@ function AccountCard(props: {
   return (
     <StyledCard elevation={5} onClick={onClick} style={{ background: "white", color: "black" }}>
       <StyledBadge badgeContent={badgeContent} color="secondary" style={{ width: "100%" }}>
-        <VerticalLayout height="100px" justifyContent="space-evenly" textAlign="left">
+        <VerticalLayout minHeight="100px" justifyContent="space-evenly" textAlign="left">
           <HorizontalLayout margin="0 0 20px">
             <Typography variant="h5" style={{ flexGrow: 1 }}>
               {props.account.name}


### PR DESCRIPTION
Use case: Some accounts might have a lot of different balances. Looks broken otherwise and happened to at least one actual user already.