### PR TITLE
Fix account title edit on click when read-only

### DIFF
--- a/src/components/Account/AccountTitle.tsx
+++ b/src/components/Account/AccountTitle.tsx
@@ -199,7 +199,11 @@ function AccountTitle(props: AccountTitleProps) {
     },
     [props.account]
   )
-  const switchToEditMode = React.useCallback(() => setMode("editing"), [])
+  const switchToEditMode = React.useCallback(() => {
+    if (props.editable) {
+      setMode("editing")
+    }
+  }, [])
   const toggleMode = React.useCallback(
     () => {
       setMode(prevMode => (prevMode === "editing" ? "readonly" : "editing"))


### PR DESCRIPTION
Could click on the account title and it would allow editing, even if not in account settings. Affects an unreleased feature only.