### PR TITLE
Fix submission-progress not displayed properly

### DIFF
--- a/src/components/SubmissionProgress.tsx
+++ b/src/components/SubmissionProgress.tsx
@@ -50,7 +50,7 @@ function SubmissionProgress(props: SubmissionProgressProps) {
       promise={props.promise}
       pending={
         <Container>
-          <CircularProgress size={70} />
+          <CircularProgress size={70} style={{ marginBottom: 24 }} />
           <Heading>Submitting to network...</Heading>
         </Container>
       }

--- a/src/components/TransactionReview/TransactionReviewDialog.tsx
+++ b/src/components/TransactionReview/TransactionReviewDialog.tsx
@@ -77,7 +77,7 @@ export function TransactionReviewDialogBody(props: TransactionReviewDialogBodyPr
 
   return (
     <DialogBody top={titleContent} actions={props.showSubmissionProgress ? null : dialogActionsRef}>
-      {props.transaction ? (
+      {props.transaction && !props.showSubmissionProgress ? (
         <Box margin={`12px ${isSmallScreen ? "4px" : "0"} 0`} textAlign="center">
           <ReviewForm
             account={props.account}

--- a/src/components/TransactionSender.tsx
+++ b/src/components/TransactionSender.tsx
@@ -32,10 +32,8 @@ function ConditionalSubmissionProgress(props: {
   const isSmallScreen = useIsMobile()
 
   const outerStyle: React.CSSProperties = {
-    position: "absolute",
+    position: "relative",
     display: props.promise ? "flex" : "none",
-    top: 0,
-    left: 0,
     width: "100%",
     height: "100%",
     alignItems: "center",


### PR DESCRIPTION
The problem was that the `position` of the div containing the submission progress was set to 'absolute' and it seems like the dialog only adjusts to content with `position` set to 'relative'.

We needed that absolute position because we put the submission progress on top of the transaction details instead of hiding it. So in order to make the `position:"relative"` property work, we have to hide the transaction details when the submission progress is shown.

This was so annoying to fix/find out that I think this will haunt me in my dreams tonight.

Closes #877.