### PR TITLE
Allow opening error messages in detail view

### DIFF
--- a/src/components/NotificationContainer.tsx
+++ b/src/components/NotificationContainer.tsx
@@ -68,7 +68,7 @@ const NotificationDetailsDialog = React.memo(function NotificationDetailsDialog(
   return (
     <Dialog fullScreen open={open} onClose={onClose} TransitionComponent={FullscreenDialogTransition}>
       <DialogBody
-        top={<MainTitle onBack={onClose} title={"Error"} />}
+        top={<MainTitle onBack={onClose} title="Error" />}
         actions={
           <DialogActionsBox>
             <ActionButton autoFocus onClick={onClose} type="primary">
@@ -97,7 +97,6 @@ interface NotificationProps {
   style?: React.CSSProperties
 }
 
-// tslint:disable-next-line no-shadowed-variable
 const Notification = React.memo(function Notification(props: NotificationProps) {
   const { open = true } = props
   const classes = useNotificationStyles()
@@ -184,6 +183,14 @@ function NotificationsContainer() {
     setDialogOpen(false)
   }, [closeNotification])
 
+  const onNotificationClick = React.useCallback(() => {
+    if (notification && notification.onClick) {
+      notification.onClick()
+    } else if (notification && notification.type === "error") {
+      showNotificationDetails()
+    }
+  }, [notification, showNotificationDetails])
+
   return (
     <>
       <Notification
@@ -191,7 +198,7 @@ function NotificationsContainer() {
         message={notification ? notification.message : ""}
         type={notification ? notification.type : "error"}
         open={open && !dialogOpen}
-        onClick={notification && notification.onClick ? notification.onClick : showNotificationDetails}
+        onClick={onNotificationClick}
         onClose={closeNotification}
       />
       <OfflineNotification message="Offline" open={!isOnline} />

--- a/src/components/NotificationContainer.tsx
+++ b/src/components/NotificationContainer.tsx
@@ -57,6 +57,34 @@ const useNotificationStyles = makeStyles({
   }
 })
 
+interface NotificationDetailsDialogProps {
+  open: boolean
+  notification: Notification | null
+  onClose: () => void
+}
+
+const NotificationDetailsDialog = React.memo(function NotificationDetailsDialog(props: NotificationDetailsDialogProps) {
+  const { open, onClose, notification } = props
+  return (
+    <Dialog fullScreen open={open} onClose={onClose} TransitionComponent={FullscreenDialogTransition}>
+      <DialogBody
+        top={<MainTitle onBack={onClose} title={"Error"} />}
+        actions={
+          <DialogActionsBox>
+            <ActionButton autoFocus onClick={onClose} type="primary">
+              Dismiss
+            </ActionButton>
+          </DialogActionsBox>
+        }
+      >
+        <Box alignSelf="center" margin="24px auto 0" maxWidth={400} width="100%">
+          <Typography>{notification ? notification.message : ""}</Typography>
+        </Box>
+      </DialogBody>
+    </Dialog>
+  )
+})
+
 interface NotificationProps {
   anchorOrigin?: SnackbarOrigin
   autoHideDuration?: number
@@ -149,49 +177,31 @@ function NotificationsContainer() {
     lastShownNotification.current = latestNotificationItem
   }
 
-  const showDialog = React.useCallback(() => {
-    setDialogOpen(true)
-  }, [setDialogOpen])
+  const showNotificationDetails = React.useCallback(() => setDialogOpen(true), [])
 
-  const closeDialog = React.useCallback(() => {
+  const closeNotificationDetails = React.useCallback(() => {
     closeNotification()
     setDialogOpen(false)
-  }, [setDialogOpen, closeNotification])
+  }, [closeNotification])
 
-  const dialog = (
-    <Dialog fullScreen open={dialogOpen} onClose={closeDialog} TransitionComponent={FullscreenDialogTransition}>
-      <DialogBody
-        top={<MainTitle onBack={closeDialog} title={"Error"} />}
-        actions={
-          <DialogActionsBox>
-            <ActionButton autoFocus icon={<CheckIcon />} onClick={closeDialog} type="primary">
-              {"Dismiss"}
-            </ActionButton>
-          </DialogActionsBox>
-        }
-      >
-        <Box alignSelf="center" margin="24px auto 0" maxWidth={400} width="100%">
-          <Typography>{notification ? notification.message : ""}</Typography>
-        </Box>
-      </DialogBody>
-    </Dialog>
-  )
-
-  const notificationJSX = (
+  return (
     <>
       <Notification
         autoHideDuration={5000}
         message={notification ? notification.message : ""}
         type={notification ? notification.type : "error"}
-        open={open}
-        onClick={notification && notification.onClick ? notification.onClick : showDialog}
+        open={open && !dialogOpen}
+        onClick={notification && notification.onClick ? notification.onClick : showNotificationDetails}
         onClose={closeNotification}
       />
       <OfflineNotification message="Offline" open={!isOnline} />
+      <NotificationDetailsDialog
+        open={dialogOpen}
+        onClose={closeNotificationDetails}
+        notification={latestNotificationItem}
+      />
     </>
   )
-
-  return dialogOpen ? dialog : notificationJSX
 }
 
 export default NotificationsContainer

--- a/src/components/NotificationContainer.tsx
+++ b/src/components/NotificationContainer.tsx
@@ -42,9 +42,12 @@ const useNotificationStyles = makeStyles({
     marginRight: theme.spacing(1)
   },
   message: {
-    display: "flex",
     alignItems: "center",
-    whiteSpace: "pre"
+    display: "block",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    width: "90vw",
+    whiteSpace: "nowrap"
   }
 })
 

--- a/src/context/notifications.tsx
+++ b/src/context/notifications.tsx
@@ -53,9 +53,6 @@ export function NotificationsProvider(props: Props) {
     const id = nextIDRef.current++
 
     setNotifications(prevNotifications => prevNotifications.concat({ ...options, id, message, type }))
-
-    // just to prevent memory leaks; the NotificationContainer component determines when to hide
-    setTimeout(() => removeNotificationByID(id), 10000)
   }
 
   const showConnectionError = (error: any) => {
@@ -70,10 +67,6 @@ export function NotificationsProvider(props: Props) {
 
     // tslint:disable-next-line:no-console
     console.error(error)
-  }
-
-  const removeNotificationByID = (notificationID: number) => {
-    setNotifications(prevNotifications => prevNotifications.filter(notification => notification.id !== notificationID))
   }
 
   trackConnectionErrorImplementation = showConnectionError


### PR DESCRIPTION
- [x] Trim notifications by showing ellipsis when message is too long
- [x] Add `onClick` function that opens a dialog with the message of the notification if `notification.onClick` is undefined

Closes #813. 