### PR TITLE
Replace usages of withStyles with makeStyles

### DIFF
--- a/src/components/Account/AccountSelectionList.tsx
+++ b/src/components/Account/AccountSelectionList.tsx
@@ -3,9 +3,9 @@ import List from "@material-ui/core/List"
 import ListItem from "@material-ui/core/ListItem"
 import ListItemIcon from "@material-ui/core/ListItemIcon"
 import ListItemText from "@material-ui/core/ListItemText"
+import makeStyles from "@material-ui/core/styles/makeStyles"
 import Radio from "@material-ui/core/Radio"
 import Typography from "@material-ui/core/Typography"
-import withStyles, { ClassNameMap, StyleRules } from "@material-ui/core/styles/withStyles"
 import { Account } from "../../context/accounts"
 import AccountBalances from "./AccountBalances"
 
@@ -47,7 +47,7 @@ function AccountSelectionList(props: AccountSelectionListProps) {
   )
 }
 
-const accountListItemStyles: StyleRules = {
+const useAccountListItemStyles = makeStyles({
   listItem: {
     background: "#FFFFFF",
     boxShadow: "0 8px 16px 0 rgba(0, 0, 0, 0.1)",
@@ -58,11 +58,10 @@ const accountListItemStyles: StyleRules = {
       backgroundColor: isMobileDevice ? "#FFFFFF" : "rgb(232, 232, 232)"
     }
   }
-}
+})
 
 interface AccountSelectionListItemProps {
   account: Account
-  classes: ClassNameMap<keyof typeof accountListItemStyles>
   disabled?: boolean
   index: number
   onClick: (event: React.MouseEvent, index: number) => void
@@ -72,11 +71,12 @@ interface AccountSelectionListItemProps {
 
 const AccountSelectionListItem = React.memo(
   // tslint:disable-next-line no-shadowed-variable
-  withStyles(accountListItemStyles)(function AccountSelectionListItem(props: AccountSelectionListItemProps) {
+  function AccountSelectionListItem(props: AccountSelectionListItemProps) {
+    const classes = useAccountListItemStyles()
     return (
       <ListItem
         button
-        className={props.classes.listItem}
+        className={classes.listItem}
         disabled={props.disabled}
         selected={props.selected}
         onClick={event => props.onClick(event, props.index)}
@@ -90,7 +90,7 @@ const AccountSelectionListItem = React.memo(
         />
       </ListItem>
     )
-  } as React.ComponentType<AccountSelectionListItemProps>)
+  } as React.ComponentType<AccountSelectionListItemProps>
 )
 
 export default AccountSelectionList

--- a/src/components/AccountList.tsx
+++ b/src/components/AccountList.tsx
@@ -2,9 +2,9 @@ import React from "react"
 import Badge, { BadgeProps } from "@material-ui/core/Badge"
 import CardActionArea from "@material-ui/core/CardActionArea"
 import CardContent from "@material-ui/core/CardContent"
+import makeStyles from "@material-ui/core/styles/makeStyles"
 import Tooltip from "@material-ui/core/Tooltip"
 import Typography from "@material-ui/core/Typography"
-import withStyles, { ClassNameMap, StyleRules } from "@material-ui/core/styles/withStyles"
 import AddIcon from "@material-ui/icons/Add"
 import GroupIcon from "@material-ui/icons/Group"
 import AccountBalances from "../components/Account/AccountBalances"
@@ -20,7 +20,7 @@ import * as routes from "../routes"
 import StellarGuardIcon from "./Icon/StellarGuard"
 import { Box, HorizontalLayout, VerticalLayout } from "./Layout/Box"
 
-const cardStyles: StyleRules = {
+const useCardStyles = makeStyles({
   cardActionArea: {
     width: "100%",
     height: "100%"
@@ -31,42 +31,41 @@ const cardStyles: StyleRules = {
     padding: "16px 24px",
     textOverflow: "ellipsis"
   }
+})
+
+const StyledCard = (props: {
+  children?: React.ReactNode
+  elevation?: number
+  onClick?: () => void
+  style?: React.CSSProperties
+}) => {
+  const classes = useCardStyles()
+  return (
+    <CardListCard elevation={props.elevation} onClick={props.onClick} style={props.style}>
+      <CardActionArea className={classes.cardActionArea} centerRipple>
+        <CardContent className={classes.content}>{props.children}</CardContent>
+      </CardActionArea>
+    </CardListCard>
+  )
 }
 
-const StyledCard = withStyles(cardStyles)(
-  (props: {
-    children?: React.ReactNode
-    classes: ClassNameMap<keyof typeof cardStyles>
-    elevation?: number
-    onClick?: () => void
-    style?: React.CSSProperties
-  }) => {
-    return (
-      <CardListCard elevation={props.elevation} onClick={props.onClick} style={props.style}>
-        <CardActionArea className={props.classes.cardActionArea} centerRipple>
-          <CardContent className={props.classes.content}>{props.children}</CardContent>
-        </CardActionArea>
-      </CardListCard>
-    )
-  }
-)
-
-const badgeStyles: StyleRules = {
+const useBadgeStyles = makeStyles({
   badge: {
     marginTop: 4,
     marginRight: -2
   }
-}
+})
 
-const StyledBadge = withStyles(badgeStyles)((props: BadgeProps) => {
+const StyledBadge = (props: BadgeProps) => {
+  const classes = useBadgeStyles()
   return props.badgeContent ? (
     <Badge {...props} />
   ) : (
-    <div className={props.className} style={props.style}>
+    <div className={classes.badge} style={props.style}>
       {props.children}
     </div>
   )
-})
+}
 
 function AccountCard(props: {
   account: Account

--- a/src/components/AccountSettings/AccountSettingsItem.tsx
+++ b/src/components/AccountSettings/AccountSettingsItem.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 import ListItem from "@material-ui/core/ListItem"
 import ListItemIcon from "@material-ui/core/ListItemIcon"
-import withStyles, { ClassNameMap, StyleRules } from "@material-ui/core/styles/withStyles"
+import makeStyles from "@material-ui/core/styles/makeStyles"
 import KeyboardArrowRightIcon from "@material-ui/icons/KeyboardArrowRight"
 import { breakpoints } from "../../theme"
 
 const isMobileDevice = process.env.PLATFORM === "android" || process.env.PLATFORM === "ios"
 
-const accountSettingsItemStyles: StyleRules = {
+const useAccountSettingsItemStyles = makeStyles({
   caret: {
     color: "rgba(0, 0, 0, 0.35)",
     fontSize: 48,
@@ -40,28 +40,27 @@ const accountSettingsItemStyles: StyleRules = {
       borderTop: "1px solid rgba(230, 230, 230, 1.0)"
     }
   }
-}
+})
 
 interface AccountSettingsItemProps {
   children: React.ReactNode
-  classes: ClassNameMap<keyof typeof accountSettingsItemStyles>
   disabled?: boolean
   icon: React.ReactElement
   onClick: () => void
 }
 
-function NakedAccountSettingsItem(props: AccountSettingsItemProps) {
+function AccountSettingsItem(props: AccountSettingsItemProps) {
+  const classes = useAccountSettingsItemStyles()
+
   return (
-    <ListItem button className={props.classes.settingsItem} disabled={props.disabled} onClick={props.onClick}>
-      <ListItemIcon className={props.classes.icon}>{props.icon}</ListItemIcon>
+    <ListItem button className={classes.settingsItem} disabled={props.disabled} onClick={props.onClick}>
+      <ListItemIcon className={classes.icon}>{props.icon}</ListItemIcon>
       {props.children}
-      <ListItemIcon className={props.classes.caret}>
-        <KeyboardArrowRightIcon className={props.classes.caret} />
+      <ListItemIcon className={classes.caret}>
+        <KeyboardArrowRightIcon className={classes.caret} />
       </ListItemIcon>
     </ListItem>
   )
 }
-
-const AccountSettingsItem = withStyles(accountSettingsItemStyles)(NakedAccountSettingsItem)
 
 export default AccountSettingsItem

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -1,9 +1,9 @@
 import React from "react"
-import Card from "@material-ui/core/Card"
-import withStyles, { StyleRules } from "@material-ui/core/styles/withStyles"
+import Card, { CardProps } from "@material-ui/core/Card"
+import makeStyles from "@material-ui/core/styles/makeStyles"
 import { HorizontalLayout } from "./Layout/Box"
 
-const cardStyles: StyleRules = {
+const useCardStyles = makeStyles({
   root: {
     width: "47%",
     minWidth: 250,
@@ -12,9 +12,12 @@ const cardStyles: StyleRules = {
     margin: "12px 1%",
     borderRadius: 8
   }
-}
+})
 
-export const CardListCard = withStyles(cardStyles)(Card)
+export const CardListCard = (props: CardProps) => {
+  const classes = useCardStyles()
+  return <Card classes={classes} {...props}></Card>
+}
 
 interface CardListProps {
   addInvisibleCard?: boolean


### PR DESCRIPTION
Replace the remaining usages of `withStyles()` with `makeStyles()` to make styling definitions more consistent. 