### PR TITLE
No unnecessary rendering of T&Cs

### DIFF
--- a/src/components/TermsAndConditionsDialog.tsx
+++ b/src/components/TermsAndConditionsDialog.tsx
@@ -10,10 +10,11 @@ import Typography from "@material-ui/core/Typography"
 import { VerticalLayout } from "./Layout/Box"
 import { Section } from "./Layout/Page"
 
-const CheckboxLabel = (props: { children: React.ReactNode }) => (
-  <span style={{ color: "white", fontSize: "120%" }}>{props.children}</span>
-)
 const Transition = React.forwardRef((props: TransitionProps, ref) => <Fade ref={ref} {...props} appear={false} />)
+
+function CheckboxLabel(props: { children: React.ReactNode }) {
+  return <span style={{ color: "white", fontSize: "120%" }}>{props.children}</span>
+}
 
 function ExternalLink(props: { children: React.ReactNode; href: string }) {
   return (
@@ -38,6 +39,63 @@ function TermsAndConditions(props: Props) {
     setCheckedNotes(updatedNoteChecks)
   }
 
+  return (
+    <Section brandColored top bottom style={{ display: "flex", flexDirection: "column" }}>
+      <VerticalLayout grow={1} justifyContent="center" margin="0 auto" padding="3vh 4vw" maxWidth={800}>
+        <Typography color="inherit" variant="h4">
+          Welcome to Solar
+        </Typography>
+        <FormGroup style={{ margin: "3em 0" }}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={checkedNotes[0]}
+                onChange={() => toggleNoteChecked(0)}
+                style={{ alignSelf: "flex-start", color: "inherit", marginTop: -7 }}
+              />
+            }
+            label={
+              <CheckboxLabel>
+                I understand that I am responsible for the safety of my funds and that Solar is not able to recover my
+                funds in case of data loss or if I lose my credentials.
+              </CheckboxLabel>
+            }
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={checkedNotes[1]}
+                onChange={() => toggleNoteChecked(1)}
+                style={{ alignSelf: "flex-start", color: "inherit", marginTop: -7 }}
+              />
+            }
+            label={
+              <CheckboxLabel>
+                I have read, understood and agree to the{" "}
+                <ExternalLink href="https://solarwallet.io/terms.html">Terms and Conditions</ExternalLink> &amp;{" "}
+                <ExternalLink href="https://solarwallet.io/privacy.html">Privacy policy</ExternalLink> of Solar.
+              </CheckboxLabel>
+            }
+            style={{
+              marginTop: 16
+            }}
+          />
+        </FormGroup>
+        <Button
+          disabled={!allConfirmed}
+          onClick={props.onConfirm}
+          size="large"
+          style={{ alignSelf: "center" }}
+          variant="contained"
+        >
+          Confirm
+        </Button>
+      </VerticalLayout>
+    </Section>
+  )
+}
+
+function TermsAndConditionsDialog(props: Props) {
   // Super important to make sure that the Dialog unmounts on exit, so it won't act as an invisible click blocker!
   return (
     <Dialog
@@ -50,60 +108,9 @@ function TermsAndConditions(props: Props) {
       TransitionComponent={Transition}
       TransitionProps={{ unmountOnExit: true }}
     >
-      <Section brandColored top bottom style={{ display: "flex", flexDirection: "column" }}>
-        <VerticalLayout grow={1} justifyContent="center" margin="0 auto" padding="3vh 4vw" maxWidth={800}>
-          <Typography color="inherit" variant="h4">
-            Welcome to Solar
-          </Typography>
-          <FormGroup style={{ margin: "3em 0" }}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={checkedNotes[0]}
-                  onChange={() => toggleNoteChecked(0)}
-                  style={{ alignSelf: "flex-start", color: "inherit", marginTop: -7 }}
-                />
-              }
-              label={
-                <CheckboxLabel>
-                  I understand that I am responsible for the safety of my funds and that Solar is not able to recover my
-                  funds in case of data loss or if I lose my credentials.
-                </CheckboxLabel>
-              }
-            />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={checkedNotes[1]}
-                  onChange={() => toggleNoteChecked(1)}
-                  style={{ alignSelf: "flex-start", color: "inherit", marginTop: -7 }}
-                />
-              }
-              label={
-                <CheckboxLabel>
-                  I have read, understood and agree to the{" "}
-                  <ExternalLink href="https://solarwallet.io/terms.html">Terms and Conditions</ExternalLink> &amp;{" "}
-                  <ExternalLink href="https://solarwallet.io/privacy.html">Privacy policy</ExternalLink> of Solar.
-                </CheckboxLabel>
-              }
-              style={{
-                marginTop: 16
-              }}
-            />
-          </FormGroup>
-          <Button
-            disabled={!allConfirmed}
-            onClick={props.onConfirm}
-            size="large"
-            style={{ alignSelf: "center" }}
-            variant="contained"
-          >
-            Confirm
-          </Button>
-        </VerticalLayout>
-      </Section>
+      <TermsAndConditions {...props} />
     </Dialog>
   )
 }
 
-export default React.memo(TermsAndConditions)
+export default React.memo(TermsAndConditionsDialog)

--- a/src/context/settings.tsx
+++ b/src/context/settings.tsx
@@ -20,6 +20,7 @@ interface ContextType {
   confirmToC: () => void
   ignoreSignatureRequest: (signatureRequestHash: string) => void
   ignoredSignatureRequests: string[]
+  initialized: boolean
   multiSignature: boolean
   multiSignatureServiceURL: string
   showTestnet: boolean
@@ -30,9 +31,14 @@ interface ContextType {
   toggleHideMemos: () => void
 }
 
-const initialSettings: SettingsData = {
+interface SettingsState extends SettingsData {
+  initialized: boolean
+}
+
+const initialSettings: SettingsState = {
   agreedToTermsAt: undefined,
   biometricLock: false,
+  initialized: false,
   multisignature: false,
   testnet: false,
   hideMemos: false
@@ -49,6 +55,7 @@ const SettingsContext = React.createContext<ContextType>({
   confirmToC: () => undefined,
   ignoreSignatureRequest: () => undefined,
   ignoredSignatureRequests: initialIgnoredSignatureRequests,
+  initialized: false,
   multiSignature: initialSettings.multisignature,
   multiSignatureServiceURL,
   showTestnet: initialSettings.testnet,
@@ -61,14 +68,14 @@ const SettingsContext = React.createContext<ContextType>({
 
 export function SettingsProvider(props: Props) {
   const [ignoredSignatureRequests, setIgnoredSignatureRequests] = React.useState(initialIgnoredSignatureRequests)
-  const [settings, setSettings] = React.useState(initialSettings)
+  const [settings, setSettings] = React.useState<SettingsState>(initialSettings)
   const [biometricLockUsable, setBiometricLockUsable] = React.useState(false)
 
   React.useEffect(() => {
     Promise.all([loadIgnoredSignatureRequestHashes(), loadSettings()])
       .then(([loadedSignatureReqHashes, loadedSettings]) => {
         setIgnoredSignatureRequests(loadedSignatureReqHashes)
-        setSettings({ ...settings, ...loadedSettings })
+        setSettings({ ...settings, ...loadedSettings, initialized: true })
       })
       .catch(trackError)
 
@@ -124,6 +131,7 @@ export function SettingsProvider(props: Props) {
     confirmToC,
     ignoreSignatureRequest,
     ignoredSignatureRequests,
+    initialized: settings.initialized,
     multiSignature: settings.multisignature,
     multiSignatureServiceURL,
     showTestnet: settings.testnet,

--- a/src/pages/all-accounts.tsx
+++ b/src/pages/all-accounts.tsx
@@ -127,7 +127,11 @@ function AllAccountsPage() {
           />
         </Box>
       </DialogBody>
-      <TermsAndConditions open={!settings.agreedToTermsAt} onConfirm={settings.confirmToC} />
+      <TermsAndConditions
+        // Do not render T&Cs while loading settings; 99.9% chance we will unmount it immediately
+        open={settings.initialized && !settings.agreedToTermsAt}
+        onConfirm={settings.confirmToC}
+      />
     </Section>
   )
 }


### PR DESCRIPTION
Decrease the amount of wasted work to improve performance. It was subtle, but we used to run all the T&Cs dialog's code at least once without ever actually mounting it.