### PR TITLE
Add support for kraken-style QR codes for payments

### DIFF
--- a/src/components/Payment/PaymentForm.tsx
+++ b/src/components/Payment/PaymentForm.tsx
@@ -158,10 +158,29 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
     props.onSubmit(formValues, spendableBalance, matchingWellknownAccount)
   }
 
+  const handleQRScan = React.useCallback((scanResult: string) => {
+    const array = scanResult.split("?")
+
+    const destination = array[0]
+    setFormValue("destination", destination)
+
+    if (array.length === 1) {
+      return
+    }
+
+    const searchParams = new URLSearchParams(array[1])
+    const memoValue = searchParams.get("dt")
+
+    if (memoValue) {
+      setFormValue("memoType", "id")
+      setFormValue("memoValue", memoValue)
+    }
+  }, [])
+
   const qrReaderAdornment = React.useMemo(
     () => (
       <InputAdornment disableTypography position="end">
-        <QRReader onScan={key => setFormValue("destination", key)} />
+        <QRReader onScan={handleQRScan} />
       </InputAdornment>
     ),
     []

--- a/src/components/Payment/PaymentForm.tsx
+++ b/src/components/Payment/PaymentForm.tsx
@@ -159,16 +159,14 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
   }
 
   const handleQRScan = React.useCallback((scanResult: string) => {
-    const array = scanResult.split("?")
-
-    const destination = array[0]
+    const [destination, query] = scanResult.split("?")
     setFormValue("destination", destination)
 
-    if (array.length === 1) {
+    if (!query) {
       return
     }
 
-    const searchParams = new URLSearchParams(array[1])
+    const searchParams = new URLSearchParams(query)
     const memoValue = searchParams.get("dt")
 
     if (memoValue) {


### PR DESCRIPTION
The result of the QR code scan is split into parts at the `?` character.
 If the result contains additional params after the `?`, we specifically look for a `dt` parameter and set the `memoValue` according to it.

Closes #897.