### PR TITLE
Don't show scrollbar on submission progress

### DIFF
--- a/src/components/Layout/Box.tsx
+++ b/src/components/Layout/Box.tsx
@@ -9,7 +9,6 @@ type BoxProps = BoxStyles & {
   style?: React.CSSProperties
 }
 
-// tslint:disable-next-line no-shadowed-variable
 const Box = React.forwardRef(function Box(props: BoxProps, ref: React.Ref<unknown>) {
   const { children, className, component, onClick, style, ...styleProps } = props
   const inlineStyle = { ...createBoxStyle(styleProps), ...style }
@@ -62,40 +61,6 @@ const VerticalLayout = React.forwardRef(function VerticalLayout(props: BoxLayout
   )
 })
 
-function AspectRatioBox({ children, ratio, ...styleProps }: BoxStyles & { children: React.ReactNode; ratio: string }) {
-  let heightOfWidthPercentage = 100
-
-  try {
-    const [hratio, vratio] = ratio.split(":")
-    heightOfWidthPercentage = (parseFloat(vratio) / parseFloat(hratio)) * 100
-
-    if (heightOfWidthPercentage <= 0 || isNaN(heightOfWidthPercentage)) {
-      throw new Error(`Invalid ratio numbers.`)
-    }
-  } catch (error) {
-    throw new Error(`AspectRatioBox: Bad ratio given: "${ratio}". Expected something like "1:2".`)
-  }
-
-  const outerStyle: React.CSSProperties = {
-    position: "relative",
-    width: "100%",
-    ...createBoxStyle(styleProps),
-    paddingTop: `${heightOfWidthPercentage}%`
-  }
-  const fillCompleteContainerStyle: React.CSSProperties = {
-    position: "absolute",
-    width: "100%",
-    height: "100%",
-    top: 0,
-    left: 0
-  }
-  return (
-    <div style={outerStyle}>
-      <div style={fillCompleteContainerStyle}>{children}</div>
-    </div>
-  )
-}
-
 function FloatingBox({ children, ...styleProps }: BoxStyles & { children: React.ReactNode }) {
   const style: React.CSSProperties = {
     position: "absolute",
@@ -109,4 +74,4 @@ function FloatingBox({ children, ...styleProps }: BoxStyles & { children: React.
 }
 
 // To circumvent TypeScript name inference bug: <https://github.com/Microsoft/TypeScript/issues/14127>
-export { AspectRatioBox, Box, FloatingBox, HorizontalLayout, VerticalLayout }
+export { Box, FloatingBox, HorizontalLayout, VerticalLayout }

--- a/src/components/SubmissionProgress.tsx
+++ b/src/components/SubmissionProgress.tsx
@@ -5,16 +5,16 @@ import Typography from "@material-ui/core/Typography"
 import { CloseButton, DialogActionsBox } from "./Dialog/Generic"
 import ErrorIcon from "./Icon/Error"
 import SuccessIcon from "./Icon/Success"
-import { AspectRatioBox, VerticalLayout } from "./Layout/Box"
+import { Box, VerticalLayout } from "./Layout/Box"
 import { explainSubmissionError } from "../lib/horizonErrors"
 
 function Container(props: { children: React.ReactNode }) {
   return (
-    <AspectRatioBox width="250px" maxWidth="40vw" ratio="3:2">
+    <Box width="250px" maxWidth="40vw" height="100%">
       <VerticalLayout padding={10} height="100%" alignItems="center" justifyContent="center">
         {props.children}
       </VerticalLayout>
-    </AspectRatioBox>
+    </Box>
   )
 }
 
@@ -50,7 +50,7 @@ function SubmissionProgress(props: SubmissionProgressProps) {
       promise={props.promise}
       pending={
         <Container>
-          <CircularProgress size={70} style={{ marginTop: 10, marginBottom: 20 }} />
+          <CircularProgress size={70} />
           <Heading>Submitting to network...</Heading>
         </Container>
       }

--- a/src/components/TransactionSender.tsx
+++ b/src/components/TransactionSender.tsx
@@ -4,6 +4,7 @@ import Zoom from "@material-ui/core/Zoom"
 import { Account } from "../context/accounts"
 import { SettingsContext, SettingsContextType } from "../context/settings"
 import { useHorizon } from "../hooks/stellar"
+import { useIsMobile } from "../hooks/userinterface"
 import { isWrongPasswordError } from "../lib/errors"
 import { explainSubmissionError } from "../lib/horizonErrors"
 import {
@@ -28,6 +29,8 @@ function ConditionalSubmissionProgress(props: {
   promise: Promise<any> | null
   type: SubmissionType
 }) {
+  const isSmallScreen = useIsMobile()
+
   const outerStyle: React.CSSProperties = {
     position: "absolute",
     display: props.promise ? "flex" : "none",
@@ -37,7 +40,7 @@ function ConditionalSubmissionProgress(props: {
     height: "100%",
     alignItems: "center",
     justifyContent: "center",
-    background: "#fcfcfc"
+    background: isSmallScreen ? "#fcfcfc" : "white"
   }
   const innerStyle: React.CSSProperties = {
     display: "flex",


### PR DESCRIPTION
- [x] Replace the `<AspectRatioBox>` with a `<Box>` and set the `height` to "100%".
- [x] Remove the margin from the `<CircularProgress>` as this would otherwise still cause a scrollbar to appear.
- [x] Change background color of the `<ConditionalSubmissionProgress>` according to screen size

Closes #840.