### PR TITLE
Use high transaction fee for multi-sig transactions

### DIFF
--- a/src/components/Payment/CreatePaymentForm.tsx
+++ b/src/components/Payment/CreatePaymentForm.tsx
@@ -15,7 +15,7 @@ import { useIsMobile, RefStateObject } from "../../hooks/userinterface"
 import { renderFormFieldError } from "../../lib/errors"
 import { findMatchingBalanceLine, getAccountMinimumBalance, stringifyAsset } from "../../lib/stellar"
 import { isPublicKey, isStellarAddress } from "../../lib/stellar-address"
-import { createPaymentOperation, createTransaction, multisigMinimumFee } from "../../lib/transaction"
+import { createPaymentOperation, createTransaction, selectSmartMultisigTransactionFee } from "../../lib/transaction"
 import { formatBalance } from "../Account/AccountBalances"
 import { ActionButton, DialogActionsBox } from "../Dialog/Generic"
 import { PriceInput, QRReader } from "../Form/FormFields"
@@ -176,7 +176,7 @@ function PaymentCreationForm(props: Props) {
     const tx = await createTransaction([payment], {
       accountData: props.accountData,
       memo: federationMemo.type !== "none" ? federationMemo : userMemo,
-      minTransactionFee: isMultisigTx ? multisigMinimumFee : 0,
+      minTransactionFee: isMultisigTx ? await selectSmartMultisigTransactionFee(horizon) : 0,
       horizon,
       walletAccount: account
     })

--- a/src/components/TransactionReview/TransactionSummary.tsx
+++ b/src/components/TransactionReview/TransactionSummary.tsx
@@ -72,27 +72,21 @@ function DefaultTransactionSummary(props: DefaultTransactionSummaryProps) {
     .mul(props.transaction.operations.length)
     .div(1e7)
 
-  const isDangerousSignatureRequest = React.useMemo(
-    () => {
-      const localAccounts = accountDataSet.filter(someAccountData =>
-        accounts.some(account => account.publicKey === someAccountData.id)
-      )
-      return props.signatureRequest && isPotentiallyDangerousTransaction(props.transaction, localAccounts)
-    },
-    [accountDataSet, accounts, props.signatureRequest, props.transaction]
-  )
+  const isDangerousSignatureRequest = React.useMemo(() => {
+    const localAccounts = accountDataSet.filter(someAccountData =>
+      accounts.some(account => account.publicKey === someAccountData.id)
+    )
+    return props.signatureRequest && isPotentiallyDangerousTransaction(props.transaction, localAccounts)
+  }, [accountDataSet, accounts, props.signatureRequest, props.transaction])
 
   const isWideScreen = useMediaQuery("(min-width:900px)")
   const widthStyling = isWideScreen ? { maxWidth: 700, minWidth: 400 } : { minWidth: "66vw" }
 
   const transaction = props.transaction as TransactionWithUndocumentedProps
-  const transactionHash = React.useMemo(
-    () => {
-      selectNetwork(props.testnet)
-      return transaction.hash().toString("hex")
-    },
-    [transaction]
-  )
+  const transactionHash = React.useMemo(() => {
+    selectNetwork(props.testnet)
+    return transaction.hash().toString("hex")
+  }, [transaction])
 
   return (
     <List disablePadding style={widthStyling}>
@@ -155,7 +149,10 @@ function DefaultTransactionSummary(props: DefaultTransactionSummaryProps) {
         </SummaryItem>
       ) : null}
       <SummaryItem>
-        <SummaryDetailsField label="Fee" value={<SingleBalance assetCode="XLM" balance={fee.toString()} inline />} />
+        <SummaryDetailsField
+          label="Maximum Fee"
+          value={<SingleBalance assetCode="XLM" balance={fee.toString()} inline />}
+        />
         {transaction.created_at ? (
           <SummaryDetailsField fullWidth={isSmallScreen} label="Submission" value={getTime(transaction.created_at)} />
         ) : null}
@@ -229,15 +226,12 @@ function TransactionSummary(props: TransactionSummaryProps) {
     )
   }
 
-  const isDangerousSignatureRequest = React.useMemo(
-    () => {
-      const localAccounts = accountDataSet.filter(someAccountData =>
-        accounts.some(account => account.publicKey === someAccountData.id)
-      )
-      return props.signatureRequest && isPotentiallyDangerousTransaction(props.transaction, localAccounts)
-    },
-    [accountDataSet, accounts, props.signatureRequest, props.transaction]
-  )
+  const isDangerousSignatureRequest = React.useMemo(() => {
+    const localAccounts = accountDataSet.filter(someAccountData =>
+      accounts.some(account => account.publicKey === someAccountData.id)
+    )
+    return props.signatureRequest && isPotentiallyDangerousTransaction(props.transaction, localAccounts)
+  }, [accountDataSet, accounts, props.signatureRequest, props.transaction])
 
   const wideScreen = useMediaQuery("(min-width:900px)")
   const widthStyling = wideScreen ? { maxWidth: 700, minWidth: 320 } : { minWidth: "66vw" }

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -86,6 +86,17 @@ async function selectTransactionFeeWithFallback(horizon: Server, fallbackFee: nu
   }
 }
 
+export async function selectSmartMultisigTransactionFee(horizon: Server) {
+  try {
+    const smartFee = await selectSmartTransactionFee(horizon, highFeePreset)
+    return Math.max(smartFee * 2, multisigMinimumFee)
+  } catch (error) {
+    // tslint:disable-next-line no-console
+    console.error("Smart fee selection failed:", error)
+    return multisigMinimumFee
+  }
+}
+
 function selectTransactionTimeout(accountData: Pick<ServerApi.AccountRecord, "signers">): number {
   // Don't forget that we must give the user enough time to enter their password and click ok
   return accountData.signers.length > 1 ? 30 * 24 * 60 * 60 * 1000 : 90


### PR DESCRIPTION
- [x] Create `selectSmartMultisigTransactionFee()` function that uses either twice the amount of the usual fee or 10k stroops as fallback.
- [x] Rename the label from "Fee" to "Maximum Fee" in `<TransactionSummary>`

Closes #531.