### PR TITLE
Trim spaces from address input fields

### DIFF
--- a/src/components/Form/CreateAccount.tsx
+++ b/src/components/Form/CreateAccount.tsx
@@ -213,7 +213,7 @@ function AccountCreationForm(props: AccountCreationFormProps) {
               fullWidth
               margin="normal"
               value={formValues.privateKey}
-              onChange={event => setFormValue("privateKey", event.target.value)}
+              onChange={event => setFormValue("privateKey", event.target.value.trim())}
               inputProps={{
                 style: { textOverflow: "ellipsis" }
               }}

--- a/src/components/ManageSigners/NewSignerForm.tsx
+++ b/src/components/ManageSigners/NewSignerForm.tsx
@@ -44,7 +44,7 @@ function NewSignerForm(props: Props) {
             error={!!props.errors.publicKey}
             label={props.errors.publicKey ? props.errors.publicKey.message : "Public Key or Stellar Address"}
             placeholder={isSmallScreen ? "GABC… or address" : "GABCDEFGHIJK… or alice*example.org"}
-            onChange={event => props.onUpdate({ publicKey: event.target.value })}
+            onChange={event => props.onUpdate({ publicKey: event.target.value.trim() })}
             style={{ flexGrow: 1 }}
             InputProps={isTinyScreen ? { style: { fontSize: "0.8rem" } } : undefined}
             value={props.values.publicKey}

--- a/src/components/Payment/PaymentForm.tsx
+++ b/src/components/Payment/PaymentForm.tsx
@@ -177,7 +177,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
         autoFocus={process.env.PLATFORM !== "ios"}
         margin="normal"
         value={formValues.destination}
-        onChange={event => setFormValue("destination", event.target.value)}
+        onChange={event => setFormValue("destination", event.target.value.trim())}
         inputProps={{
           style: { textOverflow: "ellipsis" }
         }}


### PR DESCRIPTION
Use trim() to remove leading and trailing spaces of the values of input fields that contain stellar addresses.

Closes #821. 