### PR TITLE
Make Android status bar transparent 

### DIFF
--- a/cordova/config/config.template
+++ b/cordova/config/config.template
@@ -26,6 +26,8 @@
             <manifest xmlns:tools="http://schemas.android.com/tools" />
         </edit-config>
 
+        <hook type="before_build" src="scripts/android/useFullScreenActivity.sh" />
+
         <icon background="res/icon/android/adaptiveicon/mipmap-mdpi/ic_launcher_background.png" density="mdpi" foreground="res/icon/android/adaptiveicon/mipmap-mdpi/ic_launcher_foreground.png" />
         <icon background="res/icon/android/adaptiveicon/mipmap-hdpi/ic_launcher_background.png" density="hdpi" foreground="res/icon/android/adaptiveicon/mipmap-hdpi/ic_launcher_foreground.png" />
         <icon background="res/icon/android/adaptiveicon/mipmap-xhdpi/ic_launcher_background.png" density="xhdpi" foreground="res/icon/android/adaptiveicon/mipmap-xhdpi/ic_launcher_foreground.png" />

--- a/cordova/scripts/android/MainActivity.java
+++ b/cordova/scripts/android/MainActivity.java
@@ -1,0 +1,60 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+ */
+
+package io.solarwallet;
+
+import android.graphics.Color;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.view.WindowManager;
+
+import org.apache.cordova.*;
+
+
+public class MainActivity extends CordovaActivity
+{
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            getWindow().setStatusBarColor(Color.TRANSPARENT);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN | View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+            } else {
+                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+            }
+        } else {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+        }
+
+        // enable Cordova apps to be started in the background
+        Bundle extras = getIntent().getExtras();
+        if (extras != null && extras.getBoolean("cdvStartInBackground", false)) {
+            moveTaskToBack(true);
+        }
+
+        // Set by <content src="index.html" /> in config.xml
+        loadUrl(launchUrl);
+    }
+}

--- a/cordova/scripts/android/useFullScreenActivity.sh
+++ b/cordova/scripts/android/useFullScreenActivity.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+ROOT_DIR=$1
+cp $ROOT_DIR/scripts/android/MainActivity.java $ROOT_DIR/platforms/android/app/src/main/java/io/solarwallet/MainActivity.java

--- a/src/base-styles.css
+++ b/src/base-styles.css
@@ -16,6 +16,10 @@ body {
   line-height: 20px;
 }
 
+.android-top-spacing {
+  padding-top: 28px;
+}
+
 .iphone-notch-top-spacing {
   padding-top: constant(safe-area-inset-top); /* iOS 11.0 */
   padding-top: env(safe-area-inset-top); /* iOS 11.2 */

--- a/src/components/Dialog/DialogBody.tsx
+++ b/src/components/Dialog/DialogBody.tsx
@@ -5,6 +5,7 @@ import { useIsMobile, RefStateObject } from "../../hooks/userinterface"
 import { MobileKeyboardOpenedSelector } from "../../theme"
 import ErrorBoundary from "../ErrorBoundary"
 import { Box, VerticalLayout } from "../Layout/Box"
+import { Section } from "../Layout/Page"
 
 const isRefStateObject = (thing: any): thing is RefStateObject =>
   thing && "element" in thing && typeof thing.update === "function"
@@ -46,6 +47,7 @@ const topStyle: React.CSSProperties = {
 interface Props {
   actions?: React.ReactNode | RefStateObject
   actionsPosition?: "after-content" | "bottom"
+  brandColored?: boolean
   background?: React.ReactNode
   children: React.ReactNode
   excessWidth?: number
@@ -88,15 +90,16 @@ function DialogBody(props: Props) {
 
   return (
     <ErrorBoundary>
-      <VerticalLayout
-        className="dialog-body"
+      <Section
+        brandColored={props.brandColored}
         width="100%"
         height="100%"
         maxWidth={900}
         alignItems="stretch"
         overflowX="hidden"
-        padding={isSmallScreen ? "12px 24px" : " 24px 32px"}
+        padding={isSmallScreen ? "12px 24px" : "24px 32px"}
         margin="0 auto"
+        top
       >
         <React.Suspense fallback={<CircularProgress style={{ alignSelf: "center", justifySelf: "center" }} />}>
           {topContent}
@@ -116,7 +119,7 @@ function DialogBody(props: Props) {
           </VerticalLayout>
           {actionsPosition === "bottom" ? actionsContent : null}
         </React.Suspense>
-      </VerticalLayout>
+      </Section>
     </ErrorBoundary>
   )
 }

--- a/src/components/Dialog/DialogBody.tsx
+++ b/src/components/Dialog/DialogBody.tsx
@@ -49,8 +49,8 @@ interface Props {
   actionsPosition?: "after-content" | "bottom"
   brandColored?: boolean
   background?: React.ReactNode
+  backgroundColor?: React.CSSProperties["backgroundColor"]
   children: React.ReactNode
-  inheritBackground?: boolean
   excessWidth?: number
   fitToShrink?: boolean
   preventActionsPlaceholder?: boolean
@@ -93,7 +93,7 @@ function DialogBody(props: Props) {
     <ErrorBoundary>
       <Section
         brandColored={props.brandColored}
-        inheritBackground={props.inheritBackground}
+        backgroundColor={props.backgroundColor}
         width="100%"
         height="100%"
         maxWidth={900}

--- a/src/components/Dialog/DialogBody.tsx
+++ b/src/components/Dialog/DialogBody.tsx
@@ -50,6 +50,7 @@ interface Props {
   brandColored?: boolean
   background?: React.ReactNode
   children: React.ReactNode
+  inheritBackground?: boolean
   excessWidth?: number
   fitToShrink?: boolean
   preventActionsPlaceholder?: boolean
@@ -92,6 +93,7 @@ function DialogBody(props: Props) {
     <ErrorBoundary>
       <Section
         brandColored={props.brandColored}
+        inheritBackground={props.inheritBackground}
         width="100%"
         height="100%"
         maxWidth={900}

--- a/src/components/Dialog/DialogBody.tsx
+++ b/src/components/Dialog/DialogBody.tsx
@@ -92,16 +92,18 @@ function DialogBody(props: Props) {
   return (
     <ErrorBoundary>
       <Section
+        alignItems="stretch"
         brandColored={props.brandColored}
         backgroundColor={props.backgroundColor}
-        width="100%"
+        display="flex"
         height="100%"
+        margin="0 auto"
         maxWidth={900}
-        alignItems="stretch"
         overflowX="hidden"
         padding={isSmallScreen ? "12px 24px" : "24px 32px"}
-        margin="0 auto"
+        style={{ flexDirection: "column" }}
         top
+        width="100%"
       >
         <React.Suspense fallback={<CircularProgress style={{ alignSelf: "center", justifySelf: "center" }} />}>
           {topContent}

--- a/src/components/Form/CreateAccount.tsx
+++ b/src/components/Form/CreateAccount.tsx
@@ -146,7 +146,7 @@ function AccountCreationForm(props: AccountCreationFormProps) {
 
   return (
     <form noValidate onSubmit={props.onSubmit} style={{ display: "block", height: "100vh" }}>
-      <DialogBody top={headerContent} actions={actionsContent}>
+      <DialogBody top={headerContent} backgroundColor="unset" actions={actionsContent}>
         <ToggleSection
           checked={formValues.setPassword}
           onChange={() => setFormValue("setPassword", !formValues.setPassword)}

--- a/src/components/Layout/Box.tsx
+++ b/src/components/Layout/Box.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import createBoxStyle, { BoxStyles } from "./createBoxStyle"
 
-type BoxProps = BoxStyles & {
+export type BoxProps = BoxStyles & {
   children: React.ReactNode
   className?: string
   component?: string

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -41,6 +41,7 @@ function PageInset(props: { children: React.ReactNode }) {
 }
 
 interface SectionProps extends BoxProps {
+  inheritBackground?: boolean
   backgroundColor?: React.CSSProperties["backgroundColor"]
   bottom?: boolean
   brandColored?: boolean
@@ -52,7 +53,11 @@ interface SectionProps extends BoxProps {
 }
 
 const Section = React.memo(function Section(props: SectionProps) {
-  const background = props.brandColored ? primaryBackground : props.backgroundColor || "#fcfcfc"
+  const background = props.brandColored
+    ? primaryBackground
+    : props.inheritBackground
+    ? undefined
+    : props.backgroundColor || "#fcfcfc"
   const isSmallScreen = useIsMobile()
 
   const className = [

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -20,6 +20,9 @@ function TopOfTopSection(props: { background?: React.CSSProperties["background"]
   } else if (platform === "ios") {
     // Add some additional v-space for the iPhone X notch
     return <div className="iphone-notch-top-spacing" />
+  } else if (platform === "android") {
+    // Add some additional v-space for the android full screen
+    return <div className="android-top-spacing" />
   } else {
     return null
   }
@@ -54,7 +57,11 @@ const Section = React.memo(function Section(props: SectionProps) {
   const isSmallScreen = useIsMobile()
 
   const className = [
-    platform === "ios" && props.top ? "iphone-notch-top-spacing" : "",
+    platform === "ios" && props.top
+      ? "iphone-notch-top-spacing"
+      : platform === "android" && props.top
+      ? "android-top-spacing"
+      : "",
     platform === "ios" ? "iphone-notch-left-spacing" : "",
     platform === "ios" ? "iphone-notch-right-spacing" : "",
     platform === "ios" && props.bottom ? "iphone-notch-bottom-spacing" : ""

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box } from "./Box"
+import { Box, BoxProps } from "./Box"
 import { useIsMobile } from "../../hooks/userinterface"
 import { primaryBackground } from "../../theme"
 
@@ -21,7 +21,7 @@ function TopOfTopSection(props: { background?: React.CSSProperties["background"]
     // Add some additional v-space for the iPhone X notch
     return <div className="iphone-notch-top-spacing" />
   } else if (platform === "android") {
-    // Add some additional v-space for the android full screen
+    // Add some additional v-space for android fullscreen view
     return <div className="android-top-spacing" />
   } else {
     return null
@@ -38,18 +38,15 @@ function PageInset(props: { children: React.ReactNode }) {
   )
 }
 
-interface SectionProps {
-  children: React.ReactNode
+interface SectionProps extends BoxProps {
   backgroundColor?: React.CSSProperties["backgroundColor"]
   bottom?: boolean
   brandColored?: boolean
   grow?: number
   minHeight?: React.CSSProperties["minHeight"]
   noPadding?: boolean
-  shrink?: number
   pageInset?: boolean
   top?: boolean
-  style?: React.CSSProperties
 }
 
 const Section = React.memo(function Section(props: SectionProps) {
@@ -57,15 +54,15 @@ const Section = React.memo(function Section(props: SectionProps) {
   const isSmallScreen = useIsMobile()
 
   const className = [
-    platform === "ios" && props.top
-      ? "iphone-notch-top-spacing"
-      : platform === "android" && props.top
-      ? "android-top-spacing"
-      : "",
+    platform === "ios" && props.top ? "iphone-notch-top-spacing" : "",
+    platform === "android" && props.top ? "android-top-spacing" : "",
     platform === "ios" ? "iphone-notch-left-spacing" : "",
     platform === "ios" ? "iphone-notch-right-spacing" : "",
     platform === "ios" && props.bottom ? "iphone-notch-bottom-spacing" : ""
   ].join(" ")
+
+  const padding: React.CSSProperties["padding"] = props.noPadding ? 0 : props.padding !== undefined ? props.padding : 16
+
   const style: React.CSSProperties = {
     background,
     color: props.brandColored ? "white" : undefined,
@@ -77,16 +74,16 @@ const Section = React.memo(function Section(props: SectionProps) {
     zIndex: props.top ? undefined : 1,
     ...props.style
   }
+
   const MaybeInset = props.pageInset ? PageInset : React.Fragment
+
   return (
-    <>
-      <Box className={className} component="section" padding={props.noPadding ? 0 : 16} style={style}>
-        {props.top ? <TopOfTopSection background={background} /> : null}
-        {/* Add a little padding to the top if window is frameless */}
-        {props.top && !isSmallScreen ? <div style={{ width: "100%", padding: "4px 0 0", margin: 0 }} /> : null}
-        <MaybeInset>{props.children}</MaybeInset>
-      </Box>
-    </>
+    <Box {...props} className={className} component="section" padding={padding} style={style}>
+      {props.top ? <TopOfTopSection background={background} /> : null}
+      {/* Add a little padding to the top if window is frameless */}
+      {props.top && !isSmallScreen ? <div style={{ width: "100%", padding: "4px 0 0", margin: 0 }} /> : null}
+      <MaybeInset>{props.children}</MaybeInset>
+    </Box>
   )
 })
 

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -9,6 +9,8 @@ const platform = process.env.PLATFORM || require("os").platform()
 const isFramelessWindow = platform === "darwin"
 
 function TopOfTopSection(props: { background?: React.CSSProperties["background"] }) {
+  const isSmallScreen = useIsMobile()
+
   if (isFramelessWindow) {
     // Add invisible window-drag area and a bit of additional v-space on top
     // Need to define a static CSS class for it, since `-webkit-app-region` in CSS-in-JS might lead to trouble
@@ -19,10 +21,10 @@ function TopOfTopSection(props: { background?: React.CSSProperties["background"]
     )
   } else if (platform === "ios") {
     // Add some additional v-space for the iPhone X notch
-    return <div className="iphone-notch-top-spacing" />
+    return isSmallScreen ? <div className="iphone-notch-top-spacing" /> : <></>
   } else if (platform === "android") {
     // Add some additional v-space for android fullscreen view
-    return <div className="android-top-spacing" />
+    return isSmallScreen ? <div className="android-top-spacing" /> : <></>
   } else {
     return null
   }

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -60,14 +60,6 @@ const Section = React.memo(function Section(props: SectionProps) {
     : props.backgroundColor || "#fcfcfc"
   const isSmallScreen = useIsMobile()
 
-  const className = [
-    platform === "ios" && props.top ? "iphone-notch-top-spacing" : "",
-    platform === "android" && props.top ? "android-top-spacing" : "",
-    platform === "ios" ? "iphone-notch-left-spacing" : "",
-    platform === "ios" ? "iphone-notch-right-spacing" : "",
-    platform === "ios" && props.bottom ? "iphone-notch-bottom-spacing" : ""
-  ].join(" ")
-
   const padding: React.CSSProperties["padding"] = props.noPadding ? 0 : props.padding !== undefined ? props.padding : 16
 
   const style: React.CSSProperties = {
@@ -85,7 +77,7 @@ const Section = React.memo(function Section(props: SectionProps) {
   const MaybeInset = props.pageInset ? PageInset : React.Fragment
 
   return (
-    <Box {...props} className={className} component="section" padding={padding} style={style}>
+    <Box {...props} component="section" padding={padding} style={style}>
       {props.top ? <TopOfTopSection background={background} /> : null}
       {/* Add a little padding to the top if window is frameless */}
       {props.top && !isSmallScreen ? <div style={{ width: "100%", padding: "4px 0 0", margin: 0 }} /> : null}

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -41,7 +41,6 @@ function PageInset(props: { children: React.ReactNode }) {
 }
 
 interface SectionProps extends BoxProps {
-  inheritBackground?: boolean
   backgroundColor?: React.CSSProperties["backgroundColor"]
   bottom?: boolean
   brandColored?: boolean
@@ -53,11 +52,7 @@ interface SectionProps extends BoxProps {
 }
 
 const Section = React.memo(function Section(props: SectionProps) {
-  const background = props.brandColored
-    ? primaryBackground
-    : props.inheritBackground
-    ? undefined
-    : props.backgroundColor || "#fcfcfc"
+  const background = props.brandColored ? primaryBackground : props.backgroundColor || "#fcfcfc"
   const isSmallScreen = useIsMobile()
 
   const padding: React.CSSProperties["padding"] = props.noPadding ? 0 : props.padding !== undefined ? props.padding : 16

--- a/src/components/Payment/ReceivePaymentDialog.tsx
+++ b/src/components/Payment/ReceivePaymentDialog.tsx
@@ -1,9 +1,9 @@
 import React from "react"
 import { Account } from "../../context/accounts"
-import { useIsMobile } from "../../hooks/userinterface"
 import { Box } from "../Layout/Box"
-import MainTitle from "../MainTitle"
+import DialogBody from "../Dialog/DialogBody"
 import KeyExportBox from "../Account/KeyExportBox"
+import MainTitle from "../MainTitle"
 
 interface Props {
   account: Account
@@ -11,15 +11,12 @@ interface Props {
 }
 
 function ReceivePaymentDialog(props: Props) {
-  const isSmallScreen = useIsMobile()
-
   return (
-    <>
-      <Box width="100%" maxWidth={900} padding={isSmallScreen ? "24px" : " 24px 32px"} margin="0 auto 32px">
-        <MainTitle onBack={props.onClose} title="Receive Funds" />
+    <DialogBody top={<MainTitle onBack={props.onClose} title="Receive Funds" />}>
+      <Box width="100%" margin="32px auto">
+        <KeyExportBox export={props.account.publicKey} />
       </Box>
-      <KeyExportBox export={props.account.publicKey} />
-    </>
+    </DialogBody>
   )
 }
 

--- a/src/pages/all-accounts.tsx
+++ b/src/pages/all-accounts.tsx
@@ -118,7 +118,7 @@ function AllAccountsPage() {
 
   return (
     <Section top bottom brandColored noPadding style={{ height: "100vh" }}>
-      <DialogBody top={headerContent}>
+      <DialogBody brandColored top={headerContent}>
         <VerticalLayout justifyContent="space-between" grow margin="16px 0 0">
           <AccountList
             accounts={accounts}

--- a/src/pages/all-accounts.tsx
+++ b/src/pages/all-accounts.tsx
@@ -118,7 +118,7 @@ function AllAccountsPage() {
 
   return (
     <Section top bottom brandColored noPadding style={{ height: "100vh" }}>
-      <DialogBody inheritBackground top={headerContent}>
+      <DialogBody backgroundColor="unset" top={headerContent}>
         <VerticalLayout justifyContent="space-between" grow margin="16px 0 0">
           <AccountList
             accounts={accounts}

--- a/src/pages/all-accounts.tsx
+++ b/src/pages/all-accounts.tsx
@@ -117,7 +117,7 @@ function AllAccountsPage() {
   )
 
   return (
-    <Section top bottom brandColored noPadding style={{ height: "100vh" }}>
+    <Section bottom brandColored noPadding style={{ height: "100vh" }}>
       <DialogBody backgroundColor="unset" top={headerContent}>
         <VerticalLayout justifyContent="space-between" grow margin="16px 0 0">
           <AccountList

--- a/src/pages/all-accounts.tsx
+++ b/src/pages/all-accounts.tsx
@@ -118,7 +118,7 @@ function AllAccountsPage() {
 
   return (
     <Section top bottom brandColored noPadding style={{ height: "100vh" }}>
-      <DialogBody brandColored top={headerContent}>
+      <DialogBody inheritBackground top={headerContent}>
         <VerticalLayout justifyContent="space-between" grow margin="16px 0 0">
           <AccountList
             accounts={accounts}

--- a/src/pages/create-account.tsx
+++ b/src/pages/create-account.tsx
@@ -3,7 +3,6 @@ import { Keypair } from "stellar-sdk"
 import Dialog from "@material-ui/core/Dialog"
 import ExportKeyDialog from "../components/AccountSettings/ExportKeyDialog"
 import AccountCreationForm, { AccountCreationValues } from "../components/Form/CreateAccount"
-import { Section } from "../components/Layout/Page"
 import { AccountsContext, Account } from "../context/accounts"
 import { trackError } from "../context/notifications"
 import { useRouter } from "../hooks/userinterface"
@@ -43,7 +42,7 @@ function CreateAccountPage(props: { testnet: boolean }) {
   const onClose = () => router.history.push(routes.allAccounts())
 
   return (
-    <Section top bottom noPadding>
+    <>
       <AccountCreationForm accounts={accounts} onCancel={onClose} onSubmit={onCreateAccount} testnet={props.testnet} />
       <Dialog
         fullScreen
@@ -53,7 +52,7 @@ function CreateAccountPage(props: { testnet: boolean }) {
       >
         <ExportKeyDialog account={createdAccount!} onConfirm={closeBackupDialog} variant="initial-backup" />
       </Dialog>
-    </Section>
+    </>
   )
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -119,16 +119,7 @@ const theme = createMuiTheme({
       },
       paperFullScreen: {
         backgroundColor: "#fcfcfc",
-        boxSizing: "border-box",
-
-        "&": {
-          // iOS 11
-          paddingTop: "constant(safe-area-inset-top)",
-          paddingBottom: "constant(safe-area-inset-bottom)"
-        },
-        // iOS 12
-        paddingTop: "env(safe-area-inset-top)",
-        paddingBottom: "env(safe-area-inset-bottom)"
+        boxSizing: "border-box"
       }
     },
     MuiFormLabel: {


### PR DESCRIPTION
This PR introduces changes that will make the android status bar appear transparent. To be more precise, some flags are set so that the activity is shown in full screen mode while still showing system info in the status bar. The full screen mode requires the application to set additional padding on top so that the content does not overlap the info of the status bar. 

In addition to this, some layout changes to `<ReceivePaymentDialog>` and `<SettingsPage>` were made so that their styles align with those of the other components.
The upper-area of the settings-page was adjusted to match the styling of the header of the account-page.
