### PR TITLE
Fix placeholder text bug in inflation destination dialog

### DIFF
--- a/src/components/AccountSettings/InflationDestination.tsx
+++ b/src/components/AccountSettings/InflationDestination.tsx
@@ -45,7 +45,7 @@ function InflationDestinationDialog(props: InflationDestinationDialogProps) {
   const router = useRouter()
   const isSmallScreen = useIsMobile()
 
-  const [destination, setDestination] = React.useState(() => accountData.inflation_destination)
+  const [destination, setDestination] = React.useState(() => accountData.inflation_destination || "")
   const [error, setError] = React.useState<Error | null>(null)
   const [mode, setMode] = React.useState<"editing" | "readonly">("readonly")
 
@@ -106,7 +106,7 @@ function InflationDestinationDialog(props: InflationDestinationDialogProps) {
 
   const cancelEditing = React.useCallback(
     () => {
-      setDestination(undefined)
+      setDestination(accountData.inflation_destination || "")
       setError(null)
       setMode("readonly")
       clearTextSelection()


### PR DESCRIPTION
Use `""` as default value for the `destination`-state when no destination is set for the account to prevent setting the destination to `"No inflation destination set"` on change of edit mode.