### PR TITLE
Display menus full-width on bottom (on mobile)

### DIFF
--- a/src/components/Account/AccountContextMenu.tsx
+++ b/src/components/Account/AccountContextMenu.tsx
@@ -68,11 +68,17 @@ interface MenuProps {
 
 function AccountContextMenu(props: MenuProps) {
   const isSmallScreen = useIsMobile()
+
   return (
     <ContextMenu
       anchor={props.children}
       menu={({ anchorEl, open, onClose, closeAndCall }) => (
-        <Menu anchorEl={anchorEl || undefined} disableAutoFocusItem={isSmallScreen} open={open} onClose={onClose}>
+        <Menu
+          anchorEl={isSmallScreen ? document.body : anchorEl || undefined}
+          disableAutoFocusItem={isSmallScreen}
+          onClose={onClose}
+          open={open}
+        >
           <AccountContextMenuItem
             disabled={!props.activated}
             icon={<SwapHorizIcon style={{ transform: "scale(1.2)" }} />}

--- a/src/components/Withdrawal/Offramp.tsx
+++ b/src/components/Withdrawal/Offramp.tsx
@@ -62,7 +62,7 @@ function sendWithdrawalRequest(request: WithdrawalRequestData, authToken?: strin
     account,
     wallet_name: "Solar wallet",
     ...withdrawalFormValues
-  } // previously `as any`, but shouldn't be necessary anymore with latest changes
+  } as any // FIXME
   return transferServer.withdraw(method, asset.getCode(), authToken, options)
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,5 +1,6 @@
 import { createMuiTheme } from "@material-ui/core/styles"
 import createBreakpoints from "@material-ui/core/styles/createBreakpoints"
+import Fade from "@material-ui/core/Fade"
 import ArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
 import amber from "@material-ui/core/colors/amber"
 import lightBlue from "@material-ui/core/colors/lightBlue"
@@ -31,6 +32,21 @@ const theme = createMuiTheme({
     MuiInputLabel: {
       required: false,
       shrink: true
+    },
+    MuiMenu: {
+      anchorOrigin: {
+        horizontal: "center",
+        vertical: "center"
+      },
+      BackdropProps: {
+        open: true
+      },
+      TransitionComponent: Fade,
+      transitionDuration: 300,
+      transformOrigin: {
+        horizontal: "center",
+        vertical: "center"
+      }
     },
     MuiSelect: {
       IconComponent: ArrowDownIcon
@@ -232,13 +248,31 @@ const theme = createMuiTheme({
       }
     },
     MuiMenu: {
+      paper: {
+        [breakpoints.down(600)]: {
+          // hide a small div that is shown above the anchor component
+          visibility: "hidden"
+        }
+      },
       list: {
-        padding: 0
+        padding: 0,
+        [breakpoints.down(600)]: {
+          backgroundColor: "white",
+          bottom: 0,
+          left: 0,
+          position: "fixed",
+          transitionDuration: 0,
+          // explicitly set to visible because it would be hidden by the visibility change in MuiMenu-paper
+          visibility: "visible"
+        }
       }
     } as any,
     MuiMenuItem: {
       root: {
-        borderBottom: "none"
+        borderBottom: "none",
+        [breakpoints.down(600)]: {
+          fontSize: 20
+        }
       }
     },
     MuiPaper: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -35,9 +35,6 @@ const theme = createMuiTheme({
       required: false,
       shrink: true
     },
-    MuiList: {
-      className: "iphone-notch-bottom-spacing"
-    },
     MuiMenu: isSmallScreen
       ? {
           BackdropProps: {
@@ -261,7 +258,15 @@ const theme = createMuiTheme({
           right: "0 !important",
           top: "initial !important",
           maxWidth: "100vw",
-          position: "fixed"
+          position: "fixed",
+
+          // declaring these here because passing a className into MuiMenu-props does not work as the styles of that class are overridden several times
+          "&": {
+            // iOS 11
+            paddingBottom: "constant(safe-area-inset-bottom)"
+          },
+          // iOS 12
+          paddingBottom: "env(safe-area-inset-bottom)"
         }
       },
       list: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,7 +2,6 @@ import { createMuiTheme } from "@material-ui/core/styles"
 import createBreakpoints from "@material-ui/core/styles/createBreakpoints"
 import Fade from "@material-ui/core/Fade"
 import ArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
-import { MenuProps } from "@material-ui/core/Menu"
 import amber from "@material-ui/core/colors/amber"
 import lightBlue from "@material-ui/core/colors/lightBlue"
 import { SlideLeftTransition, SlideUpTransition } from "./components/Dialog/Transitions"
@@ -27,20 +26,6 @@ export const CompactDialogTransition = SlideUpTransition
 
 const isSmallScreen = window.innerWidth <= 600
 
-const MuiMenuProps: Partial<MenuProps> | undefined = isSmallScreen
-  ? {
-      BackdropProps: {
-        open: true
-      },
-      TransitionComponent: Fade,
-      transitionDuration: 300,
-      transformOrigin: {
-        horizontal: "center",
-        vertical: "center"
-      }
-    }
-  : undefined
-
 const theme = createMuiTheme({
   props: {
     MuiDialogActions: {
@@ -50,7 +35,22 @@ const theme = createMuiTheme({
       required: false,
       shrink: true
     },
-    MuiMenu: MuiMenuProps,
+    MuiList: {
+      className: "iphone-notch-bottom-spacing"
+    },
+    MuiMenu: isSmallScreen
+      ? {
+          BackdropProps: {
+            open: true
+          },
+          TransitionComponent: Fade,
+          transitionDuration: 300,
+          transformOrigin: {
+            horizontal: "center",
+            vertical: "center"
+          }
+        }
+      : undefined,
     MuiSelect: {
       IconComponent: ArrowDownIcon
     }
@@ -253,28 +253,27 @@ const theme = createMuiTheme({
     MuiMenu: {
       paper: {
         [breakpoints.down(600)]: {
-          // hide a small div that is shown above the anchor component
-          visibility: "hidden"
+          backgroundColor: "white",
+          borderBottomLeftRadius: 0,
+          borderBottomRightRadius: 0,
+          bottom: "0 !important",
+          left: "0 !important",
+          right: "0 !important",
+          top: "initial !important",
+          maxWidth: "100vw",
+          position: "fixed"
         }
       },
       list: {
-        padding: 0,
-        [breakpoints.down(600)]: {
-          backgroundColor: "white",
-          bottom: 0,
-          left: 0,
-          position: "fixed",
-          transitionDuration: 0,
-          // explicitly set to visible because it would be hidden by the visibility change in MuiMenu-paper
-          visibility: "visible"
-        }
+        padding: 0
       }
     } as any,
     MuiMenuItem: {
       root: {
         borderBottom: "none",
         [breakpoints.down(600)]: {
-          fontSize: 20
+          fontSize: 20,
+          padding: 16
         }
       }
     },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,6 +2,7 @@ import { createMuiTheme } from "@material-ui/core/styles"
 import createBreakpoints from "@material-ui/core/styles/createBreakpoints"
 import Fade from "@material-ui/core/Fade"
 import ArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
+import { MenuProps } from "@material-ui/core/Menu"
 import amber from "@material-ui/core/colors/amber"
 import lightBlue from "@material-ui/core/colors/lightBlue"
 import { SlideLeftTransition, SlideUpTransition } from "./components/Dialog/Transitions"
@@ -24,20 +25,10 @@ export const breakpoints = createBreakpoints({})
 export const FullscreenDialogTransition = SlideLeftTransition
 export const CompactDialogTransition = SlideUpTransition
 
-const theme = createMuiTheme({
-  props: {
-    MuiDialogActions: {
-      // disableSpacing: true
-    },
-    MuiInputLabel: {
-      required: false,
-      shrink: true
-    },
-    MuiMenu: {
-      anchorOrigin: {
-        horizontal: "center",
-        vertical: "center"
-      },
+const isSmallScreen = window.innerWidth <= 600
+
+const MuiMenuProps: Partial<MenuProps> | undefined = isSmallScreen
+  ? {
       BackdropProps: {
         open: true
       },
@@ -47,7 +38,19 @@ const theme = createMuiTheme({
         horizontal: "center",
         vertical: "center"
       }
+    }
+  : undefined
+
+const theme = createMuiTheme({
+  props: {
+    MuiDialogActions: {
+      // disableSpacing: true
     },
+    MuiInputLabel: {
+      required: false,
+      shrink: true
+    },
+    MuiMenu: MuiMenuProps,
     MuiSelect: {
       IconComponent: ArrowDownIcon
     }


### PR DESCRIPTION
Change the styles in `theme.ts` so that menus like the `<AccountContextMenu>` and selectors in the trade and withdraw views are shown full-width at the bottom of the screen on mobile devices.

Closes #842. 