### PR TITLE
Hide action buttons when keyboard is shown on android

### DIFF
--- a/src/components/Dialog/DialogBody.tsx
+++ b/src/components/Dialog/DialogBody.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { makeStyles } from "@material-ui/core/styles"
 import { useIsMobile, RefStateObject } from "../../hooks/userinterface"
-import { iOSKeyboardHackSelector } from "../../theme"
+import { MobileOnScreenKeyboardHackSelector } from "../../theme"
 import ErrorBoundary from "../ErrorBoundary"
 import { Box, VerticalLayout } from "../Layout/Box"
 
@@ -28,7 +28,7 @@ function Background(props: { children: React.ReactNode; opacity?: number }) {
 
 const useDialogBodyStyles = makeStyles({
   actions: {
-    [iOSKeyboardHackSelector()]: {
+    [MobileOnScreenKeyboardHackSelector()]: {
       display: "none !important"
     }
   }

--- a/src/components/Dialog/DialogBody.tsx
+++ b/src/components/Dialog/DialogBody.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { makeStyles } from "@material-ui/core/styles"
 import { useIsMobile, RefStateObject } from "../../hooks/userinterface"
-import { MobileOnScreenKeyboardHackSelector } from "../../theme"
+import { MobileKeyboardOpenedSelector } from "../../theme"
 import ErrorBoundary from "../ErrorBoundary"
 import { Box, VerticalLayout } from "../Layout/Box"
 
@@ -28,7 +28,7 @@ function Background(props: { children: React.ReactNode; opacity?: number }) {
 
 const useDialogBodyStyles = makeStyles({
   actions: {
-    [MobileOnScreenKeyboardHackSelector()]: {
+    [MobileKeyboardOpenedSelector()]: {
       display: "none !important"
     }
   }

--- a/src/components/Dialog/Generic.tsx
+++ b/src/components/Dialog/Generic.tsx
@@ -8,7 +8,7 @@ import Typography from "@material-ui/core/Typography"
 import { makeStyles } from "@material-ui/core/styles"
 import CloseIcon from "@material-ui/icons/Close"
 import { useIsMobile } from "../../hooks/userinterface"
-import { breakpoints, MobileOnScreenKeyboardHackSelector, CompactDialogTransition } from "../../theme"
+import { breakpoints, MobileKeyboardOpenedSelector, CompactDialogTransition } from "../../theme"
 import { setupRerenderListener } from "../../platform/keyboard-hack"
 import ButtonIconLabel from "../ButtonIconLabel"
 
@@ -45,7 +45,7 @@ const useActionButtonStyles = makeStyles(theme => ({
     backgroundColor: "#fcfcfc",
     justifyContent: "flex-end",
 
-    [MobileOnScreenKeyboardHackSelector()]: {
+    [MobileKeyboardOpenedSelector()]: {
       // For iOS keyboard: Viewport shrinks when keyboard opens. Make actions non-sticky then,
       // so they don't take too much screen space; making it consistent with other iOS apps.
       position: "static !important" as any
@@ -55,7 +55,7 @@ const useActionButtonStyles = makeStyles(theme => ({
     width: "100% !important",
     height: "88px !important",
 
-    [MobileOnScreenKeyboardHackSelector()]: {
+    [MobileKeyboardOpenedSelector()]: {
       display: "none"
     }
   },

--- a/src/components/Dialog/Generic.tsx
+++ b/src/components/Dialog/Generic.tsx
@@ -8,7 +8,7 @@ import Typography from "@material-ui/core/Typography"
 import { makeStyles } from "@material-ui/core/styles"
 import CloseIcon from "@material-ui/icons/Close"
 import { useIsMobile } from "../../hooks/userinterface"
-import { breakpoints, iOSKeyboardHackSelector, CompactDialogTransition } from "../../theme"
+import { breakpoints, MobileOnScreenKeyboardHackSelector, CompactDialogTransition } from "../../theme"
 import { setupRerenderListener } from "../../platform/keyboard-hack"
 import ButtonIconLabel from "../ButtonIconLabel"
 
@@ -45,7 +45,7 @@ const useActionButtonStyles = makeStyles(theme => ({
     backgroundColor: "#fcfcfc",
     justifyContent: "flex-end",
 
-    [iOSKeyboardHackSelector()]: {
+    [MobileOnScreenKeyboardHackSelector()]: {
       // For iOS keyboard: Viewport shrinks when keyboard opens. Make actions non-sticky then,
       // so they don't take too much screen space; making it consistent with other iOS apps.
       position: "static !important" as any
@@ -55,7 +55,7 @@ const useActionButtonStyles = makeStyles(theme => ({
     width: "100% !important",
     height: "88px !important",
 
-    [iOSKeyboardHackSelector()]: {
+    [MobileOnScreenKeyboardHackSelector()]: {
       display: "none"
     }
   },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -292,8 +292,8 @@ export default theme
 
 const initialScreenHeight = window.screen.height
 
-// CSS media query selector to detect an open keyboard on iOS + android
-export const MobileOnScreenKeyboardHackSelector =
+// CSS media query selector to detect an open keyboard on iOS + Android
+export const MobileKeyboardOpenedSelector =
   process.env.PLATFORM === "ios" || process.env.PLATFORM === "android"
     ? () => `@media (max-height: ${initialScreenHeight - 100}px)`
     : () => `:not(*)`

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -292,6 +292,8 @@ export default theme
 
 const initialScreenHeight = window.screen.height
 
-// CSS media query selector to detect an open keyboard on iOS
-export const iOSKeyboardHackSelector =
-  process.env.PLATFORM === "ios" ? () => `@media (max-height: ${initialScreenHeight - 100}px)` : () => `:not(*)`
+// CSS media query selector to detect an open keyboard on iOS + android
+export const MobileOnScreenKeyboardHackSelector =
+  process.env.PLATFORM === "ios" || process.env.PLATFORM === "android"
+    ? () => `@media (max-height: ${initialScreenHeight - 100}px)`
+    : () => `:not(*)`


### PR DESCRIPTION
Hide the action buttons on android when the on-screen keyboard is shown (just like on iOS where this change was introduced recently).

- [x] Make the CSS media query selector for detection of open keyboard apply on iOS and android
- [x] Rename `iOSKeyboardHackSelector` to `MobileOnScreenKeyboardHackSelector` because it now applies to both mobile platforms
