### PR TITLE
Remove unused spacing prop of DialogActionsBox

### DIFF
--- a/src/components/Dialog/Generic.tsx
+++ b/src/components/Dialog/Generic.tsx
@@ -162,7 +162,6 @@ interface DialogActionsBoxProps {
   hidden?: boolean
   preventMobileActionsBox?: boolean
   smallDialog?: boolean
-  spacing?: "normal" | "large"
 }
 
 // tslint:disable-next-line no-shadowed-variable

--- a/src/components/Payment/CreatePaymentForm.tsx
+++ b/src/components/Payment/CreatePaymentForm.tsx
@@ -297,7 +297,7 @@ function PaymentCreationForm(props: Props) {
         />
       </HorizontalLayout>
       <Portal target={props.actionsRef.element}>
-        <DialogActionsBox spacing="large" desktopStyle={{ marginTop: 64 }}>
+        <DialogActionsBox desktopStyle={{ marginTop: 64 }}>
           <ActionButton
             disabled={isDisabled}
             form={formID}

--- a/src/components/Withdrawal/WithdrawalRequestForm.tsx
+++ b/src/components/Withdrawal/WithdrawalRequestForm.tsx
@@ -253,7 +253,7 @@ function AnchorWithdrawalInitForm(props: Props) {
           ) : null}
         </HorizontalLayout>
         <Portal target={props.actionsRef.element}>
-          <DialogActionsBox desktopStyle={{ marginTop: 0 }} spacing="large">
+          <DialogActionsBox desktopStyle={{ marginTop: 0 }}>
             <ActionButton onClick={props.onCancel}>Cancel</ActionButton>
             <ActionButton
               disabled={isDisabled}

--- a/src/components/Withdrawal/WithdrawalTransactionForm.tsx
+++ b/src/components/Withdrawal/WithdrawalTransactionForm.tsx
@@ -100,7 +100,7 @@ function WithdrawalTransactionForm(props: Props) {
         )}
         <HorizontalLayout margin="24px 0 64px">{null}</HorizontalLayout>
         <Portal target={props.actionsRef.element}>
-          <DialogActionsBox spacing="large">
+          <DialogActionsBox>
             <ActionButton onClick={props.onCancel}>Cancel</ActionButton>
             <ActionButton
               disabled={isDisabled}


### PR DESCRIPTION
The `spacing` prop is not used in `<DialogActionsBox>` anymore.