### PR TITLE
Fix console errors related to asset selector

### DIFF
--- a/src/components/Form/AssetSelector.tsx
+++ b/src/components/Form/AssetSelector.tsx
@@ -33,8 +33,10 @@ interface AssetItemProps {
 const AssetItem = React.memo(
   React.forwardRef(function AssetItem(props: AssetItemProps, ref: React.Ref<HTMLLIElement>) {
     const classes = useAssetItemStyles()
+    const { testnet, ...reducedProps } = props
+
     return (
-      <MenuItem {...props} ref={ref} value={stringifyAsset(props.asset)}>
+      <MenuItem {...reducedProps} ref={ref} value={stringifyAsset(props.asset)}>
         <ListItemIcon className={classes.icon}>
           <AssetLogo asset={props.asset} className={classes.logo} testnet={props.testnet} />
         </ListItemIcon>

--- a/src/components/Form/AssetSelector.tsx
+++ b/src/components/Form/AssetSelector.tsx
@@ -28,6 +28,9 @@ const useAssetItemStyles = makeStyles(theme => ({
 interface AssetItemProps {
   asset: Asset
   testnet: boolean
+  // key + value props are expected here from React/Material-ui validation mechanisms
+  key: string
+  value: string
 }
 
 const AssetItem = React.memo(
@@ -36,7 +39,7 @@ const AssetItem = React.memo(
     const { testnet, ...reducedProps } = props
 
     return (
-      <MenuItem {...reducedProps} ref={ref} value={stringifyAsset(props.asset)}>
+      <MenuItem {...reducedProps} key={props.key} ref={ref} value={props.value}>
         <ListItemIcon className={classes.icon}>
           <AssetLogo asset={props.asset} className={classes.logo} testnet={props.testnet} />
         </ListItemIcon>
@@ -106,7 +109,7 @@ function AssetSelector(props: AssetSelectorProps) {
       placeholder="Select an asset"
       select
       style={{ flexShrink: 0, ...props.style }}
-      value={props.value ? stringifyAsset(props.value) : ""}
+      value={props.value ? props.value.getCode() : ""}
       FormHelperTextProps={{
         className: classes.helperText
       }}
@@ -133,12 +136,18 @@ function AssetSelector(props: AssetSelectorProps) {
           Select an asset
         </MenuItem>
       )}
-      <AssetItem asset={Asset.native()} testnet={props.testnet} />
+      <AssetItem
+        asset={Asset.native()}
+        key={stringifyAsset(Asset.native())}
+        testnet={props.testnet}
+        value={Asset.native().getCode()}
+      />
       {props.trustlines
         .filter(trustline => trustline.asset_type !== "native")
-        .map(trustline => (
-          <AssetItem asset={balancelineToAsset(trustline)} key={stringifyAsset(trustline)} testnet={props.testnet} />
-        ))}
+        .map(trustline => {
+          const asset = balancelineToAsset(trustline)
+          return <AssetItem asset={asset} key={stringifyAsset(asset)} testnet={props.testnet} value={asset.getCode()} />
+        })}
     </TextField>
   )
 }


### PR DESCRIPTION
This PR adds changes that remove console error and warning messages thrown in the Trading view.

- [x] Don't pass the `testnet` to the `<MenuItem>` component
- [x] Add the `key` prop to the `<AssetItem>` component because React expects the children of list components to have a unique `key` prop 
- [x] Add the `value` prop to the `<AssetItem>` component because Material-UI expects the children of the `SelectInput` component to carry a `value` prop
- [x] Change the `value` passed to `<TextField>` from `stringifyAsset(props.value)` to `props.value.getCode()` so that it matches the value displayed in the TextField
