### PR TITLE
Update stellar-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5478,9 +5478,9 @@
       }
     },
     "@types/urijs": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.3.tgz",
-      "integrity": "sha512-L5tP2dEIV+OMVEVRhf8PCFMNMyO5ZBodrXpEqnGczky60lcv8l5Kl9Yi4J1yxhSVfHUe+Pr2nXJfDM+rUYNs3w=="
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.4.tgz",
+      "integrity": "sha512-uHUvuLfy4YkRHL4UH8J8oRsINhdEHd9ymag7KJZVT94CjAmY1njoUzhazJsZjwfy+IpWKQKGVyXCwzhZvg73Fg=="
     },
     "@types/webpack-env": {
       "version": "1.14.0",
@@ -16287,9 +16287,9 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
-      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.0.tgz",
+      "integrity": "sha512-4oiumOLhCDU9Rronz8PZ5S4IvT39H5+JEv/hps9V8s7RSLhsac0TCP78ulnHXOo8X1wdpPiTayGlM1jr4IbnaQ==",
       "optional": true
     },
     "node-libs-browser": {
@@ -21233,9 +21233,9 @@
       "dev": true
     },
     "stellar-base": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-1.1.2.tgz",
-      "integrity": "sha512-dBifZ2NPeOVtHl7pCaSCfvOedUGhKs3qIfqc/ajk9vsOFnHma0sBxb268kQhGWEAUS5tUKYei2ur4dQtB3rDSA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-2.1.2.tgz",
+      "integrity": "sha512-/U0QFfMwCAa9I0TukfLzUhHvbEXSH2gGSB5ZbabeisnVf1FFFQBjazsNBfbKADrExWE+H3833DpckE6jynlIqg==",
       "requires": {
         "base32.js": "^0.1.0",
         "bignumber.js": "^4.0.0",
@@ -21248,9 +21248,9 @@
       }
     },
     "stellar-sdk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-2.3.0.tgz",
-      "integrity": "sha512-iaeV8K98kuqgm1KH8dDitTp6qfpBb0XDZDnAVxCBCW9vs7AOnKadJbIKBtvVhuFXob4uRLvA3hfLJAAEjEzDcw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-3.3.0.tgz",
+      "integrity": "sha512-RCVjuI+SfAhExUOpKbn4i7aNvydRZaIQve25wYr5YTWIiL9ULsEY7puG92CNA7u7PLwo94lLwaHeRwRuMSVtSw==",
       "requires": {
         "@types/eventsource": "^1.1.2",
         "@types/node": ">= 8",
@@ -21263,7 +21263,7 @@
         "eventsource": "^1.0.7",
         "lodash": "^4.17.11",
         "randombytes": "^2.1.0",
-        "stellar-base": "^1.1.1",
+        "stellar-base": "^2.1.2",
         "toml": "^2.3.0",
         "tslib": "^1.10.0",
         "urijs": "^1.19.1",
@@ -21280,9 +21280,9 @@
           }
         },
         "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         },
         "randombytes": {
           "version": "2.1.0",
@@ -22588,9 +22588,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
+      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
     },
     "urix": {
       "version": "0.1.0",
@@ -22741,9 +22741,9 @@
       "dev": true
     },
     "utility-types": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.7.0.tgz",
-      "integrity": "sha512-mqRJXN7dEArK/NZNJUubjr9kbFFVZcmF/JHDc9jt5O/aYXUVmopHYujDMhLmLil1Bxo2+khe6KAIVvDH9Yc4VA=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "key-store": "^1.1.0",
     "nanoid": "^2.1.1",
     "open": "^7.0.0",
-    "stellar-sdk": "^2.3.0"
+    "stellar-sdk": "^3.3.0"
   },
   "devDependencies": {
     "@material-ui/core": "^4.5.1",

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -31,10 +31,6 @@ interface FeeStats {
   p99_accepted_fee: string
 }
 
-interface SignatureWithHint extends xdr.DecoratedSignature {
-  hint(): Buffer
-}
-
 const MAX_INT64 = "9223372036854775807"
 
 const dedupe = <T>(array: T[]) => Array.from(new Set(array))
@@ -171,10 +167,9 @@ export function assetRecordToAsset(assetRecord: AssetRecord) {
 }
 
 export function signatureMatchesPublicKey(signature: xdr.DecoratedSignature, publicKey: string): boolean {
-  const hint = (signature as SignatureWithHint).hint()
   const keypair = Keypair.fromPublicKey(publicKey)
 
-  return hint.equals(keypair.signatureHint() as Buffer)
+  return signature.hint().equals(keypair.signatureHint())
 }
 
 export function trustlineLimitEqualsUnlimited(limit: string | number) {

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -14,10 +14,6 @@ import { Account } from "../context/accounts"
 import { WrongPasswordError } from "../lib/errors"
 import { getAllSources, isNotFoundError, isSignedByAnyOf, selectSmartTransactionFee, SmartFeePreset } from "./stellar"
 
-interface SignatureWithHint extends xdr.DecoratedSignature {
-  hint(): Buffer
-}
-
 // See <https://github.com/stellar/go/issues/926>
 const highFeePreset: SmartFeePreset = {
   capacityTrigger: 0.5,
@@ -42,7 +38,7 @@ export function createCheapTxID(transaction: Transaction | ServerApi.Transaction
 
 export function hasSigned(transaction: Transaction, publicKey: string) {
   return transaction.signatures.some(signature => {
-    const hint = (signature as SignatureWithHint).hint()
+    const hint = signature.hint()
     const keypair = Keypair.fromPublicKey(publicKey)
 
     return hint.equals(keypair.rawPublicKey().slice(-hint.byteLength))


### PR DESCRIPTION
Use the latest version of the `stellar-sdk` and drop interfaces that were introduced to patch incomplete type declarations.

Closes #856. 