### PR TITLE
Fix no rounded corners of DialogActionsBox in Withdraw and Trading view

### DIFF
--- a/src/components/Dialog/Generic.tsx
+++ b/src/components/Dialog/Generic.tsx
@@ -38,9 +38,9 @@ const useActionButtonStyles = makeStyles(theme => ({
   mobileDialogActionsBox: {
     display: "flex",
     position: "fixed",
-    left: 0,
+    left: 8,
+    right: 8,
     bottom: 0,
-    width: "100%",
     backgroundColor: "#fcfcfc",
     justifyContent: "flex-end"
   },

--- a/src/components/Trading/TradingDialog.tsx
+++ b/src/components/Trading/TradingDialog.tsx
@@ -135,7 +135,7 @@ function TradingDialog(props: TradingDialogProps) {
       <Box margin="32px 0 0" textAlign="center">
         <Typography>This account doesn't use any assets other than Stellar Lumens yet.</Typography>
         <ActionsContainer>
-          <DialogActionsBox desktopStyle={{ display: "block", alignSelf: "center" }}>
+          <DialogActionsBox>
             <ActionButton
               autoFocus
               onClick={() => router.history.push(routes.manageAccountAssets(props.account.id))}

--- a/src/components/Trading/TradingDialog.tsx
+++ b/src/components/Trading/TradingDialog.tsx
@@ -134,18 +134,20 @@ function TradingDialog(props: TradingDialogProps) {
     () => (
       <Box margin="32px 0 0" textAlign="center">
         <Typography>This account doesn't use any assets other than Stellar Lumens yet.</Typography>
-        <DialogActionsBox desktopStyle={{ display: "block", alignSelf: "center" }}>
-          <ActionButton
-            autoFocus
-            onClick={() => router.history.push(routes.manageAccountAssets(props.account.id))}
-            type="primary"
-          >
-            Add asset
-          </ActionButton>
-        </DialogActionsBox>
+        <ActionsContainer>
+          <DialogActionsBox desktopStyle={{ display: "block", alignSelf: "center" }}>
+            <ActionButton
+              autoFocus
+              onClick={() => router.history.push(routes.manageAccountAssets(props.account.id))}
+              type="primary"
+            >
+              Add asset
+            </ActionButton>
+          </DialogActionsBox>
+        </ActionsContainer>
       </Box>
     ),
-    [props.account, router]
+    [props.account, router, ActionsContainer]
   )
 
   return (

--- a/src/components/Withdrawal/Offramp.tsx
+++ b/src/components/Withdrawal/Offramp.tsx
@@ -29,6 +29,7 @@ import WithdrawalKYCStatus from "./WithdrawalKYCStatus"
 import AnchorWithdrawalInitForm from "./WithdrawalRequestForm"
 import WithdrawalTransactionForm from "./WithdrawalTransactionForm"
 import TransactionReviewDialog from "../TransactionReview/TransactionReviewDialog"
+import Portal from "../Portal"
 
 const kycPollIntervalMs = 6000
 
@@ -233,15 +234,17 @@ function Offramp(props: Props) {
     return (
       <Box margin="32px 0 0" textAlign="center">
         <Typography>This account holds no withdrawable assets.</Typography>
-        <DialogActionsBox desktopStyle={{ display: "block", alignSelf: "center" }}>
-          <ActionButton
-            autoFocus
-            onClick={() => router.history.push(routes.manageAccountAssets(props.account.id))}
-            type="primary"
-          >
-            Add asset
-          </ActionButton>
-        </DialogActionsBox>
+        <Portal target={props.actionsRef.element}>
+          <DialogActionsBox desktopStyle={{ display: "block", alignSelf: "center" }}>
+            <ActionButton
+              autoFocus
+              onClick={() => router.history.push(routes.manageAccountAssets(props.account.id))}
+              type="primary"
+            >
+              Add asset
+            </ActionButton>
+          </DialogActionsBox>
+        </Portal>
       </Box>
     )
   }

--- a/src/components/Withdrawal/Offramp.tsx
+++ b/src/components/Withdrawal/Offramp.tsx
@@ -235,7 +235,7 @@ function Offramp(props: Props) {
       <Box margin="32px 0 0" textAlign="center">
         <Typography>This account holds no withdrawable assets.</Typography>
         <Portal target={props.actionsRef.element}>
-          <DialogActionsBox desktopStyle={{ display: "block", alignSelf: "center" }}>
+          <DialogActionsBox>
             <ActionButton
               autoFocus
               onClick={() => router.history.push(routes.manageAccountAssets(props.account.id))}


### PR DESCRIPTION
- [x] To fix padding issues on iOS wrap the `<DialogActionsBox` with a `<Portal>` component in the withdraw view and with the `<ActionsContainer>` in the trading view
- [x] Slightly reduce the width of the `<DialogActionsBox>` on mobile
- [x] Align the "Add Asset" buttons in trading and withdraw view to the bottom right hand side