### PR TITLE
Prevent division by zero at calculation of default price

### DIFF
--- a/src/components/Trading/TradePropertiesForm.tsx
+++ b/src/components/Trading/TradePropertiesForm.tsx
@@ -98,8 +98,8 @@ function TradePropertiesForm(props: TradePropertiesFormProps) {
   const [manualPrice, setManualPrice] = React.useState<ManualPrice>({})
   const [priceMode, setPriceMode] = React.useState<"fixed-buying" | "fixed-selling">("fixed-selling")
 
-  const price = props.price.eq(0) ? BigNumber(1) : props.price // prevent division by zero
-  const defaultPrice = bigNumberToInputValue(priceMode === "fixed-buying" ? BigNumber(1).div(price) : price)
+  const inversePrice = props.price.eq(0) ? BigNumber(0) : BigNumber(1).div(props.price) // prevent division by zero
+  const defaultPrice = bigNumberToInputValue(priceMode === "fixed-buying" ? inversePrice : props.price)
 
   const buyingAmountString =
     editableAmount.field === "buying" ? editableAmount.value : bigNumberToInputValue(props.buyingAmount)

--- a/src/components/Trading/TradePropertiesForm.tsx
+++ b/src/components/Trading/TradePropertiesForm.tsx
@@ -98,7 +98,8 @@ function TradePropertiesForm(props: TradePropertiesFormProps) {
   const [manualPrice, setManualPrice] = React.useState<ManualPrice>({})
   const [priceMode, setPriceMode] = React.useState<"fixed-buying" | "fixed-selling">("fixed-selling")
 
-  const defaultPrice = bigNumberToInputValue(priceMode === "fixed-buying" ? BigNumber(1).div(props.price) : props.price)
+  const price = props.price.eq(0) ? BigNumber(1) : props.price // prevent division by zero
+  const defaultPrice = bigNumberToInputValue(priceMode === "fixed-buying" ? BigNumber(1).div(price) : price)
 
   const buyingAmountString =
     editableAmount.field === "buying" ? editableAmount.value : bigNumberToInputValue(props.buyingAmount)


### PR DESCRIPTION
Set the price to 0 instead of 1/0 when switching a zero price.
