### PR TITLE
Make trading price inline editable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11117,8 +11117,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
       "version": "2.2.6",
@@ -15815,8 +15814,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -18103,6 +18101,32 @@
       "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-4.2.2.tgz",
       "integrity": "sha512-8zn2OmjP/BhsW0spc5/nsYFsS3ybqwkoZypFl7PU92Jt1cJAjOo8Y7kfo/+ja4c/88UNLBTLfMcnlE+4Diq/5w==",
       "dev": true
+    },
+    "react-contenteditable": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/react-contenteditable/-/react-contenteditable-3.3.2.tgz",
+      "integrity": "sha512-dGj4ABKOG/AwuboJFTSxX4dQvCXboSOJcC2K1k/rZat+7hebO9iVpIDG8W2Kbj2Vbxbx2rAVCp9xlWEJa1+FGA==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "prop-types": "^15.7.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.10.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+        }
+      }
     },
     "react-dev-utils": {
       "version": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "nanoid": "^2.1.1",
     "opn": "^5.5.0",
     "p-queue": "^6.1.1",
+    "react-contenteditable": "^3.3.2",
     "react-window": "^1.8.5",
     "stellar-base": "^1.1.2",
     "stellar-sdk": "^2.3.0"


### PR DESCRIPTION
So you don't have the accept and dismiss icon buttons. Should improve the usability of the trading view and make the price input's behavior more consistent with the other inputs.