### PR TITLE
Show numeric keyboard when entering an amount

### DIFF
--- a/src/components/AccountAssets/CustomTrustline.tsx
+++ b/src/components/AccountAssets/CustomTrustline.tsx
@@ -51,6 +51,10 @@ function CustomTrustlineDialog(props: Props) {
           onChange={event => setIssuerPublicKey(event.target.value)}
         />
         <TextField
+          inputProps={{
+            pattern: "[0-9]*",
+            inputMode: "decimal"
+          }}
           fullWidth
           label="Limit (optional)"
           placeholder="Limit trust in this asset / maximum balance to hold"

--- a/src/components/Form/FormFields.tsx
+++ b/src/components/Form/FormFields.tsx
@@ -52,6 +52,10 @@ export const PriceInput = React.memo(function PriceInput(props: PriceInputProps)
   return (
     <TextField
       {...textfieldProps}
+      inputProps={{
+        pattern: "[0-9]*",
+        inputMode: "decimal"
+      }}
       InputProps={{
         endAdornment: (
           <InputAdornment

--- a/src/components/ManageSigners/ManageSignersDialogContent.tsx
+++ b/src/components/ManageSigners/ManageSignersDialogContent.tsx
@@ -160,6 +160,10 @@ function ManageSignersDialogContent(props: Props) {
     <HorizontalLayout justifyContent="space-between" alignItems="center" margin="48px 0 0" wrap="wrap">
       <TextField
         error={!!weightThresholdError}
+        inputProps={{
+          pattern: "[0-9]*",
+          inputMode: "decimal"
+        }}
         label={weightThresholdError ? renderFormFieldError(weightThresholdError) : weightThresholdLabel}
         onChange={event => setWeightThreshold(event.target.value)}
         type="number"

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -206,6 +206,8 @@ function TradingForm(props: Props) {
               (props.primaryAction === "buy" && secondaryBalance && secondaryAmount.gt(secondaryBalance.balance))
             }
             inputProps={{
+              pattern: "[0-9]*",
+              inputMode: "decimal",
               min: "0.0000001",
               max: maxPrimaryAmount.toFixed(7),
               style: { height: 27 }
@@ -267,6 +269,7 @@ function TradingForm(props: Props) {
             label={props.primaryAction === "buy" ? "Estimated costs" : "Estimated return"}
             placeholder={`Max. ${secondaryBalance ? secondaryBalance.balance : "0"}`}
             style={{ flexGrow: 1, flexShrink: 1, width: "55%" }}
+            inputMode="decimal"
             type="number"
             value={
               // Format amount without thousands grouping, since it may lead to illegal number input values (#831)

--- a/src/components/Trading/TradingPrice.tsx
+++ b/src/components/Trading/TradingPrice.tsx
@@ -44,6 +44,8 @@ function TradingPrice(props: TradingPriceProps) {
   return (
     <TextField
       inputProps={{
+        pattern: "[0-9]*",
+        inputMode: "decimal",
         min: "0.0000001"
       }}
       InputProps={{ endAdornment }}


### PR DESCRIPTION
Add `pattern: "[0-9]*"` and `inputMode: "decimal"` to `inputProps` of TextFields that are supposed to handle numeric input.
This will cause the onscreen keyboards on Android and iOS to show numeric input keys.

Closes #826.