### PR TITLE
Fix no error shown on wrong password

### DIFF
--- a/electron/lib/storage.js
+++ b/electron/lib/storage.js
@@ -71,7 +71,12 @@ expose(ipcMain, commands.signTransactionCommand, events.signTransactionEvent, fu
   password
 ) {
   const transaction = new Transaction(txEnvelopeXdr)
-  const { privateKey } = keystore.getPrivateKeyData(keyID, password)
+  let privateKey
+  try {
+    privateKey = keystore.getPrivateKeyData(keyID, password)
+  } catch (error) {
+    throw Object.assign(new Error("Wrong password."), { name: "WrongPasswordError" })
+  }
 
   Network.use(new Network(networkPassphrase))
   transaction.sign(Keypair.fromSecret(privateKey))

--- a/src/context/accounts.tsx
+++ b/src/context/accounts.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Keypair } from "stellar-sdk"
 import { Transaction } from "stellar-base"
-import { createWrongPasswordError } from "../lib/errors"
+import { WrongPasswordError } from "../lib/errors"
 import getKeyStore from "../platform/key-store"
 import { KeyStoreAPI } from "../platform/types"
 import { trackError } from "./notifications"
@@ -62,7 +62,7 @@ async function createAccountInstance(keyStore: KeyStoreAPI, keyID: string) {
       } catch (error) {
         // tslint:disable-next-line:no-console
         console.debug("Decrypting private key data failed. Assuming wrong password:", error)
-        throw createWrongPasswordError()
+        throw WrongPasswordError()
       }
     },
 
@@ -192,7 +192,7 @@ export function AccountsProvider(props: Props) {
     } catch (error) {
       // tslint:disable-next-line:no-console
       console.debug("Decrypting private key data failed. Assuming wrong password:", error)
-      throw createWrongPasswordError()
+      throw WrongPasswordError()
     }
 
     // Setting `password: true` explicitly, in case there was no password set before
@@ -212,7 +212,7 @@ export function AccountsProvider(props: Props) {
     } catch (error) {
       // tslint:disable-next-line:no-console
       console.debug("Decrypting private key data failed. Assuming wrong password:", error)
-      throw createWrongPasswordError()
+      throw WrongPasswordError()
     }
 
     await keyStore.saveKey(accountID, "", privateKeyData, { ...publicKeyData, password: false })

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -10,7 +10,7 @@ export function isCancellation(thing: any) {
   return thing instanceof Error && thing.name === "Cancellation"
 }
 
-export function createWrongPasswordError(message: string = "Wrong password.") {
+export function WrongPasswordError(message: string = "Wrong password.") {
   return Object.assign(new Error(message), { name: "WrongPasswordError" })
 }
 

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -11,7 +11,7 @@ import {
   Networks
 } from "stellar-sdk"
 import { Account } from "../context/accounts"
-import { createWrongPasswordError } from "../lib/errors"
+import { WrongPasswordError } from "../lib/errors"
 import { getAllSources, isNotFoundError, isSignedByAnyOf, selectSmartTransactionFee, SmartFeePreset } from "./stellar"
 
 interface SignatureWithHint extends xdr.DecoratedSignature {
@@ -146,7 +146,7 @@ export async function createPaymentOperation(options: PaymentOperationBlueprint)
 
 export async function signTransaction(transaction: Transaction, walletAccount: Account, password: string | null) {
   if (walletAccount.requiresPassword && !password) {
-    throw createWrongPasswordError(`Account is password-protected, but no password has been provided.`)
+    throw WrongPasswordError(`Account is password-protected, but no password has been provided.`)
   }
 
   const signedTransaction = walletAccount.signTransaction(transaction, password)

--- a/src/platform/cordova/key-store.ts
+++ b/src/platform/cordova/key-store.ts
@@ -4,6 +4,7 @@ import { Account } from "../../context/accounts"
 import { networkPassphrases } from "../../lib/stellar"
 import { KeyStoreAPI } from "../types"
 import { sendCommand } from "./message-handler"
+import { WrongPasswordError } from "../../lib/errors"
 
 export default async function createKeyStore(): Promise<KeyStoreAPI> {
   return {
@@ -37,9 +38,13 @@ export default async function createKeyStore(): Promise<KeyStoreAPI> {
         password,
         transactionEnvelope
       })
-      const signedTransactionEnvelope = event.data.result
-      const networkPassphrase = account.testnet ? Networks.TESTNET : Networks.PUBLIC
-      return new Transaction(signedTransactionEnvelope, networkPassphrase)
+      if (event.data.error === "Wrong password") {
+        throw WrongPasswordError()
+      } else {
+        const signedTransactionEnvelope = event.data.result
+        const networkPassphrase = account.testnet ? Networks.TESTNET : Networks.PUBLIC
+        return new Transaction(signedTransactionEnvelope, networkPassphrase)
+      }
     },
     async removeKey(keyID: string) {
       const data = { keyID }


### PR DESCRIPTION
Catch the error that is thrown by `keystore.getPrivateKeyData()` when the given password is wrong and throw a `WrongPasswordError` so that the 'wrong password'-scenario is handled properly by the `TransactionSender` component.

Closes #764.