### PR TITLE
Append the user-agent header in cordova 

### DIFF
--- a/cordova/config/config.template
+++ b/cordova/config/config.template
@@ -105,6 +105,7 @@
     <engine name="ios" spec="^5.0.0" />
 
     <preference name="AndroidLaunchMode" value="singleTask"/>
+    <preference name="AppendUserAgent" value="SatoshiPaySolar/$PACKAGE_VERSION" />
     <preference name="AutoHideSplashScreen" value="$AUTO_HIDE" />
     <preference name="DisallowOverscroll" value="true" />
     <preference name="ShowSplashScreenSpinner" value="false" />


### PR DESCRIPTION
This sets a preference for cordova applications so that the `User-Agent` header is appended with 'SatoshiPaySolar/' and the current version from `package.json`.