### PR TITLE
Show asset logos in AssetSelector menu

### DIFF
--- a/src/components/AccountAssets/AssetDetailsDialog.tsx
+++ b/src/components/AccountAssets/AssetDetailsDialog.tsx
@@ -375,7 +375,7 @@ function AssetDetailsDialog(props: Props) {
               <AccountName publicKey={asset.getIssuer()} testnet={props.account.testnet} />
             )}
           </Typography>
-          <AssetLogo asset={asset} className={classes.logo} imageURL={metadata && metadata.image} />
+          <AssetLogo asset={asset} className={classes.logo} testnet={props.account.testnet} />
         </>
       }
       actions={dialogActions}

--- a/src/components/AccountAssets/AssetLogo.tsx
+++ b/src/components/AccountAssets/AssetLogo.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Asset } from "stellar-sdk"
 import Avatar from "@material-ui/core/Avatar"
 import makeStyles from "@material-ui/core/styles/makeStyles"
+import { useAssetMetadata } from "../../hooks/stellar"
 import { brandColor } from "../../theme"
 import LumenIcon from "../Icon/Lumen"
 
@@ -43,7 +44,7 @@ const useAssetLogoStyles = makeStyles({
   }
 })
 
-interface Props {
+interface AssetLogoProps {
   asset: Asset
   className?: string
   dark?: boolean
@@ -51,7 +52,7 @@ interface Props {
   style?: React.CSSProperties
 }
 
-function AssetLogo(props: Props) {
+function AssetLogo(props: AssetLogoProps) {
   const className = props.className || ""
   const classes = useAssetLogoStyles()
 
@@ -80,4 +81,25 @@ function AssetLogo(props: Props) {
   }
 }
 
-export default React.memo(AssetLogo)
+interface SuspendingAssetLogoProps {
+  asset: Asset
+  className?: string
+  dark?: boolean
+  style?: React.CSSProperties
+  testnet: boolean
+}
+
+function SuspendingAssetLogo(props: SuspendingAssetLogoProps) {
+  const metadata = useAssetMetadata(props.asset, props.testnet)
+  return <AssetLogo {...props} imageURL={metadata ? metadata.image : undefined} />
+}
+
+function AssetLogoWithFallback(props: SuspendingAssetLogoProps) {
+  return (
+    <React.Suspense fallback={<AssetLogo {...props} />}>
+      <SuspendingAssetLogo {...props} />
+    </React.Suspense>
+  )
+}
+
+export default React.memo(AssetLogoWithFallback)

--- a/src/components/AccountAssets/BalanceDetailsListItem.tsx
+++ b/src/components/AccountAssets/BalanceDetailsListItem.tsx
@@ -114,7 +114,11 @@ function BalanceListItem(props: BalanceListItemProps) {
         style={props.style}
       >
         <ListItemIcon className={classes.icon}>
-          <AssetLogo asset={asset} className={`${classes.logo} ${props.hideLogo ? classes.logoHidden : ""}`} />
+          <AssetLogo
+            asset={asset}
+            className={`${classes.logo} ${props.hideLogo ? classes.logoHidden : ""}`}
+            testnet={props.testnet}
+          />
         </ListItemIcon>
         <ListItemText
           classes={{
@@ -148,7 +152,7 @@ function BalanceListItem(props: BalanceListItemProps) {
             asset={asset}
             className={`${classes.logo} ${props.hideLogo ? classes.logoHidden : ""}`}
             dark
-            imageURL={assetMetadata && assetMetadata.image}
+            testnet={props.testnet}
           />
         </Badge>
       </ListItemIcon>

--- a/src/components/AccountAssets/ScrollableBalanceItem.tsx
+++ b/src/components/AccountAssets/ScrollableBalanceItem.tsx
@@ -1,7 +1,6 @@
 import { Horizon } from "stellar-sdk"
 import React from "react"
 import makeStyles from "@material-ui/core/styles/makeStyles"
-import { useAssetMetadata } from "../../hooks/stellar"
 import { balancelineToAsset } from "../../lib/stellar"
 import { breakpoints } from "../../theme"
 import { SingleBalance } from "../Account/AccountBalances"
@@ -117,7 +116,6 @@ interface BalanceItemProps {
 function BalanceItem(props: BalanceItemProps, ref: React.Ref<any>) {
   const classes = useBalanceItemStyles()
   const asset = React.useMemo(() => balancelineToAsset(props.balance), [props.balance])
-  const assetMetadata = useAssetMetadata(asset, props.testnet)
 
   return (
     <div
@@ -125,7 +123,7 @@ function BalanceItem(props: BalanceItemProps, ref: React.Ref<any>) {
       onClick={props.onClick}
       ref={ref}
     >
-      <AssetLogo asset={asset} className={classes.logo} imageURL={assetMetadata ? assetMetadata.image : undefined} />
+      <AssetLogo asset={asset} className={classes.logo} testnet={props.testnet} />
       <div className={classes.balance}>
         <span className={classes.assetCode}>
           {props.balance.asset_type === "native" ? "XLM" : props.balance.asset_code}

--- a/src/components/Form/AssetSelector.tsx
+++ b/src/components/Form/AssetSelector.tsx
@@ -1,9 +1,46 @@
 import React from "react"
 import { Asset, Horizon } from "stellar-sdk"
+import ListItemIcon from "@material-ui/core/ListItemIcon"
+import ListItemText from "@material-ui/core/ListItemText"
 import MenuItem from "@material-ui/core/MenuItem"
 import TextField, { TextFieldProps } from "@material-ui/core/TextField"
 import { makeStyles } from "@material-ui/core/styles"
 import { balancelineToAsset, stringifyAsset } from "../../lib/stellar"
+import AssetLogo from "../AccountAssets/AssetLogo"
+
+const useAssetItemStyles = makeStyles(theme => ({
+  icon: {
+    [theme.breakpoints.up(600)]: {
+      minWidth: 48
+    }
+  },
+  logo: {
+    width: 32,
+    height: 32,
+
+    [theme.breakpoints.up(600)]: {
+      width: 28,
+      height: 28
+    }
+  }
+}))
+
+interface AssetItemProps {
+  asset: Asset
+  testnet: boolean
+}
+
+const AssetItem = React.memo(function AssetItem(props: AssetItemProps) {
+  const classes = useAssetItemStyles()
+  return (
+    <MenuItem value={stringifyAsset(props.asset)}>
+      <ListItemIcon className={classes.icon}>
+        <AssetLogo asset={props.asset} className={classes.logo} testnet={props.testnet} />
+      </ListItemIcon>
+      <ListItemText>{props.asset.getCode()}</ListItemText>
+    </MenuItem>
+  )
+})
 
 const useAssetSelectorStyles = makeStyles({
   helperText: {
@@ -30,6 +67,7 @@ interface AssetSelectorProps {
   minWidth?: number | string
   onChange: (asset: Asset) => void
   style?: React.CSSProperties
+  testnet: boolean
   trustlines: Horizon.BalanceLine[]
   value?: Asset
 }
@@ -91,16 +129,14 @@ function AssetSelector(props: AssetSelectorProps) {
           Select an asset
         </MenuItem>
       )}
-      <MenuItem value={stringifyAsset(Asset.native())}>XLM</MenuItem>
+      <AssetItem asset={Asset.native()} testnet={props.testnet} />
       {props.trustlines
         .filter(trustline => trustline.asset_type !== "native")
         .map(trustline => (
-          <MenuItem key={stringifyAsset(trustline)} value={stringifyAsset(trustline)}>
-            {trustline.asset_type === "native" ? "XLM" : trustline.asset_code}
-          </MenuItem>
+          <AssetItem asset={balancelineToAsset(trustline)} key={stringifyAsset(trustline)} testnet={props.testnet} />
         ))}
     </TextField>
   )
 }
 
-export default AssetSelector
+export default React.memo(AssetSelector)

--- a/src/components/Payment/PaymentForm.tsx
+++ b/src/components/Payment/PaymentForm.tsx
@@ -195,6 +195,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
         disableUnderline
         onChange={asset => setFormValue("asset", asset)}
         style={{ alignSelf: "center" }}
+        testnet={props.testnet}
         trustlines={props.accountData.balances}
         value={formValues.asset}
       />

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -198,6 +198,7 @@ function TradingForm(props: Props) {
             onChange={setPrimaryAsset}
             minWidth={75}
             style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
+            testnet={props.account.testnet}
             trustlines={props.trustlines}
             value={primaryAsset}
           />
@@ -262,6 +263,7 @@ function TradingForm(props: Props) {
             minWidth={75}
             onChange={setSecondaryAsset}
             style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
+            testnet={props.account.testnet}
             trustlines={props.trustlines}
             value={secondaryAsset}
           />


### PR DESCRIPTION
Was a by-product of `feature/deposit`.

#### Mobile

![Bildschirmfoto 2020-01-20 um 12 07 32](https://user-images.githubusercontent.com/1842462/72721972-86fe8780-3b7d-11ea-9338-03914eea85f5.png)

#### Desktop

![Bildschirmfoto 2020-01-20 um 12 06 39](https://user-images.githubusercontent.com/1842462/72721953-7b12c580-3b7d-11ea-874b-531ee1484fb3.png)
