### PR TITLE
Update 'prettier' to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18400,9 +18400,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.0.tgz",
-      "integrity": "sha512-KtQ2EGaUwf2EyDfp1fxyEb0PqGKakVm0WyXwDt6u+cAoxbO2Z2CwKvOe3+b4+F2IlO9lYHi1kqFuRM70ddBnow==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "nunjucks": "^3.1.3",
     "parcel-bundler": "^1.12.3",
     "parcel-plugin-nunjucks": "^1.0.0",
-    "prettier": "^1.13.7",
+    "prettier": "~1.18.2",
     "qrcode.react": "^0.9.3",
     "qs": "^6.7.0",
     "react": "^16.9.0",


### PR DESCRIPTION
- [x] Bump `prettier` version in `package.json`
- [x] Use `~` instead of `^` to only allow patch level updates for `prettier`