### PR TITLE
Add helper text to textfield for private key import

### DIFF
--- a/src/components/Form/CreateAccount.tsx
+++ b/src/components/Form/CreateAccount.tsx
@@ -207,8 +207,8 @@ function AccountCreationForm(props: AccountCreationFormProps) {
               error={Boolean(errors.privateKey)}
               helperText={
                 errors.privateKey
-                  ? "A Stellar secret key is 56 alphanumeric characters long and always starts with an S"
-                  : undefined
+                  ? "A Stellar secret key is 56 alphanumeric characters long and starts with an S"
+                  : " "
               }
               label={errors.privateKey ? renderFormFieldError(errors.privateKey) : "Secret key"}
               placeholder="SABCDEFGH…"

--- a/src/components/Form/CreateAccount.tsx
+++ b/src/components/Form/CreateAccount.tsx
@@ -205,6 +205,11 @@ function AccountCreationForm(props: AccountCreationFormProps) {
             <TextField
               disabled={Boolean(formValues.createNewKey)}
               error={Boolean(errors.privateKey)}
+              helperText={
+                errors.privateKey
+                  ? "A Stellar secret key is 56 alphanumeric characters long and always starts with an S"
+                  : undefined
+              }
               label={errors.privateKey ? renderFormFieldError(errors.privateKey) : "Secret key"}
               placeholder="SABCDEFGH…"
               fullWidth


### PR DESCRIPTION
Show helper text below the TextField for import of a private key if the key is invalid.

Closes #722.