### PR TITLE
Use explicit network passphrase when creating new transactions

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,7 +4,6 @@ import React from "react"
 import ReactDOM from "react-dom"
 import { HashRouter as Router, Route, Switch } from "react-router-dom"
 import SmoothScroll from "smoothscroll-polyfill"
-import { Network } from "stellar-sdk"
 import { MuiThemeProvider } from "@material-ui/core/styles"
 import AndroidBackButton from "./components/AndroidBackButton"
 import ErrorBoundary from "./components/ErrorBoundary"
@@ -25,7 +24,6 @@ import SettingsPage from "./pages/settings"
 import handleSplashScreen from "./splash-screen"
 import theme from "./theme"
 
-Network.usePublicNetwork()
 SmoothScroll.polyfill()
 
 const CreateMainnetAccount = () => <CreateAccountPage testnet={false} />

--- a/src/components/Account/TransactionList.tsx
+++ b/src/components/Account/TransactionList.tsx
@@ -19,7 +19,7 @@ import { SettingsContext } from "../../context/settings"
 import { useIsMobile, useRouter } from "../../hooks/userinterface"
 import * as routes from "../../routes"
 import { getPaymentSummary, PaymentSummary } from "../../lib/paymentSummary"
-import { createCheapTxID, selectNetwork } from "../../lib/transaction"
+import { createCheapTxID } from "../../lib/transaction"
 import { breakpoints } from "../../theme"
 import { PublicKey } from "../PublicKey"
 import MemoMessage from "../Stellar/MemoMessage"
@@ -99,17 +99,14 @@ function RemotePublicKeys(props: { publicKeys: string[]; short?: boolean }) {
 }
 
 function Time(props: { time: string }) {
-  const { localeString, unixTime } = React.useMemo(
-    () => {
-      // Turns out that this takes more time than expected
-      const date = new Date(props.time)
-      return {
-        localeString: date.toLocaleString(),
-        unixTime: date.getTime()
-      }
-    },
-    [props.time]
-  )
+  const { localeString, unixTime } = React.useMemo(() => {
+    // Turns out that this takes more time than expected
+    const date = new Date(props.time)
+    return {
+      localeString: date.toLocaleString(),
+      unixTime: date.getTime()
+    }
+  }, [props.time])
   return (
     <Tooltip title={<span style={{ fontSize: "110%" }}>{localeString}</span>}>
       <span style={{ whiteSpace: "nowrap" }}>
@@ -437,8 +434,6 @@ function TransactionList(props: TransactionListProps) {
   const classes = useTransactionListStyles(props)
   const isSmallScreen = useIsMobile()
   const router = useRouter()
-
-  selectNetwork(props.account.testnet) // needed for hashing
 
   const openedTxHash = matchesRoute(router.location.pathname, routes.showTransaction("*", "*"))
     ? (router.match.params as { id: string; subaction: string }).subaction

--- a/src/components/TransactionReview/ReviewForm.tsx
+++ b/src/components/TransactionReview/ReviewForm.tsx
@@ -9,7 +9,7 @@ import { SettingsContext } from "../../context/settings"
 import { RefStateObject } from "../../hooks/userinterface"
 import { renderFormFieldError } from "../../lib/errors"
 import { SignatureRequest } from "../../lib/multisig-service"
-import { createCheapTxID, selectNetwork } from "../../lib/transaction"
+import { createCheapTxID } from "../../lib/transaction"
 import { openLink } from "../../platform/links"
 import { ActionButton, DialogActionsBox } from "../Dialog/Generic"
 import { VerticalLayout } from "../Layout/Box"
@@ -50,19 +50,16 @@ function TxConfirmationForm(props: Props) {
   const cancelDismissal = React.useCallback(() => setDismissalConfirmationPending(false), [])
   const requestDismissalConfirmation = React.useCallback(() => setDismissalConfirmationPending(true), [])
 
-  const dismissSignatureRequest = React.useCallback(
-    () => {
-      if (!props.signatureRequest) return
+  const dismissSignatureRequest = React.useCallback(() => {
+    if (!props.signatureRequest) return
 
-      settings.ignoreSignatureRequest(props.signatureRequest.hash)
-      setDismissalConfirmationPending(false)
+    settings.ignoreSignatureRequest(props.signatureRequest.hash)
+    setDismissalConfirmationPending(false)
 
-      if (props.onClose) {
-        props.onClose()
-      }
-    },
-    [props.signatureRequest]
-  )
+    if (props.onClose) {
+      props.onClose()
+    }
+  }, [props.signatureRequest])
   const setFormValue = <Key extends keyof FormValues>(key: keyof FormValues, value: FormValues[Key]) => {
     setFormValues(prevValues => ({
       ...prevValues,
@@ -70,17 +67,13 @@ function TxConfirmationForm(props: Props) {
     }))
   }
 
-  const openInStellarExpert = React.useCallback(
-    () => {
-      selectNetwork(props.account.testnet)
-      openLink(
-        `https://stellar.expert/explorer/${
-          props.account.testnet ? "testnet" : "public"
-        }/tx/${props.transaction.hash().toString("hex")}`
-      )
-    },
-    [createCheapTxID(props.transaction)]
-  )
+  const openInStellarExpert = React.useCallback(() => {
+    openLink(
+      `https://stellar.expert/explorer/${
+        props.account.testnet ? "testnet" : "public"
+      }/tx/${props.transaction.hash().toString("hex")}`
+    )
+  }, [createCheapTxID(props.transaction)])
 
   const handleFormSubmission = React.useCallback(
     (event: React.SyntheticEvent) => {

--- a/src/components/TransactionReview/TransactionSummary.tsx
+++ b/src/components/TransactionReview/TransactionSummary.tsx
@@ -11,7 +11,7 @@ import { Account, AccountsContext } from "../../context/accounts"
 import { SigningKeyCacheContext } from "../../context/caches"
 import { SignatureRequest } from "../../lib/multisig-service"
 import { getAllSources } from "../../lib/stellar"
-import { isPotentiallyDangerousTransaction, isStellarWebAuthTransaction, selectNetwork } from "../../lib/transaction"
+import { isPotentiallyDangerousTransaction, isStellarWebAuthTransaction } from "../../lib/transaction"
 import theme from "../../theme"
 import { SingleBalance } from "../Account/AccountBalances"
 import { AccountName } from "../Fetchers"
@@ -84,7 +84,6 @@ function DefaultTransactionSummary(props: DefaultTransactionSummaryProps) {
 
   const transaction = props.transaction as TransactionWithUndocumentedProps
   const transactionHash = React.useMemo(() => {
-    selectNetwork(props.testnet)
     return transaction.hash().toString("hex")
   }, [transaction])
 

--- a/src/cordova/keystore.ts
+++ b/src/cordova/keystore.ts
@@ -1,5 +1,5 @@
 import { KeyStore } from "key-store"
-import { Transaction, Network, Keypair } from "stellar-sdk"
+import { Transaction, Keypair } from "stellar-sdk"
 import { CommandHandlers, registerCommandHandler } from "./ipc"
 
 export const commands = {
@@ -118,10 +118,9 @@ async function respondWithSignedTransaction(
 ) {
   const { keyID, networkPassphrase, password, transactionEnvelope } = event.data
 
-  const transaction = new Transaction(transactionEnvelope)
+  const transaction = new Transaction(transactionEnvelope, networkPassphrase)
   const { privateKey } = keyStore.getPrivateKeyData(keyID, password)
 
-  Network.use(new Network(networkPassphrase))
   transaction.sign(Keypair.fromSecret(privateKey))
 
   const result = transaction.toEnvelope().toXDR("base64")

--- a/src/hooks/stellar-subscriptions.ts
+++ b/src/hooks/stellar-subscriptions.ts
@@ -111,7 +111,10 @@ export function useLiveOrderbook(selling: Asset, buying: Asset, testnet: boolean
 
 export function useLiveRecentTransactions(accountID: string, testnet: boolean): ObservedRecentTxs {
   const horizon = useHorizon(testnet)
-  const recentTxsSubscription = React.useMemo(() => subscribeToRecentTxs(horizon, accountID), [accountID, horizon])
+  const recentTxsSubscription = React.useMemo(() => subscribeToRecentTxs(horizon, accountID, testnet), [
+    accountID,
+    horizon
+  ])
 
   return useDataSubscription(recentTxsSubscription)
 }

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -2,13 +2,13 @@ import {
   Asset,
   Keypair,
   Memo,
-  Network,
   Operation,
   Server,
   ServerApi,
   TransactionBuilder,
   Transaction,
-  xdr
+  xdr,
+  Networks
 } from "stellar-sdk"
 import { Account } from "../context/accounts"
 import { createWrongPasswordError } from "../lib/errors"
@@ -38,14 +38,6 @@ export function createCheapTxID(transaction: Transaction | ServerApi.Transaction
   }
 
   return `${source}:${sequence}`
-}
-
-export function selectNetwork(testnet = false) {
-  if (testnet) {
-    Network.useTestNetwork()
-  } else {
-    Network.usePublicNetwork()
-  }
 }
 
 export function hasSigned(transaction: Transaction, publicKey: string) {
@@ -109,14 +101,14 @@ export async function createTransaction(operations: Array<xdr.Operation<any>>, o
     horizon.fetchTimebounds(timeout)
   ])
 
+  const networkPassphrase = walletAccount.testnet ? Networks.TESTNET : Networks.PUBLIC
   const txFee = Math.max(smartTxFee, options.minTransactionFee || 0)
-
-  selectNetwork(walletAccount.testnet)
 
   const builder = new TransactionBuilder(account, {
     fee: txFee,
     memo: options.memo || undefined,
-    timebounds
+    timebounds,
+    networkPassphrase
   })
 
   for (const operation of operations) {

--- a/src/platform/cordova/key-store.ts
+++ b/src/platform/cordova/key-store.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "stellar-sdk"
+import { Transaction, Networks } from "stellar-sdk"
 import { commands } from "../../cordova/ipc"
 import { Account } from "../../context/accounts"
 import { networkPassphrases } from "../../lib/stellar"
@@ -38,7 +38,8 @@ export default async function createKeyStore(): Promise<KeyStoreAPI> {
         transactionEnvelope
       })
       const signedTransactionEnvelope = event.data.result
-      return new Transaction(signedTransactionEnvelope)
+      const networkPassphrase = account.testnet ? Networks.TESTNET : Networks.PUBLIC
+      return new Transaction(signedTransactionEnvelope, networkPassphrase)
     },
     async removeKey(keyID: string) {
       const data = { keyID }

--- a/src/platform/web/key-store.ts
+++ b/src/platform/web/key-store.ts
@@ -1,5 +1,5 @@
 import { createStore, KeysData } from "key-store"
-import { Keypair, Network, Transaction } from "stellar-sdk"
+import { Keypair, Transaction, Networks } from "stellar-sdk"
 import { Account } from "../../context/accounts"
 import { KeyStoreAPI } from "../types"
 
@@ -66,16 +66,12 @@ export default async function createKeyStore(): Promise<KeyStoreAPI> {
     saveKey: async (...args) => keyStore.saveKey(...args),
     savePublicKeyData: async (...args) => keyStore.savePublicKeyData(...args),
     async signTransaction(tx: Transaction, account: Account, password: string): Promise<Transaction> {
-      if (account.testnet) {
-        Network.useTestNetwork()
-      } else {
-        Network.usePublicNetwork()
-      }
-
       const { privateKey } = keyStore.getPrivateKeyData(account.id, password)
       const keypair = Keypair.fromSecret(privateKey)
 
-      const signedTx = new Transaction((tx.toEnvelope().toXDR("base64") as unknown) as string)
+      const networkPassphrase = account.testnet ? Networks.TESTNET : Networks.PUBLIC
+
+      const signedTx = new Transaction((tx.toEnvelope().toXDR("base64") as unknown) as string, networkPassphrase)
       signedTx.sign(keypair)
 
       return signedTx

--- a/src/subscriptions/index.ts
+++ b/src/subscriptions/index.ts
@@ -109,14 +109,18 @@ export function subscribeToOrders(
   }
 }
 
-export function subscribeToRecentTxs(horizon: Server, accountPubKey: string): SubscriptionTarget<ObservedRecentTxs> {
+export function subscribeToRecentTxs(
+  horizon: Server,
+  accountPubKey: string,
+  testnet: boolean
+): SubscriptionTarget<ObservedRecentTxs> {
   const cacheKey = getHorizonURL(horizon) + accountPubKey
   const cached = recentTxsSubscriptionsCache.get(cacheKey)
 
   if (cached && !cached.closed) {
     return cached
   } else {
-    const recentTxsSubscription = createRecentTxsSubscription(horizon, accountPubKey)
+    const recentTxsSubscription = createRecentTxsSubscription(horizon, accountPubKey, testnet)
     recentTxsSubscriptionsCache.set(cacheKey, recentTxsSubscription)
     return recentTxsSubscription
   }


### PR DESCRIPTION
- [x] Removes usages of the global `Network` singleton 
- [x] Use the according network passphrase on creation of new `Transaction`s.

This eliminates the console messages that warn about using the global `Network` singleton.