### PR TITLE
Fix wrong amount shown in order description

### DIFF
--- a/src/components/Account/TransactionList.tsx
+++ b/src/components/Account/TransactionList.tsx
@@ -77,7 +77,7 @@ function OfferDescription(props: {
     <>
       {prefix}
       {props.type === "manageBuyOffer"
-        ? `Buy ${formatBalance(amount.toString())} ${buying.code} for ${formatBalance(amount.div(price).toString())} ${
+        ? `Buy ${formatBalance(amount.toString())} ${buying.code} for ${formatBalance(amount.mul(price).toString())} ${
             selling.code
           }`
         : `Sell ${formatBalance(amount.toString())} ${selling.code} for ${formatBalance(


### PR DESCRIPTION
Fix wrong amount shown in the description of orders in the recent transaction list.

@andywer I assume that changing the calculation from `div` to `mul` is correct because we do the same for the `TransactionReview` (?)
https://github.com/satoshipay/solar/blob/4085be3b0b225ab375799f11c494c0aa73174775/src/components/TransactionReview/Operations.tsx#L213-L216


Closes #891.