### PR TITLE
Disable bio-auth settings flag if authentication is unusable/unavailable

### DIFF
--- a/src/cordova/ipc.ts
+++ b/src/cordova/ipc.ts
@@ -23,6 +23,7 @@ export const commands = {
   storeIgnoredSignatureRequestsCommand: "storage:ignoredSignatureRequests:store",
 
   testBioAuthCommand: "test:auth",
+  bioAuthAvailableCommand: "test:auth:available",
 
   openLink: "link:open",
 
@@ -45,6 +46,7 @@ export const events = {
   storedIgnoredSignatureRequestsEvent: "storage:ignoredSignatureRequests:stored",
 
   testBioAuthResponseEvent: "test:auth:result",
+  bioAuthAvailableResponseEvent: "test:auth:available:result",
 
   qrcodeResultEvent: "qr-code:result",
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -19,10 +19,12 @@ function Settings() {
   const { accounts } = React.useContext(AccountsContext)
   const settings = React.useContext(SettingsContext)
   const hasTestnetAccount = accounts.some(account => account.testnet)
+
   return (
     <>
       <ToggleSection
-        checked={settings.biometricLock}
+        disabled={!settings.biometricLockUsable}
+        checked={settings.biometricLock && settings.biometricLockUsable}
         onChange={settings.toggleBiometricLock}
         style={biometricLockAvailable ? {} : { display: "none" }}
         title={process.env.PLATFORM === "ios" ? "Face ID / Touch ID" : "Fingerprint Lock"}

--- a/src/platform/cordova/bio-auth.ts
+++ b/src/platform/cordova/bio-auth.ts
@@ -1,6 +1,17 @@
 import { commands } from "../../cordova/ipc"
 import { sendCommand } from "./message-handler"
 
+export function isBiometricAuthAvailable() {
+  return new Promise<boolean>(async resolve => {
+    const event = await sendCommand(commands.bioAuthAvailableCommand)
+    if (event.data.available) {
+      resolve(true)
+    } else {
+      resolve(false)
+    }
+  })
+}
+
 export function testBiometricAuth(message: string) {
   return new Promise<void>(async (resolve, reject) => {
     if (window.confirm(message)) {

--- a/src/platform/cordova/bio-auth.ts
+++ b/src/platform/cordova/bio-auth.ts
@@ -2,12 +2,12 @@ import { commands } from "../../cordova/ipc"
 import { sendCommand } from "./message-handler"
 
 export function isBiometricAuthAvailable() {
-  return new Promise<boolean>(async resolve => {
-    const event = await sendCommand(commands.bioAuthAvailableCommand)
-    if (event.data.available) {
-      resolve(true)
-    } else {
-      resolve(false)
+  return new Promise<boolean>(async (resolve, reject) => {
+    try {
+      const event = await sendCommand(commands.bioAuthAvailableCommand)
+      resolve(event.data.available ? true : false)
+    } catch (error) {
+      reject(error)
     }
   })
 }


### PR DESCRIPTION
- [x] Set up IPC message handling between mainframe and iframe to make authentication-availability check possible from within the iframe
- [x] Add `biometricLockUsable` variable to `SettingsContext`
- [x] Check if biometric authentication is available when first loading the `SettingsContext` and set the `biometricLockUsable` flag based on it
- [x] Disable the bio-auth toggle on the settings page if `biometricLockUsable` is false

Closes #718.