### PR TITLE
[WIP] Show fiat estimates

### DIFF
--- a/src/hooks/stellar-ecosystem.ts
+++ b/src/hooks/stellar-ecosystem.ts
@@ -2,6 +2,7 @@ import React from "react"
 import { trackError } from "../context/notifications"
 import { AccountRecord, fetchWellknownAccounts } from "../lib/stellar-expert"
 import { AssetRecord, fetchAllAssets } from "../lib/stellar-ticker"
+import { CurrencyCode, fetchCryptoPrice } from "../lib/currency-conversion"
 import { tickerAssetsCache, wellKnownAccountsCache } from "./_caches"
 import { useForceRerender } from "./util"
 
@@ -41,4 +42,29 @@ export function useWellKnownAccounts(testnet: boolean) {
   }, [accounts])
 
   return wellknownAccounts
+}
+
+export function usePriceConversion(currency: CurrencyCode, testnet: boolean) {
+  const [price, setPrice] = React.useState<number>(0)
+
+  React.useEffect(() => {
+    fetchCryptoPrice(currency, testnet).then(setPrice)
+
+    const interval = setInterval(() => {
+      fetchCryptoPrice(currency, testnet).then(setPrice)
+    }, 60 * 1000)
+
+    return () => clearInterval(interval)
+  }, [])
+
+  const conversion = React.useMemo(() => {
+    return {
+      price,
+      convertXLM(amount: number): number {
+        return price * amount
+      }
+    }
+  }, [price])
+
+  return conversion
 }

--- a/src/lib/currency-conversion.ts
+++ b/src/lib/currency-conversion.ts
@@ -1,0 +1,126 @@
+import { workers } from "../worker-controller"
+
+export type CurrencyCode =
+  | "USD"
+  | "ALL"
+  | "DZD"
+  | "ARS"
+  | "AMD"
+  | "AUD"
+  | "AZN"
+  | "BHD"
+  | "BDT"
+  | "BYN"
+  | "BMD"
+  | "BOB"
+  | "BAM"
+  | "BRL"
+  | "BGN"
+  | "KHR"
+  | "CAD"
+  | "CLP"
+  | "CNY"
+  | "COP"
+  | "CRC"
+  | "HRK"
+  | "CUP"
+  | "CZK"
+  | "DKK"
+  | "DOP"
+  | "EGP"
+  | "EUR"
+  | "GEL"
+  | "GHS"
+  | "GTQ"
+  | "HNL"
+  | "HKD"
+  | "HUF"
+  | "ISK"
+  | "INR"
+  | "IDR"
+  | "IRR"
+  | "IQD"
+  | "ILS"
+  | "JMD"
+  | "JPY"
+  | "JOD"
+  | "KZT"
+  | "KES"
+  | "KWD"
+  | "KGS"
+  | "LBP"
+  | "MKD"
+  | "MYR"
+  | "MUR"
+  | "MXN"
+  | "MDL"
+  | "MNT"
+  | "MAD"
+  | "MMK"
+  | "NAD"
+  | "NPR"
+  | "TWD"
+  | "NZD"
+  | "NIO"
+  | "NGN"
+  | "NOK"
+  | "OMR"
+  | "PKR"
+  | "PAB"
+  | "PEN"
+  | "PHP"
+  | "PLN"
+  | "GBP"
+  | "QAR"
+  | "RON"
+  | "RUB"
+  | "SAR"
+  | "RSD"
+  | "SGD"
+  | "ZAR"
+  | "KRW"
+  | "SSP"
+  | "VES"
+  | "LKR"
+  | "SEK"
+  | "CHF"
+  | "THB"
+  | "TTD"
+  | "TND"
+  | "TRY"
+  | "UGX"
+  | "UAH"
+  | "AED"
+  | "UYU"
+  | "UZS"
+  | "VND"
+
+export interface QuoteRecord {
+  price: number
+  volume_24h: number
+  percent_change_1h: number
+  percent_change_24h: number
+  percent_change_7d: number
+  market_cap: number
+  last_updated: string
+}
+
+export async function fetchCryptoPrice(currency: CurrencyCode, testnet: boolean): Promise<number> {
+  const cacheKey = testnet ? `cryptocurrency-price:testnet` : `cryptocurrency-price:mainnet`
+
+  const cachedCryptoPrice = localStorage.getItem(cacheKey)
+  const timestamp = localStorage.getItem("cryptocurrency-price:timestamp")
+
+  const { netWorker } = await workers
+
+  if (cachedCryptoPrice && timestamp && +timestamp > Date.now() - 60 * 1000) {
+    // use cached price if it is not older than 1 minute
+    return JSON.parse(cachedCryptoPrice)
+  } else {
+    const cryptoPriceQuote = await netWorker.fetchCryptoPrice(currency, testnet)
+    const cryptoPrice = cryptoPriceQuote.price
+    localStorage.setItem(cacheKey, JSON.stringify(cryptoPrice))
+    localStorage.setItem("cryptocurrency-price:timestamp", Date.now().toString())
+    return cryptoPrice
+  }
+}

--- a/src/lib/currency-conversion.ts
+++ b/src/lib/currency-conversion.ts
@@ -1,99 +1,102 @@
 import { workers } from "../worker-controller"
 
-export type CurrencyCode =
-  | "USD"
-  | "ALL"
-  | "DZD"
-  | "ARS"
-  | "AMD"
-  | "AUD"
-  | "AZN"
-  | "BHD"
-  | "BDT"
-  | "BYN"
-  | "BMD"
-  | "BOB"
-  | "BAM"
-  | "BRL"
-  | "BGN"
-  | "KHR"
-  | "CAD"
-  | "CLP"
-  | "CNY"
-  | "COP"
-  | "CRC"
-  | "HRK"
-  | "CUP"
-  | "CZK"
-  | "DKK"
-  | "DOP"
-  | "EGP"
-  | "EUR"
-  | "GEL"
-  | "GHS"
-  | "GTQ"
-  | "HNL"
-  | "HKD"
-  | "HUF"
-  | "ISK"
-  | "INR"
-  | "IDR"
-  | "IRR"
-  | "IQD"
-  | "ILS"
-  | "JMD"
-  | "JPY"
-  | "JOD"
-  | "KZT"
-  | "KES"
-  | "KWD"
-  | "KGS"
-  | "LBP"
-  | "MKD"
-  | "MYR"
-  | "MUR"
-  | "MXN"
-  | "MDL"
-  | "MNT"
-  | "MAD"
-  | "MMK"
-  | "NAD"
-  | "NPR"
-  | "TWD"
-  | "NZD"
-  | "NIO"
-  | "NGN"
-  | "NOK"
-  | "OMR"
-  | "PKR"
-  | "PAB"
-  | "PEN"
-  | "PHP"
-  | "PLN"
-  | "GBP"
-  | "QAR"
-  | "RON"
-  | "RUB"
-  | "SAR"
-  | "RSD"
-  | "SGD"
-  | "ZAR"
-  | "KRW"
-  | "SSP"
-  | "VES"
-  | "LKR"
-  | "SEK"
-  | "CHF"
-  | "THB"
-  | "TTD"
-  | "TND"
-  | "TRY"
-  | "UGX"
-  | "UAH"
-  | "AED"
-  | "UYU"
-  | "UZS"
-  | "VND"
+export enum CurrencyCodes {
+  "USD",
+  "ALL",
+  "DZD",
+  "ARS",
+  "AMD",
+  "AUD",
+  "AZN",
+  "BHD",
+  "BDT",
+  "BYN",
+  "BMD",
+  "BOB",
+  "BAM",
+  "BRL",
+  "BGN",
+  "KHR",
+  "CAD",
+  "CLP",
+  "CNY",
+  "COP",
+  "CRC",
+  "HRK",
+  "CUP",
+  "CZK",
+  "DKK",
+  "DOP",
+  "EGP",
+  "EUR",
+  "GEL",
+  "GHS",
+  "GTQ",
+  "HNL",
+  "HKD",
+  "HUF",
+  "ISK",
+  "INR",
+  "IDR",
+  "IRR",
+  "IQD",
+  "ILS",
+  "JMD",
+  "JPY",
+  "JOD",
+  "KZT",
+  "KES",
+  "KWD",
+  "KGS",
+  "LBP",
+  "MKD",
+  "MYR",
+  "MUR",
+  "MXN",
+  "MDL",
+  "MNT",
+  "MAD",
+  "MMK",
+  "NAD",
+  "NPR",
+  "TWD",
+  "NZD",
+  "NIO",
+  "NGN",
+  "NOK",
+  "OMR",
+  "PKR",
+  "PAB",
+  "PEN",
+  "PHP",
+  "PLN",
+  "GBP",
+  "QAR",
+  "RON",
+  "RUB",
+  "SAR",
+  "RSD",
+  "SGD",
+  "ZAR",
+  "KRW",
+  "SSP",
+  "VES",
+  "LKR",
+  "SEK",
+  "CHF",
+  "THB",
+  "TTD",
+  "TND",
+  "TRY",
+  "UGX",
+  "UAH",
+  "AED",
+  "UYU",
+  "UZS",
+  "VND"
+}
+
+export type CurrencyCode = keyof typeof CurrencyCodes
 
 export interface QuoteRecord {
   price: number

--- a/src/workers/net-worker/stellar-ecosystem.ts
+++ b/src/workers/net-worker/stellar-ecosystem.ts
@@ -3,6 +3,7 @@
 import { FederationServer, StellarTomlResolver } from "stellar-sdk"
 import { AccountRecord } from "../../lib/stellar-expert"
 import { AssetRecord } from "../../lib/stellar-ticker"
+import { CurrencyCode, QuoteRecord } from "../../lib/currency-conversion"
 
 export async function fetchWellknownAccounts(testnet: boolean): Promise<AccountRecord[]> {
   const requestURL = testnet
@@ -66,4 +67,22 @@ export async function fetchStellarToml(domain: string): Promise<any> {
 
 export function resolveStellarAddress(address: string, options?: FederationServer.Options) {
   return FederationServer.resolve(address, options)
+}
+
+export async function fetchCryptoPrice(currencyCode: CurrencyCode, testnet: boolean) {
+  const baseURL = testnet
+    ? "https://api.satoshipay.io/testnet/coinmarketcap/v1/cryptocurrency/quotes/latest"
+    : "https://api.satoshipay.io/mainnet/coinmarketcap/v1/cryptocurrency/quotes/latest"
+
+  const requestURL = `${baseURL}?symbol=XLM&convert=${currencyCode}`
+
+  const response = await fetch(requestURL)
+
+  if (response.status >= 400) {
+    throw Error(`Bad response (${response.status}) from conversion rate endpoint`)
+  }
+
+  const json = await response.json()
+  const quoteRecord = json.data.XLM.quote[currencyCode] as QuoteRecord
+  return quoteRecord
 }


### PR DESCRIPTION
Show fiat estimates where needed.

## To Do
- [x] Create hook to fetch conversion rate
- [ ] Come up with consistent visual concept where and how to show estimates
- [ ]  Add currency preference to app settings (ideally pick initial value based on system locale)
- [ ]  Show estimates in assets details
- [ ]  Show estimates in send payment
- [ ] (Nice to have:) Show estimates in trading & withdrawal dialog

Closes #744.