### PR TITLE
Change background styling in submission progress

### DIFF
--- a/src/components/TransactionSender.tsx
+++ b/src/components/TransactionSender.tsx
@@ -37,7 +37,7 @@ function ConditionalSubmissionProgress(props: {
     height: "100%",
     alignItems: "center",
     justifyContent: "center",
-    background: "white"
+    background: "#fcfcfc"
   }
   const innerStyle: React.CSSProperties = {
     display: "flex",


### PR DESCRIPTION
Change the color of the submission progress background to the `#fcfcfc` so that it matches the color of the outer background. 