### PR TITLE
[WIP] Add 'useTranslation'-hook and replace hard-coded strings

### DIFF
--- a/src/components/Account/AccountContextMenu.tsx
+++ b/src/components/Account/AccountContextMenu.tsx
@@ -15,6 +15,7 @@ import { Account } from "../../context/accounts"
 import { SettingsContextType } from "../../context/settings"
 import { useLiveAccountData } from "../../hooks/stellar-subscriptions"
 import { useIsMobile } from "../../hooks/userinterface"
+import { useTranslation } from "../../hooks/i18n"
 import ContextMenu, { AnchorRenderProps } from "../ContextMenu"
 
 const useContextMenuItemStyles = makeStyles({
@@ -72,6 +73,8 @@ interface MenuProps {
 function AccountContextMenu(props: MenuProps) {
   const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
   const isSmallScreen = useIsMobile()
+  const { t } = useTranslation()
+
   const activated = accountData.balances.length > 0
 
   return (
@@ -87,33 +90,37 @@ function AccountContextMenu(props: MenuProps) {
           <AccountContextMenuItem
             disabled={!activated}
             icon={<SwapHorizIcon style={{ transform: "scale(1.2)" }} />}
-            label="Trade"
+            label={t("account-context-menu.trade-label")}
             onClick={closeAndCall(props.onTrade)}
           />
-          <AccountContextMenuItem icon={<CallReceivedIcon />} label="Deposit" onClick={closeAndCall(props.onDeposit)} />
+          <AccountContextMenuItem
+            icon={<CallReceivedIcon />}
+            label={t("account-context-menu.deposit-label")}
+            onClick={closeAndCall(props.onDeposit)}
+          />
           <AccountContextMenuItem
             disabled={!activated}
             icon={<CallMadeIcon />}
-            label="Withdraw"
+            label={t("account-context-menu.withdraw-label")}
             onClick={closeAndCall(props.onWithdraw)}
           />
           <Divider />
           <AccountContextMenuItem
             disabled={!activated}
             icon={<MoneyIcon />}
-            label="Assets & Balances"
+            label={t("account-context-menu.assets-and-balances-label")}
             onClick={closeAndCall(props.onManageAssets)}
           />
           {props.showingSettings ? (
             <AccountContextMenuItem
               icon={<ListIcon />}
-              label="Transactions"
+              label={t("account-context-menu.transactions-label")}
               onClick={closeAndCall(props.onAccountTransactions)}
             />
           ) : (
             <AccountContextMenuItem
               icon={<SettingsIcon />}
-              label="Account Settings"
+              label={t("account-context-menu.account-settings-label")}
               onClick={closeAndCall(props.onAccountSettings)}
             />
           )}

--- a/src/hooks/i18n.ts
+++ b/src/hooks/i18n.ts
@@ -1,0 +1,51 @@
+import React from "react"
+
+const translations = {
+  de: {},
+  en: {}
+}
+
+type Language = keyof typeof translations
+let currentLanguage: Language = getDefaultLanguage() || "en"
+
+function getDefaultLanguage() {
+  const lang = navigator.languages ? navigator.languages[0] : navigator.language
+  const langShort = lang.substr(0, 2)
+
+  const availableTranslations = Object.keys(translations)
+  if (availableTranslations.indexOf(langShort) !== -1) {
+    return langShort as Language
+  } else {
+    return null
+  }
+}
+
+function createT(language: Language) {
+  const translation = translations[language]
+
+  const t = (key: string) => {
+    const keys = key.split(".")
+    const text = keys.reduce((obj: any, i) => {
+      return obj[i]
+    }, translation)
+
+    return text || key
+  }
+
+  return t
+}
+
+export function useTranslation() {
+  // wrap 't' in object since we can't have functions as state
+  const [t, setT] = React.useState<{ t: (key: string) => string }>({ t: createT(currentLanguage) })
+
+  const i18n = {
+    changeLanguage: (newLanguage: Language) => (currentLanguage = newLanguage)
+  }
+
+  React.useEffect(() => {
+    setT({ t: createT(currentLanguage) })
+  }, [currentLanguage])
+
+  return { t: t.t, i18n }
+}

--- a/src/hooks/i18n.ts
+++ b/src/hooks/i18n.ts
@@ -10,6 +10,21 @@ const translations = {
       "trade-label": "Trade",
       "transactions-label": "Account Settings",
       "withdraw-label": "Withdraw"
+    },
+    "all-accounts-page": {
+      "switch-to-mainnet-label-short": "Mainnet",
+      "switch-to-testnet-label-short": "Testnet",
+      "switch-to-mainnet-label": "Switch To Mainnet",
+      "switch-to-testnet-label": "Switch To Testnet",
+      "header-mainnet": "My accounts",
+      "header-testnet": "Testnet accounts"
+    },
+    notification: {
+      "start-download-of-update": "Starting download of update...",
+      "download-ready": "Download is ready and will be installed on next restart!"
+    },
+    tooltip: {
+      "update-available": "Update available"
     }
   }
 }

--- a/src/hooks/i18n.ts
+++ b/src/hooks/i18n.ts
@@ -23,6 +23,24 @@ const translations = {
       "start-download-of-update": "Starting download of update...",
       "download-ready": "Download is ready and will be installed on next restart!"
     },
+    "settings-page": {
+      "biometric-lock-title-ios": "Face ID / Touch ID",
+      "biometric-lock-title": "Fingerprint Lock",
+      "biometric-lock-description":
+        "Enable this option to lock the app whenever you leave it. Unlock it using biometric authentication (usually your fingerprint).",
+      "show-testnet-accounts-title": "Show Testnet Accounts",
+      "show-testnet-accounts-description-1":
+        "The test network is a copy of the main Stellar network were the traded tokens have no real-world value. You can request free testnet XLM from the so-called friendbot to activate a testnet account and get started without owning any actual funds.",
+      "show-testnet-accounts-description-2":
+        "Note: Testnet accounts will always be shown if you have got testnet accounts already.",
+      "hide-memos-title": "Hide memos in transactions overview",
+      "hide-memos-description":
+        "Memos are text messages that can be included with transactions. Enable this option to hide them in the overview. They will still be shown in the detailed view of a transaction.",
+      "enable-multi-sig-title": "Enable Multi-Signature",
+      "enable-multi-sig-description":
+        "<b> Experimental feature: </b> Add co-signers to an account, define that all signers of an account have to sign transactions unanimously or a certain subset of signers have to sign a transaction in order to be valid.",
+      "main-title": "Settings"
+    },
     tooltip: {
       "update-available": "Update available"
     }

--- a/src/hooks/i18n.ts
+++ b/src/hooks/i18n.ts
@@ -2,7 +2,16 @@ import React from "react"
 
 const translations = {
   de: {},
-  en: {}
+  en: {
+    "account-context-menu": {
+      "account-settings-label": "Account Settings",
+      "assets-and-balances-label": "Assets & Balances",
+      "deposit-label": "Deposit",
+      "trade-label": "Trade",
+      "transactions-label": "Account Settings",
+      "withdraw-label": "Withdraw"
+    }
+  }
 }
 
 type Language = keyof typeof translations

--- a/src/pages/all-accounts.tsx
+++ b/src/pages/all-accounts.tsx
@@ -15,6 +15,7 @@ import TermsAndConditions from "../components/TermsAndConditionsDialog"
 import { AccountsContext } from "../context/accounts"
 import { SettingsContext } from "../context/settings"
 import { useIsMobile, useRouter } from "../hooks/userinterface"
+import { useTranslation } from "../hooks/i18n"
 import * as routes from "../routes"
 import { NotificationsContext, trackError } from "../context/notifications"
 import getUpdater from "../platform/updater"
@@ -43,9 +44,15 @@ function AllAccountsPage() {
   const styles = useStyles()
   const isSmallScreen = useIsMobile()
   const isWidthMax450 = useMediaQuery("(max-width:450px)")
+  const { t } = useTranslation()
 
-  const switchToMainnetLabel = isSmallScreen ? "Mainnet" : "Switch To Mainnet"
-  const switchToTestnetLabel = isSmallScreen ? "Testnet" : "Switch To Testnet"
+  const switchToMainnetLabel = isSmallScreen
+    ? t("all-accounts-page.switch-to-mainnet-label-short")
+    : t("all-accounts-page.switch-to-mainnet-label")
+
+  const switchToTestnetLabel = isSmallScreen
+    ? t("all-accounts-page.switch-to-testnet-label-short")
+    : t("all-accounts-page.switch-to-testnet-label")
 
   const updater = getUpdater()
 
@@ -58,10 +65,10 @@ function AllAccountsPage() {
   const startUpdate = React.useCallback(async () => {
     if (isUpdateAvailable && !updater.isUpdateStarted()) {
       try {
-        showNotification("info", "Starting download of update...")
+        showNotification("info", t("notification.start-download-of-update"))
         setUpdateInProgress(true)
         await updater.startUpdate()
-        showNotification("success", "Download is ready and will be installed on next restart!")
+        showNotification("success", t("notification.download-ready"))
       } catch (error) {
         trackError(error)
       } finally {
@@ -71,7 +78,7 @@ function AllAccountsPage() {
   }, [updater, isUpdateAvailable])
 
   const updateButton = (
-    <Tooltip title="Update available">
+    <Tooltip title={t("tooltip.update-available")}>
       <IconButton
         onClick={startUpdate}
         color="secondary"
@@ -91,7 +98,9 @@ function AllAccountsPage() {
   const headerContent = React.useMemo(
     () => (
       <MainTitle
-        title={networkSwitch === "testnet" ? "Testnet Accounts" : "My Accounts"}
+        title={
+          networkSwitch === "testnet" ? t("all-accounts-page.header-testnet") : t("all-accounts-page.header-mainnet")
+        }
         titleColor="inherit"
         titleStyle={isWidthMax450 ? { marginRight: 0 } : {}}
         hideBackButton

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -9,6 +9,7 @@ import MainTitle from "../components/MainTitle"
 import ToggleSection from "../components/Layout/ToggleSection"
 import { Section } from "../components/Layout/Page"
 import { useIsMobile, useRouter } from "../hooks/userinterface"
+import { useTranslation } from "../hooks/i18n"
 import { biometricLockAvailable } from "../platform/settings"
 import * as routes from "../routes"
 
@@ -20,6 +21,7 @@ function Settings() {
   const settings = React.useContext(SettingsContext)
   const hasTestnetAccount = accounts.some(account => account.testnet)
   const [bioLockAvailable, setBioLockAvailable] = React.useState(false)
+  const { t } = useTranslation()
 
   React.useEffect(() => {
     biometricLockAvailable().then(setBioLockAvailable)
@@ -32,66 +34,65 @@ function Settings() {
         checked={settings.biometricLock && settings.biometricLockUsable}
         onChange={settings.toggleBiometricLock}
         style={bioLockAvailable ? {} : { display: "none" }}
-        title={process.env.PLATFORM === "ios" ? "Face ID / Touch ID" : "Fingerprint Lock"}
+        title={
+          process.env.PLATFORM === "ios"
+            ? t("settings-page.biometric-lock-title-ios")
+            : t("settings-page.biometric-lock-title")
+        }
       >
         <Typography
           color={settings.biometricLock ? "initial" : "textSecondary"}
           style={{ margin: "8px 0 0" }}
           variant="body2"
         >
-          Enable this option to lock the app whenever you leave it. Unlock it using biometric authentication (usually
-          your fingerprint).
+          {t("settings-page.biometric-lock-description")}
         </Typography>
       </ToggleSection>
       <ToggleSection
         checked={settings.showTestnet}
         disabled={hasTestnetAccount}
         onChange={settings.toggleTestnet}
-        title="Show Testnet Accounts"
+        title={t("settings-page.show-testnet-accounts-title")}
       >
         <Typography
           color={settings.showTestnet ? "initial" : "textSecondary"}
           style={{ margin: "8px 0 0" }}
           variant="body2"
         >
-          The test network is a copy of the main Stellar network were the traded tokens have no real-world value. You
-          can request free testnet XLM from the so-called friendbot to activate a testnet account and get started
-          without owning any actual funds.
+          {t("settings-page.show-testnet-accounts-description-1")}
         </Typography>
         <Typography
           color={settings.showTestnet ? "initial" : "textSecondary"}
           style={{ margin: "12px 0 0" }}
           variant="body2"
         >
-          Note: Testnet accounts will always be shown if you have got testnet accounts already.
+          {t("settings-page.show-testnet-accounts-description-2")}
         </Typography>
       </ToggleSection>
       <ToggleSection
         checked={settings.hideMemos}
         onChange={settings.toggleHideMemos}
-        title="Hide memos in transactions overview"
+        title={t("settings-page.hide-memos-title")}
       >
         <Typography
           color={settings.hideMemos ? undefined : "textSecondary"}
           style={{ margin: "8px 0 0" }}
           variant="body2"
         >
-          Memos are text messages that can be included with transactions. Enable this option to hide them in the
-          overview. They will still be shown in the detailed view of a transaction.
+          {t("settings-page.hide-memos-description")}
         </Typography>
       </ToggleSection>
       <ToggleSection
         checked={settings.multiSignature}
         onChange={settings.toggleMultiSignature}
-        title="Enable Multi-Signature"
+        title={t("settings-page.enable-multi-sig-title")}
       >
         <Typography
           color={settings.multiSignature ? "initial" : "textSecondary"}
           style={{ margin: "8px 0 0" }}
           variant="body2"
         >
-          <b>Experimental feature:</b> Add co-signers to an account, define that all signers of an account have to sign
-          transactions unanimously or a certain subset of signers have to sign a transaction in order to be valid.
+          {t("settings-page.enable-multi-sig-description")}
         </Typography>
       </ToggleSection>
     </>
@@ -101,6 +102,8 @@ function Settings() {
 function SettingsPage() {
   const isSmallScreen = useIsMobile()
   const router = useRouter()
+  const { t } = useTranslation()
+
   return (
     <>
       <Section top brandColored style={{ flexGrow: 0 }}>
@@ -116,7 +119,7 @@ function SettingsPage() {
             <MainTitle
               onBack={() => router.history.push(routes.allAccounts())}
               style={{ margin: "-12px 0 -10px", minHeight: 56 }}
-              title="Settings"
+              title={t("settings-page.main-title")}
               titleColor="inherit"
             />
           </CardContent>


### PR DESCRIPTION
- [x] Add `useTranslation()` hook (similar to the one from [react-i18next](https://react.i18next.com/latest/usetranslation-hook))
- [x] Start adding translations for the `en`-locale
- [ ] Add remaining translations for `en`-locale for all hard-coded strings
- [ ] Escape HTML-tags from strings if present

I decided to have some basic 'namespace' support as they do in `i18next` so that the translations-object becomes more readable. I think this is a good way to cluster it into logical units so that we can keep a better overview.

@andywer please let me know what you think and if you have some suggestions for improvements before I start adding the remaining translations.

Closes #876.