### PR TITLE
Fix "Done"-Button cut off in Export Secret Key dialog on desktop

### DIFF
--- a/src/components/Account/KeyExportBox.tsx
+++ b/src/components/Account/KeyExportBox.tsx
@@ -1,7 +1,7 @@
 import QRCode from "qrcode.react"
 import React from "react"
 import Typography from "@material-ui/core/Typography"
-import { useClipboard } from "../../hooks"
+import { useClipboard, useIsMobile } from "../../hooks"
 import { Box, VerticalLayout } from "../Layout/Box"
 
 interface Props {
@@ -11,13 +11,14 @@ interface Props {
 
 function KeyExportBox(props: Props) {
   const clipboard = useClipboard()
+  const isSmallScreen = useIsMobile()
   const copyToClipboard = React.useCallback(() => clipboard.copyToClipboard(props.export), [props.export])
 
   return (
     <VerticalLayout alignItems="center" justifyContent="center">
       <VerticalLayout>
         <Box onClick={copyToClipboard} margin="0 auto" style={{ cursor: "pointer" }}>
-          <QRCode size={256} value={props.export} />
+          <QRCode size={isSmallScreen ? 192 : 256} value={props.export} />
         </Box>
         <Box margin="16px auto">
           <Typography align="center" style={{ display: props.hideTapToCopy ? "none" : undefined, marginBottom: 12 }}>

--- a/src/components/AccountSettings/ExportKeyDialog.tsx
+++ b/src/components/AccountSettings/ExportKeyDialog.tsx
@@ -90,11 +90,11 @@ function ShowSecretKey(props: ShowSecretKeyProps) {
       }
     >
       {props.variant === "initial-backup" ? (
-        <Typography align="center" component="p" variant="h6" style={{ marginTop: -8, marginBottom: 24 }}>
+        <Typography align="center" component="p" variant="h6" style={{ marginTop: -8, marginBottom: 16 }}>
           Write down the key on paper and store it in a safe place.
         </Typography>
       ) : null}
-      <Box padding="8px 0 16px">
+      <Box padding={"8px 0 0"}>
         <KeyExportBox hideTapToCopy={props.variant === "initial-backup"} export={props.export} />
       </Box>
     </DialogBody>

--- a/src/components/Dialog/Generic.tsx
+++ b/src/components/Dialog/Generic.tsx
@@ -169,12 +169,13 @@ interface ConfirmDialogProps {
 }
 
 export function ConfirmDialog(props: ConfirmDialogProps) {
+  const isSmallScreen = useIsMobile()
   return (
     <Dialog open={props.open} onClose={props.onClose} TransitionComponent={Transition}>
       <DialogTitle>{props.title}</DialogTitle>
-      <DialogContent>
+      <DialogContent style={{ paddingBottom: isSmallScreen ? 24 : undefined }}>
         <Typography variant="body2">{props.children}</Typography>
-        <DialogActionsBox>
+        <DialogActionsBox smallDialog>
           {props.cancelButton}
           {props.confirmButton}
         </DialogActionsBox>


### PR DESCRIPTION
- [x] Reduce size of QR-code on small screens
- [x] Reduce padding in `ExportKeyDialog`