### PR TITLE
Restyle app settings

### DIFF
--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -1,0 +1,109 @@
+import React from "react"
+import List from "@material-ui/core/List"
+import Switch from "@material-ui/core/Switch"
+import FingerprintIcon from "@material-ui/icons/Fingerprint"
+import GroupIcon from "@material-ui/icons/Group"
+import MessageIcon from "@material-ui/icons/Message"
+import TestnetIcon from "@material-ui/icons/Language"
+import { AccountsContext } from "../../context/accounts"
+import { SettingsContext } from "../../context/settings"
+import { useIsMobile } from "../../hooks/userinterface"
+import AppSettingsItem from "./AppSettingsItem"
+
+interface SettingsToggleProps {
+  checked: boolean
+  disabled?: boolean
+  onChange: (checked: boolean) => void
+}
+
+function SettingsToggle(props: SettingsToggleProps) {
+  const { checked, disabled, onChange } = props
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.checked)
+  }
+
+  return (
+    <>
+      <Switch checked={checked} color="primary" disabled={disabled} onChange={handleChange} />
+    </>
+  )
+}
+
+function AppSettings() {
+  const isSmallScreen = useIsMobile()
+
+  const { accounts } = React.useContext(AccountsContext)
+  const settings = React.useContext(SettingsContext)
+
+  const hasTestnetAccount = accounts.some(account => account.testnet)
+
+  return (
+    <>
+      <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
+        <AppSettingsItem
+          actions={
+            <SettingsToggle
+              checked={settings.biometricLock && settings.biometricLockUsable}
+              disabled={!settings.biometricLockUsable}
+              onChange={settings.toggleBiometricLock}
+            />
+          }
+          disabled={!settings.biometricLockUsable}
+          icon={<FingerprintIcon style={{ fontSize: "100%" }} />}
+          onClick={settings.toggleBiometricLock}
+          primaryText="Biometric authentication"
+          secondaryText={
+            settings.biometricLockUsable
+              ? settings.biometricLock
+                ? "Biometric authentication is enabled"
+                : "Biometric authentication is disabled"
+              : "Not available for your device"
+          }
+        />
+        <AppSettingsItem
+          actions={
+            <SettingsToggle
+              checked={settings.showTestnet}
+              disabled={hasTestnetAccount}
+              onChange={settings.toggleTestnet}
+            />
+          }
+          disabled={hasTestnetAccount}
+          icon={<TestnetIcon style={{ fontSize: "100%" }} />}
+          onClick={settings.toggleTestnet}
+          primaryText="Show Testnet Accounts"
+          secondaryText={
+            hasTestnetAccount
+              ? "Cannot be disabled because you added testnet accounts already"
+              : settings.showTestnet
+              ? "Testnet accounts are shown"
+              : "Testnet accounts are hidden"
+          }
+        />
+        <AppSettingsItem
+          actions={<SettingsToggle checked={!settings.hideMemos} onChange={settings.toggleHideMemos} />}
+          icon={<MessageIcon style={{ fontSize: "100%" }} />}
+          onClick={settings.toggleHideMemos}
+          primaryText="Show Memos"
+          secondaryText={
+            settings.hideMemos
+              ? "Memos are hidden in the transaction overview"
+              : "Memos are shown in the transaction overview"
+          }
+        />
+        <AppSettingsItem
+          actions={<SettingsToggle checked={settings.multiSignature} onChange={settings.toggleMultiSignature} />}
+          icon={<GroupIcon style={{ fontSize: "100%" }} />}
+          onClick={settings.toggleMultiSignature}
+          primaryText="Enable Multi-Signature"
+          secondaryText={
+            settings.multiSignature ? "Multi-Signature features are enabled" : "Multi-Signature features are disabled"
+          }
+        />
+      </List>
+    </>
+  )
+}
+
+export default React.memo(AppSettings)

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -4,7 +4,7 @@ import Switch from "@material-ui/core/Switch"
 import FingerprintIcon from "@material-ui/icons/Fingerprint"
 import GroupIcon from "@material-ui/icons/Group"
 import MessageIcon from "@material-ui/icons/Message"
-import TestnetIcon from "@material-ui/icons/Language"
+import TestnetIcon from "@material-ui/icons/MoneyOff"
 import { AccountsContext } from "../../context/accounts"
 import { SettingsContext } from "../../context/settings"
 import { useIsMobile } from "../../hooks/userinterface"
@@ -41,26 +41,23 @@ function AppSettings() {
   return (
     <>
       <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
-        <AppSettingsItem
-          actions={
-            <SettingsToggle
-              checked={settings.biometricLock && settings.biometricLockUsable}
-              disabled={!settings.biometricLockUsable}
-              onChange={settings.toggleBiometricLock}
-            />
-          }
-          disabled={!settings.biometricLockUsable}
-          icon={<FingerprintIcon style={{ fontSize: "100%" }} />}
-          onClick={settings.toggleBiometricLock}
-          primaryText="Biometric authentication"
-          secondaryText={
-            settings.biometricLockUsable
-              ? settings.biometricLock
-                ? "Biometric authentication is enabled"
-                : "Biometric authentication is disabled"
-              : "Not available for your device"
-          }
-        />
+        {settings.biometricLockUsable ? (
+          <AppSettingsItem
+            actions={
+              <SettingsToggle
+                checked={settings.biometricLock && settings.biometricLockUsable}
+                disabled={!settings.biometricLockUsable}
+                onChange={settings.toggleBiometricLock}
+              />
+            }
+            icon={<FingerprintIcon style={{ fontSize: "100%" }} />}
+            onClick={settings.toggleBiometricLock}
+            primaryText="Biometric authentication"
+            secondaryText={
+              settings.biometricLock ? "Biometric authentication is enabled" : "Biometric authentication is disabled"
+            }
+          />
+        ) : null}
         <AppSettingsItem
           actions={
             <SettingsToggle
@@ -69,13 +66,12 @@ function AppSettings() {
               onChange={settings.toggleTestnet}
             />
           }
-          disabled={hasTestnetAccount}
           icon={<TestnetIcon style={{ fontSize: "100%" }} />}
-          onClick={settings.toggleTestnet}
+          onClick={hasTestnetAccount ? undefined : settings.toggleTestnet}
           primaryText="Show Testnet Accounts"
           secondaryText={
             hasTestnetAccount
-              ? "Cannot be disabled because you added testnet accounts already"
+              ? "Cannot be disabled because you already added testnet accounts"
               : settings.showTestnet
               ? "Testnet accounts are shown"
               : "Testnet accounts are hidden"

--- a/src/components/AppSettings/AppSettingsItem.tsx
+++ b/src/components/AppSettings/AppSettingsItem.tsx
@@ -1,0 +1,78 @@
+import React from "react"
+import ListItem from "@material-ui/core/ListItem"
+import ListItemIcon from "@material-ui/core/ListItemIcon"
+import makeStyles from "@material-ui/core/styles/makeStyles"
+import ListItemText from "@material-ui/core/ListItemText"
+import { useIsMobile } from "../../hooks/userinterface"
+import { breakpoints } from "../../theme"
+
+const isMobileDevice = process.env.PLATFORM === "android" || process.env.PLATFORM === "ios"
+
+const useAppSettingsItemStyles = makeStyles({
+  caret: {
+    color: "rgba(0, 0, 0, 0.35)",
+    fontSize: 48,
+    justifyContent: "center",
+    marginRight: -8,
+    width: 48
+  },
+  icon: {
+    fontSize: 28,
+    justifyContent: "center",
+    marginRight: 4,
+    width: 28
+  },
+  settingsItem: {
+    position: "relative",
+    padding: "16px 24px",
+    background: "#FFFFFF",
+
+    [breakpoints.down(600)]: {
+      padding: "16px 12px"
+    },
+
+    "&:focus": {
+      backgroundColor: "#FFFFFF"
+    },
+    "&:hover": {
+      backgroundColor: isMobileDevice ? "#FFFFFF" : "rgb(232, 232, 232)"
+    },
+    "&:not(:first-child)": {
+      borderTop: "1px solid rgba(230, 230, 230, 1.0)"
+    }
+  }
+})
+
+interface AppSettingsItemProps {
+  actions?: React.ReactNode
+  disabled?: boolean
+  icon: React.ReactElement
+  primaryText: string
+  secondaryText?: string
+  style?: React.CSSProperties
+  onClick: () => void
+}
+
+function AppSettingsItem(props: AppSettingsItemProps) {
+  const classes = useAppSettingsItemStyles()
+  const isSmallScreen = useIsMobile()
+
+  const { actions, primaryText, secondaryText, style } = props
+
+  const listItemTextStyle: React.CSSProperties = React.useMemo(
+    () => ({
+      paddingRight: isSmallScreen ? 0 : undefined
+    }),
+    [isSmallScreen]
+  )
+
+  return (
+    <ListItem button className={classes.settingsItem} disabled={props.disabled} onClick={props.onClick} style={style}>
+      <ListItemIcon className={classes.icon}>{props.icon}</ListItemIcon>
+      <ListItemText primary={primaryText} secondary={secondaryText} style={listItemTextStyle} />
+      {actions}
+    </ListItem>
+  )
+}
+
+export default AppSettingsItem

--- a/src/components/AppSettings/AppSettingsItem.tsx
+++ b/src/components/AppSettings/AppSettingsItem.tsx
@@ -34,13 +34,14 @@ const useAppSettingsItemStyles = makeStyles({
     "&:focus": {
       backgroundColor: "#FFFFFF"
     },
-    "&:hover": {
+    "&$actionable:hover": {
       backgroundColor: isMobileDevice ? "#FFFFFF" : "rgb(232, 232, 232)"
     },
     "&:not(:first-child)": {
       borderTop: "1px solid rgba(230, 230, 230, 1.0)"
     }
-  }
+  },
+  actionable: {}
 })
 
 interface AppSettingsItemProps {
@@ -50,7 +51,7 @@ interface AppSettingsItemProps {
   primaryText: string
   secondaryText?: string
   style?: React.CSSProperties
-  onClick: () => void
+  onClick?: () => void
 }
 
 function AppSettingsItem(props: AppSettingsItemProps) {
@@ -66,8 +67,16 @@ function AppSettingsItem(props: AppSettingsItemProps) {
     [isSmallScreen]
   )
 
+  const className = `${classes.settingsItem} ${props.onClick ? classes.actionable : ""}`
+
   return (
-    <ListItem button className={classes.settingsItem} disabled={props.disabled} onClick={props.onClick} style={style}>
+    <ListItem
+      button={Boolean(props.onClick) as any}
+      className={className}
+      disabled={props.disabled}
+      onClick={props.onClick}
+      style={style}
+    >
       <ListItemIcon className={classes.icon}>{props.icon}</ListItemIcon>
       <ListItemText primary={primaryText} secondary={secondaryText} style={listItemTextStyle} />
       {actions}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -2,101 +2,15 @@ import React from "react"
 import Card from "@material-ui/core/Card"
 import CardContent from "@material-ui/core/CardContent"
 import Typography from "@material-ui/core/Typography"
-import { AccountsContext } from "../context/accounts"
-import { SettingsContext } from "../context/settings"
+import AppSettings from "../components/AppSettings/AppSettings"
 import { Box, VerticalLayout } from "../components/Layout/Box"
 import MainTitle from "../components/MainTitle"
-import ToggleSection from "../components/Layout/ToggleSection"
 import { Section } from "../components/Layout/Page"
 import { useIsMobile, useRouter } from "../hooks/userinterface"
-import { biometricLockAvailable } from "../platform/settings"
 import * as routes from "../routes"
 
 // tslint:disable-next-line
 const pkg = require("../../package.json")
-
-function Settings() {
-  const { accounts } = React.useContext(AccountsContext)
-  const settings = React.useContext(SettingsContext)
-  const hasTestnetAccount = accounts.some(account => account.testnet)
-  const [bioLockAvailable, setBioLockAvailable] = React.useState(false)
-
-  React.useEffect(() => {
-    biometricLockAvailable().then(setBioLockAvailable)
-  }, [biometricLockAvailable])
-
-  return (
-    <>
-      <ToggleSection
-        disabled={!settings.biometricLockUsable}
-        checked={settings.biometricLock && settings.biometricLockUsable}
-        onChange={settings.toggleBiometricLock}
-        style={bioLockAvailable ? {} : { display: "none" }}
-        title={process.env.PLATFORM === "ios" ? "Face ID / Touch ID" : "Fingerprint Lock"}
-      >
-        <Typography
-          color={settings.biometricLock ? "initial" : "textSecondary"}
-          style={{ margin: "8px 0 0" }}
-          variant="body2"
-        >
-          Enable this option to lock the app whenever you leave it. Unlock it using biometric authentication (usually
-          your fingerprint).
-        </Typography>
-      </ToggleSection>
-      <ToggleSection
-        checked={settings.showTestnet}
-        disabled={hasTestnetAccount}
-        onChange={settings.toggleTestnet}
-        title="Show Testnet Accounts"
-      >
-        <Typography
-          color={settings.showTestnet ? "initial" : "textSecondary"}
-          style={{ margin: "8px 0 0" }}
-          variant="body2"
-        >
-          The test network is a copy of the main Stellar network were the traded tokens have no real-world value. You
-          can request free testnet XLM from the so-called friendbot to activate a testnet account and get started
-          without owning any actual funds.
-        </Typography>
-        <Typography
-          color={settings.showTestnet ? "initial" : "textSecondary"}
-          style={{ margin: "12px 0 0" }}
-          variant="body2"
-        >
-          Note: Testnet accounts will always be shown if you have got testnet accounts already.
-        </Typography>
-      </ToggleSection>
-      <ToggleSection
-        checked={settings.hideMemos}
-        onChange={settings.toggleHideMemos}
-        title="Hide memos in transactions overview"
-      >
-        <Typography
-          color={settings.hideMemos ? undefined : "textSecondary"}
-          style={{ margin: "8px 0 0" }}
-          variant="body2"
-        >
-          Memos are text messages that can be included with transactions. Enable this option to hide them in the
-          overview. They will still be shown in the detailed view of a transaction.
-        </Typography>
-      </ToggleSection>
-      <ToggleSection
-        checked={settings.multiSignature}
-        onChange={settings.toggleMultiSignature}
-        title="Enable Multi-Signature"
-      >
-        <Typography
-          color={settings.multiSignature ? "initial" : "textSecondary"}
-          style={{ margin: "8px 0 0" }}
-          variant="body2"
-        >
-          <b>Experimental feature:</b> Add co-signers to an account, define that all signers of an account have to sign
-          transactions unanimously or a certain subset of signers have to sign a transaction in order to be valid.
-        </Typography>
-      </ToggleSection>
-    </>
-  )
-}
 
 function SettingsPage() {
   const isSmallScreen = useIsMobile()
@@ -127,13 +41,23 @@ function SettingsPage() {
 
   return (
     <VerticalLayout height="100%">
-      <Section top brandColored grow={0}>
+      <Section top brandColored grow={0} shrink={0}>
         {headerCard}
       </Section>
-      <Section bottom style={{ display: "flex", paddingTop: 0, flexDirection: "column", overflowY: "auto" }}>
-        <VerticalLayout height="100%" padding="0 8px" grow>
-          <Box grow margin={isSmallScreen ? "0 -8px" : "24px 4px"} padding="0 8px" overflowY="auto">
-            <Settings />
+      <Section
+        bottom={isSmallScreen}
+        style={{
+          backgroundColor: "#fcfcfc",
+          height: "100%",
+          flexGrow: 1,
+          flexShrink: 1,
+          padding: isSmallScreen ? undefined : "0 24px",
+          overflowY: "auto"
+        }}
+      >
+        <VerticalLayout height="100%" grow>
+          <Box grow overflowY="auto">
+            <AppSettings />
           </Box>
           <Box grow={0} margin="16px 0 0">
             <Typography align="center" color="textSecondary">

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -101,26 +101,34 @@ function Settings() {
 function SettingsPage() {
   const isSmallScreen = useIsMobile()
   const router = useRouter()
+
+  const headerCard = React.useMemo(
+    () => (
+      <Card
+        style={{
+          color: "white",
+          position: "relative",
+          background: "transparent",
+          boxShadow: "none"
+        }}
+      >
+        <CardContent style={{ padding: isSmallScreen ? 8 : undefined, paddingBottom: 8 }}>
+          <MainTitle
+            onBack={() => router.history.push(routes.allAccounts())}
+            title="Settings"
+            titleColor="inherit"
+            style={{ marginTop: -12, marginLeft: 0 }}
+          />
+        </CardContent>
+      </Card>
+    ),
+    [isSmallScreen, router]
+  )
+
   return (
-    <>
-      <Section top brandColored style={{ flexGrow: 0 }}>
-        <Card
-          style={{
-            color: "white",
-            position: "relative",
-            background: "transparent",
-            boxShadow: "none"
-          }}
-        >
-          <CardContent style={{ paddingTop: 16, paddingBottom: 16 }}>
-            <MainTitle
-              onBack={() => router.history.push(routes.allAccounts())}
-              style={{ margin: "-12px 0 -10px", minHeight: 56 }}
-              title="Settings"
-              titleColor="inherit"
-            />
-          </CardContent>
-        </Card>
+    <VerticalLayout height="100%">
+      <Section top brandColored grow={0}>
+        {headerCard}
       </Section>
       <Section bottom style={{ display: "flex", paddingTop: 0, flexDirection: "column", overflowY: "auto" }}>
         <VerticalLayout height="100%" padding="0 8px" grow>
@@ -134,7 +142,7 @@ function SettingsPage() {
           </Box>
         </VerticalLayout>
       </Section>
-    </>
+    </VerticalLayout>
   )
 }
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -59,7 +59,7 @@ function SettingsPage() {
           <Box grow overflowY="auto">
             <AppSettings />
           </Box>
-          <Box grow={0} margin="16px 0 0">
+          <Box grow={0} margin="16px 0">
             <Typography align="center" color="textSecondary">
               v{pkg.version}
             </Typography>


### PR DESCRIPTION
This PR changes the style of the app settings so that they look similar to the account settings.

- [x] Add an `AppSettings` component which is similar to the existing `AccountSettings` component
- [x] Add toggle sections to enable/disable every settings
- [x] Adjust the style of the header of the `settings`-page so that it matches alignment of the `account`-page header

Previews:
<img width="1440" alt="Screenshot 2020-01-23 at 17 42 18" src="https://user-images.githubusercontent.com/6690623/73004516-bd4f3780-3e07-11ea-8957-02bd92a6f798.png">

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-01-23 at 17 42 03](https://user-images.githubusercontent.com/6690623/73004523-c213eb80-3e07-11ea-9df6-e14b6039e34d.png)


