### PR TITLE
Add spinner to TX review confirm button

### DIFF
--- a/src/components/TransactionReview/ReviewForm.tsx
+++ b/src/components/TransactionReview/ReviewForm.tsx
@@ -44,6 +44,7 @@ function TxConfirmationForm(props: Props) {
   const [dismissalConfirmationPending, setDismissalConfirmationPending] = React.useState(false)
   const [errors, setErrors] = React.useState<Partial<FormErrors>>({})
   const [formValues, setFormValues] = React.useState<FormValues>({ password: null })
+  const [loading, setLoading] = React.useState<boolean>(false)
 
   const passwordError = props.passwordError || errors.password
 
@@ -131,7 +132,13 @@ function TxConfirmationForm(props: Props) {
             </ActionButton>
           ) : null}
           {props.disabled ? null : (
-            <ActionButton icon={<CheckIcon />} form={formID} onClick={() => undefined} type="submit">
+            <ActionButton
+              icon={<CheckIcon />}
+              form={formID}
+              loading={loading}
+              onClick={() => setLoading(true)}
+              type="submit"
+            >
               Confirm
             </ActionButton>
           )}


### PR DESCRIPTION
I used this small and simple fix which does not rely on a `txCreationPending` prop from the parent because the only time this will cause bad UX is when we go offline while in this view (as we cannot reach it if we were offline beforehand already). 

Closes #863.