### PR TITLE
Pass preselected asset when opening trading view from asset details

### DIFF
--- a/src/components/AccountAssets/AssetDetailsActions.tsx
+++ b/src/components/AccountAssets/AssetDetailsActions.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "../../hooks/userinterface"
 import { createTransaction } from "../../lib/transaction"
 import * as routes from "../../routes"
 import { CompactDialogTransition } from "../../theme"
+import { stringifyAsset } from "../../lib/stellar"
 import { DialogActionsBox, ActionButton } from "../Dialog/Generic"
 import TransactionSender from "../TransactionSender"
 import RemoveTrustlineDialog from "./RemoveTrustline"
@@ -63,9 +64,10 @@ function AssetDetailsActions(props: Props) {
   const closeRemovalDialog = React.useCallback(() => setRemovalDialogOpen(false), [])
   const removeThisAsset = React.useCallback(() => setRemovalDialogOpen(true), [])
 
-  const tradeThisAsset = React.useCallback(() => router.history.push(routes.tradeAsset(props.account.id)), [
-    router.history
-  ])
+  const tradeThisAsset = React.useCallback(
+    () => router.history.push(routes.tradeAsset(props.account.id, undefined, stringifyAsset(asset))),
+    [asset, router.history]
+  )
 
   return (
     <>

--- a/src/components/Trading/TradingDialog.tsx
+++ b/src/components/Trading/TradingDialog.tsx
@@ -5,6 +5,7 @@ import Typography from "@material-ui/core/Typography"
 import { Account } from "../../context/accounts"
 import { useLiveAccountData } from "../../hooks/stellar-subscriptions"
 import { useDialogActions, useRouter } from "../../hooks/userinterface"
+import { getLastArgumentFromURL } from "../../lib/url"
 import { matchesRoute } from "../../lib/routes"
 import { parseAssetID, stringifyAsset } from "../../lib/stellar"
 import * as routes from "../../routes"
@@ -28,7 +29,7 @@ interface TradingDialogProps {
 
 function getAssetFromPath(pathname: string) {
   if (matchesRoute(pathname, routes.tradeAsset("*", undefined, "*"))) {
-    const lastArgument = pathname.replace(/^.*\/([^\/]+)/, "$1")
+    const lastArgument = getLastArgumentFromURL(pathname)
     if (lastArgument !== "buy" && lastArgument !== "sell") {
       return parseAssetID(lastArgument)
     }

--- a/src/components/Trading/TradingDialog.tsx
+++ b/src/components/Trading/TradingDialog.tsx
@@ -64,8 +64,10 @@ function TradingDialog(props: TradingDialogProps) {
     : undefined
 
   const clearPrimaryAction = React.useCallback(() => {
-    router.history.push(routes.tradeAsset(props.account.id))
-  }, [props.account, router.history])
+    router.history.push(
+      routes.tradeAsset(props.account.id, undefined, preselectedAsset ? stringifyAsset(preselectedAsset) : undefined)
+    )
+  }, [preselectedAsset, props.account, router.history])
 
   const selectPrimaryAction = React.useCallback(
     (mainAction: "buy" | "sell") => {
@@ -73,7 +75,7 @@ function TradingDialog(props: TradingDialogProps) {
         routes.tradeAsset(props.account.id, mainAction, preselectedAsset ? stringifyAsset(preselectedAsset) : undefined)
       )
     },
-    [props.account, router.history]
+    [preselectedAsset, props.account, router.history]
   )
 
   const mainContentStageStyle: React.CSSProperties = {

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -11,3 +11,7 @@ export function joinURL(...fragments: string[]) {
     }
   }, "")
 }
+
+export function getLastArgumentFromURL(url: string) {
+  return url.replace(/^.*\/([^\/]+)/, "$1")
+}

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -19,6 +19,7 @@ import WithdrawalDialog from "../components/Withdrawal/WithdrawalDialog"
 import { Account, AccountsContext } from "../context/accounts"
 import { useLiveAccountData } from "../hooks/stellar-subscriptions"
 import { useIsMobile, useRouter } from "../hooks/userinterface"
+import { getLastArgumentFromURL } from "../lib/url"
 import { matchesRoute } from "../lib/routes"
 import * as routes from "../routes"
 import { FullscreenDialogTransition } from "../theme"
@@ -235,7 +236,7 @@ const AccountPageContent = React.memo(function AccountPageContent(props: { accou
         <React.Suspense fallback={<ViewLoading />}>
           <AssetDetailsDialog
             account={props.account}
-            assetID={showAssetDetails ? router.location.pathname.replace(/^.*\/([^\/]+)/, "$1") : "XLM"}
+            assetID={showAssetDetails ? getLastArgumentFromURL(router.location.pathname) : "XLM"}
             onClose={closeAssetDetails}
           />
         </React.Suspense>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -19,8 +19,8 @@ export const withdrawAsset = (accountID: string) => `/account/${accountID}/withd
 export const showTransaction = (accountID: string, transactionHash: string) =>
   `/account/${accountID}/tx/${transactionHash}`
 
-export const tradeAsset = (accountID: string, method?: "buy" | "sell") => {
-  return method ? `/account/${accountID}/trade/${method}` : `/account/${accountID}/trade`
+export const tradeAsset = (accountID: string, method?: "buy" | "sell", preselectedAsset?: string) => {
+  return `/account/${accountID}/trade` + (method ? `/${method}` : "") + (preselectedAsset ? `/${preselectedAsset}` : "")
 }
 
 export function routeUp(currentPath: string) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -20,7 +20,7 @@ export const showTransaction = (accountID: string, transactionHash: string) =>
   `/account/${accountID}/tx/${transactionHash}`
 
 export const tradeAsset = (accountID: string, method?: "buy" | "sell", preselectedAsset?: string) => {
-  return `/account/${accountID}/trade` + (method ? `/${method}` : "") + (preselectedAsset ? `/${preselectedAsset}` : "")
+  return [`/account/${accountID}/trade`, method || "", preselectedAsset || ""].filter(fragment => !!fragment).join("/")
 }
 
 export function routeUp(currentPath: string) {


### PR DESCRIPTION
- [x] Change route for `tradeAsset`
- [x] Add asset-code of selected asset to url when clicking 'Trade' in asset-details view
- [x] Parse asset-code (if any) to asset in trading dialog and pass that asset to the trading form
- [x] Add `getLastArgumentFromURL()` function

The preselected asset will be preserved on back navigation so that if the user clicks on 'buy' first and decides that he rather wants to sell it, the asset will get preselected again. 

Closes #857.