### PR TITLE
Fix horizon connection error shown after QR scan on iOS

### DIFF
--- a/src/platform/cordova/qr-reader.ts
+++ b/src/platform/cordova/qr-reader.ts
@@ -13,11 +13,16 @@ interface Props {
 
 function CordovaQRReader(props: Props): ReturnType<React.FunctionComponent<Props>> {
   React.useEffect(() => {
+    // send pause event to signal that streaming errors should not be shown temporarily
+    window.postMessage("app:pause", "*")
+
     sendCommand(commands.scanQRCodeCommand)
       .then(event => {
+        window.postMessage("app:resume", "*")
         props.onScan(event.data.qrdata)
       })
       .catch(error => {
+        window.postMessage("app:resume", "*")
         props.onError(error)
         trackError(error)
       })


### PR DESCRIPTION
- [x] Send pause and resume events before opening and after returning from qr-scanner to prevent showing of error messages concerning connection issues for the time being

Fixes #688.