### PR TITLE
Fix account title not updating on account change

### DIFF
--- a/src/components/Account/AccountHeaderCard.tsx
+++ b/src/components/Account/AccountHeaderCard.tsx
@@ -113,6 +113,9 @@ function AccountHeaderCard(props: Props) {
       <CardContent style={isSmallScreen ? { padding: 8 } : undefined}>
         <React.Suspense fallback={null}>
           <AccountTitle
+            // set the key to force the component to remount on account change
+            // this is needed because we want to reset the local state
+            key={props.account.id}
             account={props.account}
             actions={actions}
             badges={badges}

--- a/src/components/Account/AccountHeaderCard.tsx
+++ b/src/components/Account/AccountHeaderCard.tsx
@@ -114,7 +114,7 @@ function AccountHeaderCard(props: Props) {
         <React.Suspense fallback={null}>
           <AccountTitle
             // set the key to force the component to remount on account change
-            // this is needed because we want to reset the local state
+            // in order to clear the component state containing a copy of the account title
             key={props.account.id}
             account={props.account}
             actions={actions}


### PR DESCRIPTION
Fixes an issue where the account title does not update when switching from one account to another.

When switching accounts without going to the overview page (e.g. changing the `id` in the URL or clicking on a notification that leads to a different account) the account title shown in the `AccountHeaderCard` is not updated properly.