### PR TITLE
Add trusted service management

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -141,6 +141,12 @@
           "shown": "Testnet accounts are shown"
         }
       }
+    },
+    "trusted-services": {
+      "text": {
+        "primary": "Manage Trusted Services",
+        "secondary": "Remove Trusted Services"
+      }
     }
   },
   "asset-details": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -442,6 +442,20 @@
       "no-threshold": "Please set a threshold"
     }
   },
+  "manage-trusted-services": {
+    "info": "Trusted Services are domains whose (SEP-0007) requests will be processed without requiring additional confirmation from you. You can choose to add a new service to this list every time you receive a request from an unknown domain.",
+    "service-selection": {
+      "actions": {
+        "cancel": "Cancel",
+        "confirm": "Confirm"
+      },
+      "confirm": {
+        "title": "Confirm removal",
+        "text": "The service will be removed from your trust list. Are you sure?"
+      },
+      "no-services": "No trusted services"
+    }
+  },
   "operations": {
     "account-merge": {
       "summary": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -443,7 +443,7 @@
     }
   },
   "manage-trusted-services": {
-    "info": "Trusted Services are domains whose (SEP-0007) requests will be processed without requiring additional confirmation from you. You can choose to add a new service to this list every time you receive a request from an unknown domain.",
+    "info": "Trusted Services are web services that are allowed to interact with Solar wallet by requesting account data or proposing transactions. You can add a new service once it tries to interact with Solar.",
     "service-selection": {
       "actions": {
         "cancel": "Cancel",

--- a/shared/types/platform.d.ts
+++ b/shared/types/platform.d.ts
@@ -1,3 +1,8 @@
+interface TrustedService {
+  domain: string
+  signingKey: string
+}
+
 declare namespace Platform {
   export interface SettingsData {
     agreedToTermsAt?: string
@@ -7,6 +12,7 @@ declare namespace Platform {
     hideMemos: boolean
   }
 }
+
 declare namespace NodeJS {
   interface Process {
     browser?: boolean

--- a/shared/types/platform.d.ts
+++ b/shared/types/platform.d.ts
@@ -7,9 +7,10 @@ declare namespace Platform {
   export interface SettingsData {
     agreedToTermsAt?: string
     biometricLock: boolean
+    hideMemos: boolean
     multisignature: boolean
     testnet: boolean
-    hideMemos: boolean
+    trustedServices: TrustedService[]
   }
 }
 

--- a/src/app-stage2.tsx
+++ b/src/app-stage2.tsx
@@ -4,7 +4,6 @@ import AndroidBackButton from "./components/AndroidBackButton"
 import DesktopNotifications from "./components/DesktopNotifications"
 import ErrorBoundary from "./components/ErrorBoundary"
 import { VerticalLayout } from "./components/Layout/Box"
-import withFallback from "./components/Lazy/withFallback"
 import LinkHandler from "./components/LinkHandler"
 import ConnectionErrorListener from "./components/Toasts/ConnectionErrorListener"
 import NotificationContainer from "./components/Toasts/NotificationContainer"
@@ -38,7 +37,14 @@ function Stage2() {
                   </React.Suspense>
                 )}
               />
-              <Route exact path="/settings" component={withFallback(SettingsPage, null)} />
+              <Route
+                path={["/settings/:action", "/settings"]}
+                render={() => (
+                  <React.Suspense fallback={null}>
+                    <SettingsPage />
+                  </React.Suspense>
+                )}
+              />
             </Switch>
           </ErrorBoundary>
         </VerticalLayout>

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import Dialog from "@material-ui/core/Dialog"
 import List from "@material-ui/core/List"
+import ListItemIcon from "@material-ui/core/ListItemIcon"
+import { makeStyles } from "@material-ui/core"
 import Switch from "@material-ui/core/Switch"
 import ArrowRightIcon from "@material-ui/icons/KeyboardArrowRight"
 import FingerprintIcon from "@material-ui/icons/Fingerprint"
@@ -12,12 +14,11 @@ import TrustIcon from "@material-ui/icons/VerifiedUser"
 import { AccountsContext } from "../../context/accounts"
 import { SettingsContext } from "../../context/settings"
 import { useIsMobile, useRouter } from "../../hooks/userinterface"
-import * as routes from "../../routes"
-import { matchesRoute } from "../../lib/routes"
 import { FullscreenDialogTransition } from "../../theme"
+import { matchesRoute } from "../../lib/routes"
+import * as routes from "../../routes"
 import AppSettingsItem from "./AppSettingsItem"
 import ManageTrustedServicesDialog from "./ManageTrustedServicesDialog"
-import { ListItemIcon } from "@material-ui/core"
 
 interface SettingsToggleProps {
   checked: boolean
@@ -53,7 +54,25 @@ function SettingsDialogs() {
   )
 }
 
+const useAppSettingsStyles = makeStyles({
+  caret: {
+    color: "rgba(0, 0, 0, 0.35)",
+    fontSize: 48,
+    justifyContent: "center",
+    marginRight: -8,
+    width: 48
+  },
+  icon: {
+    fontSize: 28,
+    justifyContent: "center",
+    marginRight: 4,
+    width: 28
+  }
+})
+
 function AppSettings() {
+  const classes = useAppSettingsStyles()
+
   const isSmallScreen = useIsMobile()
   const { t } = useTranslation()
   const router = useRouter()
@@ -78,7 +97,7 @@ function AppSettings() {
                 onChange={settings.toggleBiometricLock}
               />
             }
-            icon={<FingerprintIcon style={{ fontSize: "100%" }} />}
+            icon={<FingerprintIcon className={classes.icon} />}
             onClick={settings.biometricAvailability.enrolled ? settings.toggleBiometricLock : undefined}
             primaryText={t("app-settings.biometric-lock.text.primary")}
             secondaryText={
@@ -98,7 +117,7 @@ function AppSettings() {
               onChange={settings.toggleTestnet}
             />
           }
-          icon={<TestnetIcon style={{ fontSize: "100%" }} />}
+          icon={<TestnetIcon className={classes.icon} />}
           onClick={hasTestnetAccount ? undefined : settings.toggleTestnet}
           primaryText="Show Testnet Accounts"
           secondaryText={
@@ -111,7 +130,7 @@ function AppSettings() {
         />
         <AppSettingsItem
           actions={<SettingsToggle checked={!settings.hideMemos} onChange={settings.toggleHideMemos} />}
-          icon={<MessageIcon style={{ fontSize: "100%" }} />}
+          icon={<MessageIcon className={classes.icon} />}
           onClick={settings.toggleHideMemos}
           primaryText={t("app-settings.memo.text.primary")}
           secondaryText={
@@ -122,7 +141,7 @@ function AppSettings() {
         />
         <AppSettingsItem
           actions={<SettingsToggle checked={settings.multiSignature} onChange={settings.toggleMultiSignature} />}
-          icon={<GroupIcon style={{ fontSize: "100%" }} />}
+          icon={<GroupIcon className={classes.icon} />}
           onClick={settings.toggleMultiSignature}
           primaryText={t("app-settings.multi-sig.text.primary")}
           secondaryText={
@@ -133,11 +152,11 @@ function AppSettings() {
         />
         <AppSettingsItem
           actions={
-            <ListItemIcon>
-              <ArrowRightIcon style={{ fontSize: "100%" }} />
+            <ListItemIcon className={classes.caret}>
+              <ArrowRightIcon className={classes.caret} />
             </ListItemIcon>
           }
-          icon={<TrustIcon style={{ fontSize: "100%" }} />}
+          icon={<TrustIcon className={classes.icon} />}
           onClick={navigateToTrustedServices}
           primaryText={t("app-settings.trusted-services.text.primary")}
           secondaryText={t("app-settings.trusted-services.text.secondary")}

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import Dialog from "@material-ui/core/Dialog"
 import List from "@material-ui/core/List"
 import ListItemIcon from "@material-ui/core/ListItemIcon"
 import { makeStyles } from "@material-ui/core"
@@ -14,9 +13,9 @@ import TrustIcon from "@material-ui/icons/VerifiedUser"
 import { AccountsContext } from "../../context/accounts"
 import { SettingsContext } from "../../context/settings"
 import { useIsMobile, useRouter } from "../../hooks/userinterface"
-import { FullscreenDialogTransition } from "../../theme"
 import { matchesRoute } from "../../lib/routes"
 import * as routes from "../../routes"
+import Carousel from "../Layout/Carousel"
 import AppSettingsItem from "./AppSettingsItem"
 import ManageTrustedServicesDialog from "./ManageTrustedServicesDialog"
 
@@ -42,16 +41,11 @@ function SettingsDialogs() {
   const showManageTrustedServices = matchesRoute(router.location.pathname, routes.manageTrustedServices())
   const navigateToSettings = React.useCallback(() => router.history.push(routes.settings()), [router.history])
 
-  return (
-    <Dialog
-      fullScreen
-      open={showManageTrustedServices}
-      onClose={navigateToSettings}
-      TransitionComponent={FullscreenDialogTransition}
-    >
-      <ManageTrustedServicesDialog onClose={navigateToSettings} />
-    </Dialog>
-  )
+  const ShownDialog = React.useMemo(() => {
+    return showManageTrustedServices ? <ManageTrustedServicesDialog onClose={navigateToSettings} /> : <></>
+  }, [showManageTrustedServices, navigateToSettings])
+
+  return ShownDialog
 }
 
 const useAppSettingsStyles = makeStyles({
@@ -77,6 +71,8 @@ function AppSettings() {
   const { t } = useTranslation()
   const router = useRouter()
 
+  const showSettingsOverview = matchesRoute(router.location.pathname, routes.settings(), true)
+
   const { accounts } = React.useContext(AccountsContext)
   const settings = React.useContext(SettingsContext)
 
@@ -86,7 +82,7 @@ function AppSettings() {
   ])
 
   return (
-    <>
+    <Carousel current={showSettingsOverview ? 0 : 1}>
       <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
         {settings.biometricAvailability.available ? (
           <AppSettingsItem
@@ -163,7 +159,7 @@ function AppSettings() {
         />
       </List>
       <SettingsDialogs />
-    </>
+    </Carousel>
   )
 }
 

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -39,11 +39,10 @@ function SettingsDialogs() {
   const router = useRouter()
 
   const showManageTrustedServices = matchesRoute(router.location.pathname, routes.manageTrustedServices())
-  const navigateToSettings = React.useCallback(() => router.history.push(routes.settings()), [router.history])
 
   const ShownDialog = React.useMemo(() => {
-    return showManageTrustedServices ? <ManageTrustedServicesDialog onClose={navigateToSettings} /> : <></>
-  }, [showManageTrustedServices, navigateToSettings])
+    return showManageTrustedServices ? <ManageTrustedServicesDialog /> : <></>
+  }, [showManageTrustedServices])
 
   return ShownDialog
 }

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -1,15 +1,23 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
+import Dialog from "@material-ui/core/Dialog"
 import List from "@material-ui/core/List"
 import Switch from "@material-ui/core/Switch"
+import ArrowRightIcon from "@material-ui/icons/KeyboardArrowRight"
 import FingerprintIcon from "@material-ui/icons/Fingerprint"
 import GroupIcon from "@material-ui/icons/Group"
 import MessageIcon from "@material-ui/icons/Message"
 import TestnetIcon from "@material-ui/icons/MoneyOff"
+import TrustIcon from "@material-ui/icons/VerifiedUser"
 import { AccountsContext } from "../../context/accounts"
 import { SettingsContext } from "../../context/settings"
-import { useIsMobile } from "../../hooks/userinterface"
+import { useIsMobile, useRouter } from "../../hooks/userinterface"
+import * as routes from "../../routes"
+import { matchesRoute } from "../../lib/routes"
+import { FullscreenDialogTransition } from "../../theme"
 import AppSettingsItem from "./AppSettingsItem"
+import ManageTrustedServicesDialog from "./ManageTrustedServicesDialog"
+import { ListItemIcon } from "@material-ui/core"
 
 interface SettingsToggleProps {
   checked: boolean
@@ -24,21 +32,39 @@ function SettingsToggle(props: SettingsToggleProps) {
     onChange(event.target.checked)
   }
 
+  return <Switch checked={checked} color="primary" disabled={disabled} onChange={handleChange} />
+}
+
+function SettingsDialogs() {
+  const router = useRouter()
+
+  const showManageTrustedServices = matchesRoute(router.location.pathname, routes.manageTrustedServices())
+  const navigateToSettings = React.useCallback(() => router.history.push(routes.settings()), [router.history])
+
   return (
-    <>
-      <Switch checked={checked} color="primary" disabled={disabled} onChange={handleChange} />
-    </>
+    <Dialog
+      fullScreen
+      open={showManageTrustedServices}
+      onClose={navigateToSettings}
+      TransitionComponent={FullscreenDialogTransition}
+    >
+      <ManageTrustedServicesDialog onClose={navigateToSettings} />
+    </Dialog>
   )
 }
 
 function AppSettings() {
   const isSmallScreen = useIsMobile()
   const { t } = useTranslation()
+  const router = useRouter()
 
   const { accounts } = React.useContext(AccountsContext)
   const settings = React.useContext(SettingsContext)
 
   const hasTestnetAccount = accounts.some(account => account.testnet)
+  const navigateToTrustedServices = React.useCallback(() => router.history.push(routes.manageTrustedServices()), [
+    router.history
+  ])
 
   return (
     <>
@@ -105,7 +131,19 @@ function AppSettings() {
               : t("app-settings.multi-sig.text.secondary.disabled")
           }
         />
+        <AppSettingsItem
+          actions={
+            <ListItemIcon>
+              <ArrowRightIcon style={{ fontSize: "100%" }} />
+            </ListItemIcon>
+          }
+          icon={<TrustIcon style={{ fontSize: "100%" }} />}
+          onClick={navigateToTrustedServices}
+          primaryText={t("app-settings.trusted-services.text.primary")}
+          secondaryText={t("app-settings.trusted-services.text.secondary")}
+        />
       </List>
+      <SettingsDialogs />
     </>
   )
 }

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -80,7 +80,7 @@ function AppSettings() {
     router.history
   ])
 
-  const trustedServicesEnabled = process.env.TRUSTED_SERVICES
+  const trustedServicesEnabled = process.env.TRUSTED_SERVICES && process.env.TRUSTED_SERVICES === "enabled"
 
   return (
     <Carousel current={showSettingsOverview ? 0 : 1}>

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -80,6 +80,8 @@ function AppSettings() {
     router.history
   ])
 
+  const trustedServicesEnabled = process.env.TRUSTED_SERVICES
+
   return (
     <Carousel current={showSettingsOverview ? 0 : 1}>
       <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
@@ -145,17 +147,21 @@ function AppSettings() {
               : t("app-settings.multi-sig.text.secondary.disabled")
           }
         />
-        <AppSettingsItem
-          actions={
-            <ListItemIcon className={classes.caret}>
-              <ArrowRightIcon className={classes.caret} />
-            </ListItemIcon>
-          }
-          icon={<TrustIcon className={classes.icon} />}
-          onClick={navigateToTrustedServices}
-          primaryText={t("app-settings.trusted-services.text.primary")}
-          secondaryText={t("app-settings.trusted-services.text.secondary")}
-        />
+        {trustedServicesEnabled ? (
+          <AppSettingsItem
+            actions={
+              <ListItemIcon className={classes.caret}>
+                <ArrowRightIcon className={classes.caret} />
+              </ListItemIcon>
+            }
+            icon={<TrustIcon className={classes.icon} />}
+            onClick={navigateToTrustedServices}
+            primaryText={t("app-settings.trusted-services.text.primary")}
+            secondaryText={t("app-settings.trusted-services.text.secondary")}
+          />
+        ) : (
+          undefined
+        )}
       </List>
       <SettingsDialogs />
     </Carousel>

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -35,17 +35,12 @@ function SettingsToggle(props: SettingsToggleProps) {
   return <Switch checked={checked} color="primary" disabled={disabled} onChange={handleChange} />
 }
 
-function SettingsDialogs() {
+const SettingsDialogs = React.memo(function SettingsDialogs() {
   const router = useRouter()
-
   const showManageTrustedServices = matchesRoute(router.location.pathname, routes.manageTrustedServices())
 
-  const ShownDialog = React.useMemo(() => {
-    return showManageTrustedServices ? <ManageTrustedServicesDialog /> : <></>
-  }, [showManageTrustedServices])
-
-  return ShownDialog
-}
+  return showManageTrustedServices ? <ManageTrustedServicesDialog /> : <></>
+})
 
 const useAppSettingsStyles = makeStyles({
   caret: {

--- a/src/components/AppSettings/ManageTrustedServicesDialog.tsx
+++ b/src/components/AppSettings/ManageTrustedServicesDialog.tsx
@@ -11,7 +11,7 @@ function ManageTrustedServicesDialog() {
   return (
     <DialogBody>
       <DialogContent style={{ flexGrow: 0, padding: 0 }}>
-        <DialogContentText align="justify" style={{ marginTop: 24 }}>
+        <DialogContentText align="justify" style={{ marginTop: 8 }}>
           {t("manage-trusted-services.info")}
         </DialogContentText>
 

--- a/src/components/AppSettings/ManageTrustedServicesDialog.tsx
+++ b/src/components/AppSettings/ManageTrustedServicesDialog.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import DialogContent from "@material-ui/core/DialogContent"
+import DialogContentText from "@material-ui/core/DialogContentText"
+import DialogBody from "../Dialog/DialogBody"
+import MainTitle from "../MainTitle"
+import TrustedServiceSelectionList from "./TrustedServiceSelectionList"
+
+interface ManageTrustedServicesDialogProps {
+  onClose: () => void
+}
+
+function ManageTrustedServicesDialog(props: ManageTrustedServicesDialogProps) {
+  return (
+    <DialogBody
+      top={
+        <MainTitle
+          title="View Trusted Services"
+          titleColor="inherit"
+          onBack={props.onClose}
+          style={{ marginTop: 0, marginLeft: 0 }}
+        />
+      }
+    >
+      <DialogContent style={{ flexGrow: 0, padding: 0 }}>
+        <DialogContentText align="justify" style={{ marginTop: 24 }}>
+          Trusted Services are domains whose (SEP-0007) requests will be processed without requiring additional
+          confirmation from you. You can choose to add a new service to this list every time you receive a request from
+          an unknown domain.
+        </DialogContentText>
+
+        <TrustedServiceSelectionList />
+      </DialogContent>
+    </DialogBody>
+  )
+}
+
+export default React.memo(ManageTrustedServicesDialog)

--- a/src/components/AppSettings/ManageTrustedServicesDialog.tsx
+++ b/src/components/AppSettings/ManageTrustedServicesDialog.tsx
@@ -2,25 +2,11 @@ import React from "react"
 import DialogContent from "@material-ui/core/DialogContent"
 import DialogContentText from "@material-ui/core/DialogContentText"
 import DialogBody from "../Dialog/DialogBody"
-import MainTitle from "../MainTitle"
 import TrustedServiceSelectionList from "./TrustedServiceSelectionList"
 
-interface ManageTrustedServicesDialogProps {
-  onClose: () => void
-}
-
-function ManageTrustedServicesDialog(props: ManageTrustedServicesDialogProps) {
+function ManageTrustedServicesDialog() {
   return (
-    <DialogBody
-      top={
-        <MainTitle
-          title="View Trusted Services"
-          titleColor="inherit"
-          onBack={props.onClose}
-          style={{ marginTop: 0, marginLeft: 0 }}
-        />
-      }
-    >
+    <DialogBody>
       <DialogContent style={{ flexGrow: 0, padding: 0 }}>
         <DialogContentText align="justify" style={{ marginTop: 24 }}>
           Trusted Services are domains whose (SEP-0007) requests will be processed without requiring additional

--- a/src/components/AppSettings/ManageTrustedServicesDialog.tsx
+++ b/src/components/AppSettings/ManageTrustedServicesDialog.tsx
@@ -1,17 +1,18 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import DialogContent from "@material-ui/core/DialogContent"
 import DialogContentText from "@material-ui/core/DialogContentText"
 import DialogBody from "../Dialog/DialogBody"
 import TrustedServiceSelectionList from "./TrustedServiceSelectionList"
 
 function ManageTrustedServicesDialog() {
+  const { t } = useTranslation()
+
   return (
     <DialogBody>
       <DialogContent style={{ flexGrow: 0, padding: 0 }}>
         <DialogContentText align="justify" style={{ marginTop: 24 }}>
-          Trusted Services are domains whose (SEP-0007) requests will be processed without requiring additional
-          confirmation from you. You can choose to add a new service to this list every time you receive a request from
-          an unknown domain.
+          {t("manage-trusted-services.info")}
         </DialogContentText>
 
         <TrustedServiceSelectionList />

--- a/src/components/AppSettings/TrustedServiceSelectionList.tsx
+++ b/src/components/AppSettings/TrustedServiceSelectionList.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import Avatar from "@material-ui/core/Avatar"
 import CloudIcon from "@material-ui/icons/Cloud"
 import RemoveIcon from "@material-ui/icons/RemoveCircle"
@@ -30,6 +31,8 @@ function TrustedServiceList() {
   const { setSetting, trustedServices } = React.useContext(SettingsContext)
   const [confirmationPending, setConfirmationPending] = React.useState(false)
   const [selectedIndex, setSelectedIndex] = React.useState(-1)
+
+  const { t } = useTranslation()
 
   const onDelete = () => {
     const selectedService = trustedServices[selectedIndex]
@@ -64,21 +67,27 @@ function TrustedServiceList() {
             />
           ))}
         {trustedServices.length === 0 ? (
-          <Typography className={classes.typography}>(No trusted services)</Typography>
+          <Typography className={classes.typography}>
+            ({t("manage-trusted-services.service-selection.no-services")})
+          </Typography>
         ) : null}
       </List>
       <ConfirmDialog
-        cancelButton={<ActionButton onClick={() => setConfirmationPending(false)}>Cancel</ActionButton>}
+        cancelButton={
+          <ActionButton onClick={() => setConfirmationPending(false)}>
+            {t("manage-trusted-services.service-selection.actions.cancel")}
+          </ActionButton>
+        }
         confirmButton={
           <ActionButton onClick={onConfirm} type="primary">
-            Confirm
+            {t("manage-trusted-services.service-selection.actions.confirm")}
           </ActionButton>
         }
         open={confirmationPending}
         onClose={() => setConfirmationPending(false)}
-        title="Confirm removal"
+        title={t("manage-trusted-services.service-selection.confirm.title")}
       >
-        The service will be removed from your trust list. Are you sure?
+        {t("manage-trusted-services.service-selection.confirm.text")}
       </ConfirmDialog>
     </>
   )

--- a/src/components/AppSettings/TrustedServiceSelectionList.tsx
+++ b/src/components/AppSettings/TrustedServiceSelectionList.tsx
@@ -1,0 +1,116 @@
+import React from "react"
+import DeleteIcon from "@material-ui/icons/Delete"
+import IconButton from "@material-ui/core/IconButton"
+import List from "@material-ui/core/List"
+import ListItem from "@material-ui/core/ListItem"
+import ListItemIcon from "@material-ui/core/ListItemIcon"
+import ListItemText from "@material-ui/core/ListItemText"
+import Typography from "@material-ui/core/Typography"
+import { makeStyles } from "@material-ui/core/styles"
+import { SettingsContext } from "../../context/settings"
+import { useIsMobile } from "../../hooks/userinterface"
+import { ActionButton, ConfirmDialog } from "../Dialog/Generic"
+import { Address } from "../PublicKey"
+
+const isMobileDevice = process.env.PLATFORM === "android" || process.env.PLATFORM === "ios"
+
+function TrustedServiceList() {
+  const { setSetting, trustedServices } = React.useContext(SettingsContext)
+  const [confirmationPending, setConfirmationPending] = React.useState(false)
+  const [selectedIndex, setSelectedIndex] = React.useState(-1)
+
+  const onDelete = () => {
+    const selectedService = trustedServices[selectedIndex]
+    if (!selectedService) {
+      return
+    }
+
+    const newTrustedServices = trustedServices.filter(service => service.domain !== selectedService.domain)
+    setSetting("trustedServices", newTrustedServices)
+  }
+
+  const onConfirm = () => {
+    setConfirmationPending(false)
+    setSelectedIndex(-1)
+    onDelete()
+  }
+
+  return (
+    <>
+      <List style={{ background: "transparent", paddingLeft: 0, paddingRight: 0 }}>
+        {trustedServices.map((service, index) => (
+          <TrustedServiceListItem
+            index={index}
+            key={service.domain}
+            onDeleteClick={() => {
+              setSelectedIndex(index)
+              setConfirmationPending(true)
+            }}
+            trustedService={service}
+          />
+        ))}
+        {trustedServices.length === 0 ? (
+          <Typography style={{ opacity: 0.7, textAlign: "center" }}>(No trusted services)</Typography>
+        ) : null}
+      </List>
+      <ConfirmDialog
+        cancelButton={<ActionButton onClick={() => setConfirmationPending(false)}>Cancel</ActionButton>}
+        confirmButton={
+          <ActionButton onClick={onConfirm} type="primary">
+            Confirm
+          </ActionButton>
+        }
+        open={confirmationPending}
+        onClose={() => setConfirmationPending(false)}
+        title="Confirm removal"
+      >
+        The service will be removed from your trust list. Are you sure?
+      </ConfirmDialog>
+    </>
+  )
+}
+
+const useTrustedServiceListItemStyles = makeStyles({
+  listItem: {
+    background: "#FFFFFF",
+    boxShadow: "0 8px 16px 0 rgba(0, 0, 0, 0.1)",
+    "&:focus": {
+      backgroundColor: "#FFFFFF"
+    },
+    "&:hover": {
+      backgroundColor: isMobileDevice ? "#FFFFFF" : "rgb(232, 232, 232)"
+    }
+  }
+})
+
+interface TrustedServiceListItemProps {
+  index: number
+  onClick?: (event: React.MouseEvent, index: number) => void
+  onDeleteClick?: (event: React.MouseEvent, index: number) => void
+  trustedService: TrustedService
+  style?: React.CSSProperties
+}
+
+const TrustedServiceListItem = React.memo(function TrustedServiceListItem(props: TrustedServiceListItemProps) {
+  const classes = useTrustedServiceListItemStyles()
+  const isSmallScreen = useIsMobile()
+
+  return (
+    <ListItem button className={classes.listItem} onClick={event => props.onClick && props.onClick(event, props.index)}>
+      <ListItemIcon style={{ marginRight: 0 }}>
+        <div />
+      </ListItemIcon>
+      <ListItemText
+        primary={props.trustedService.domain}
+        secondary={<Address address={props.trustedService.signingKey} variant={isSmallScreen ? "short" : "full"} />}
+      />
+      <ListItemIcon style={{ marginRight: 0 }}>
+        <IconButton onClick={event => props.onDeleteClick && props.onDeleteClick(event, props.index)}>
+          <DeleteIcon />
+        </IconButton>
+      </ListItemIcon>
+    </ListItem>
+  )
+} as React.ComponentType<TrustedServiceListItemProps>)
+
+export default TrustedServiceList

--- a/src/components/AppSettings/TrustedServiceSelectionList.tsx
+++ b/src/components/AppSettings/TrustedServiceSelectionList.tsx
@@ -14,85 +14,6 @@ import { SettingsContext } from "../../context/settings"
 import { useStellarToml } from "../../hooks/stellar"
 import { ActionButton, ConfirmDialog } from "../Dialog/Generic"
 
-const useTrustedServiceListStyles = makeStyles({
-  list: {
-    background: "transparent",
-    paddingBottom: 16
-  },
-  typography: {
-    opacity: 0.7,
-    textAlign: "center"
-  }
-})
-
-function TrustedServiceList() {
-  const classes = useTrustedServiceListStyles()
-
-  const { setSetting, trustedServices } = React.useContext(SettingsContext)
-  const [confirmationPending, setConfirmationPending] = React.useState(false)
-  const [selectedIndex, setSelectedIndex] = React.useState(-1)
-
-  const { t } = useTranslation()
-
-  const onDelete = () => {
-    const selectedService = trustedServices[selectedIndex]
-    if (!selectedService) {
-      return
-    }
-
-    const newTrustedServices = trustedServices.filter(service => service.domain !== selectedService.domain)
-    setSetting("trustedServices", newTrustedServices)
-  }
-
-  const onConfirm = () => {
-    setConfirmationPending(false)
-    setSelectedIndex(-1)
-    onDelete()
-  }
-
-  return (
-    <>
-      <List className={classes.list}>
-        {trustedServices
-          .sort((a, b) => a.domain.localeCompare(b.domain))
-          .map((service, index) => (
-            <TrustedServiceListItem
-              index={index}
-              key={service.domain}
-              onDeleteClick={() => {
-                setSelectedIndex(index)
-                setConfirmationPending(true)
-              }}
-              trustedService={service}
-            />
-          ))}
-        {trustedServices.length === 0 ? (
-          <Typography className={classes.typography}>
-            ({t("manage-trusted-services.service-selection.no-services")})
-          </Typography>
-        ) : null}
-      </List>
-      <ConfirmDialog
-        cancelButton={
-          <ActionButton onClick={() => setConfirmationPending(false)}>
-            {t("manage-trusted-services.service-selection.actions.cancel")}
-          </ActionButton>
-        }
-        confirmButton={
-          <ActionButton onClick={onConfirm} type="primary">
-            {t("manage-trusted-services.service-selection.actions.confirm")}
-          </ActionButton>
-        }
-        open={confirmationPending}
-        onClose={() => setConfirmationPending(false)}
-        title={t("manage-trusted-services.service-selection.confirm.title")}
-      >
-        {t("manage-trusted-services.service-selection.confirm.text")}
-      </ConfirmDialog>
-    </>
-  )
-}
-
 const useTrustedServiceListItemStyles = makeStyles({
   listItem: {
     background: "#FFFFFF",
@@ -147,6 +68,80 @@ const TrustedServiceListItem = React.memo(function TrustedServiceListItem(props:
       </ListItemIcon>
     </ListItem>
   )
-} as React.ComponentType<TrustedServiceListItemProps>)
+})
 
-export default TrustedServiceList
+const useTrustedServiceListStyles = makeStyles({
+  list: {
+    background: "transparent",
+    paddingBottom: 16
+  }
+})
+
+const TrustedServiceList = React.memo(function TrustedServiceList() {
+  const classes = useTrustedServiceListStyles()
+
+  const { t } = useTranslation()
+  const { setSetting, trustedServices } = React.useContext(SettingsContext)
+  const [confirmationPending, setConfirmationPending] = React.useState(false)
+  const [selectedIndex, setSelectedIndex] = React.useState(-1)
+
+  const onDelete = () => {
+    const selectedService = trustedServices[selectedIndex]
+    if (!selectedService) {
+      return
+    }
+
+    const newTrustedServices = trustedServices.filter(service => service.domain !== selectedService.domain)
+    setSetting("trustedServices", newTrustedServices)
+  }
+
+  const onConfirm = () => {
+    setConfirmationPending(false)
+    setSelectedIndex(-1)
+    onDelete()
+  }
+
+  return (
+    <>
+      <List className={classes.list}>
+        {trustedServices
+          .sort((a, b) => a.domain.localeCompare(b.domain))
+          .map((service, index) => (
+            <TrustedServiceListItem
+              index={index}
+              key={service.domain}
+              onDeleteClick={() => {
+                setSelectedIndex(index)
+                setConfirmationPending(true)
+              }}
+              trustedService={service}
+            />
+          ))}
+      </List>
+      {trustedServices.length === 0 ? (
+        <Typography align="center" color="textSecondary">
+          ({t("manage-trusted-services.service-selection.no-services")})
+        </Typography>
+      ) : null}
+      <ConfirmDialog
+        cancelButton={
+          <ActionButton onClick={() => setConfirmationPending(false)}>
+            {t("manage-trusted-services.service-selection.actions.cancel")}
+          </ActionButton>
+        }
+        confirmButton={
+          <ActionButton onClick={onConfirm} type="primary">
+            {t("manage-trusted-services.service-selection.actions.confirm")}
+          </ActionButton>
+        }
+        open={confirmationPending}
+        onClose={() => setConfirmationPending(false)}
+        title={t("manage-trusted-services.service-selection.confirm.title")}
+      >
+        {t("manage-trusted-services.service-selection.confirm.text")}
+      </ConfirmDialog>
+    </>
+  )
+})
+
+export default React.memo(TrustedServiceList)

--- a/src/components/AppSettings/TrustedServiceSelectionList.tsx
+++ b/src/components/AppSettings/TrustedServiceSelectionList.tsx
@@ -1,5 +1,7 @@
 import React from "react"
-import DeleteIcon from "@material-ui/icons/Delete"
+import Avatar from "@material-ui/core/Avatar"
+import CloudIcon from "@material-ui/icons/Cloud"
+import RemoveIcon from "@material-ui/icons/RemoveCircle"
 import IconButton from "@material-ui/core/IconButton"
 import List from "@material-ui/core/List"
 import ListItem from "@material-ui/core/ListItem"
@@ -8,11 +10,8 @@ import ListItemText from "@material-ui/core/ListItemText"
 import Typography from "@material-ui/core/Typography"
 import { makeStyles } from "@material-ui/core/styles"
 import { SettingsContext } from "../../context/settings"
-import { useIsMobile } from "../../hooks/userinterface"
+import { useStellarToml } from "../../hooks/stellar"
 import { ActionButton, ConfirmDialog } from "../Dialog/Generic"
-import { Address } from "../PublicKey"
-
-const isMobileDevice = process.env.PLATFORM === "android" || process.env.PLATFORM === "ios"
 
 function TrustedServiceList() {
   const { setSetting, trustedServices } = React.useContext(SettingsContext)
@@ -76,16 +75,18 @@ const useTrustedServiceListItemStyles = makeStyles({
     boxShadow: "0 8px 16px 0 rgba(0, 0, 0, 0.1)",
     "&:focus": {
       backgroundColor: "#FFFFFF"
-    },
-    "&:hover": {
-      backgroundColor: isMobileDevice ? "#FFFFFF" : "rgb(232, 232, 232)"
     }
+  },
+  cloudAvatar: {
+    backgroundColor: "rgba(0, 0, 0, 0.54)"
+  },
+  logoAvatar: {
+    backgroundColor: "white"
   }
 })
 
 interface TrustedServiceListItemProps {
   index: number
-  onClick?: (event: React.MouseEvent, index: number) => void
   onDeleteClick?: (event: React.MouseEvent, index: number) => void
   trustedService: TrustedService
   style?: React.CSSProperties
@@ -93,20 +94,26 @@ interface TrustedServiceListItemProps {
 
 const TrustedServiceListItem = React.memo(function TrustedServiceListItem(props: TrustedServiceListItemProps) {
   const classes = useTrustedServiceListItemStyles()
-  const isSmallScreen = useIsMobile()
+
+  const stellarToml = useStellarToml(props.trustedService.domain)
+  const imageURL = stellarToml && stellarToml.DOCUMENTATION && stellarToml.DOCUMENTATION.ORG_LOGO
+  const orgName = stellarToml && stellarToml.DOCUMENTATION && stellarToml.DOCUMENTATION.ORG_NAME
 
   return (
-    <ListItem button className={classes.listItem} onClick={event => props.onClick && props.onClick(event, props.index)}>
+    <ListItem className={classes.listItem}>
       <ListItemIcon style={{ marginRight: 0 }}>
-        <div />
+        {imageURL ? (
+          <Avatar alt={name} className={classes.logoAvatar} src={imageURL} />
+        ) : (
+          <Avatar alt={name} className={classes.cloudAvatar}>
+            <CloudIcon />
+          </Avatar>
+        )}
       </ListItemIcon>
-      <ListItemText
-        primary={props.trustedService.domain}
-        secondary={<Address address={props.trustedService.signingKey} variant={isSmallScreen ? "short" : "full"} />}
-      />
+      <ListItemText primary={orgName ? orgName : props.trustedService.domain} secondary={props.trustedService.domain} />
       <ListItemIcon style={{ marginRight: 0 }}>
         <IconButton onClick={event => props.onDeleteClick && props.onDeleteClick(event, props.index)}>
-          <DeleteIcon />
+          <RemoveIcon />
         </IconButton>
       </ListItemIcon>
     </ListItem>

--- a/src/components/AppSettings/TrustedServiceSelectionList.tsx
+++ b/src/components/AppSettings/TrustedServiceSelectionList.tsx
@@ -37,17 +37,19 @@ function TrustedServiceList() {
   return (
     <>
       <List style={{ background: "transparent", paddingLeft: 0, paddingRight: 0 }}>
-        {trustedServices.map((service, index) => (
-          <TrustedServiceListItem
-            index={index}
-            key={service.domain}
-            onDeleteClick={() => {
-              setSelectedIndex(index)
-              setConfirmationPending(true)
-            }}
-            trustedService={service}
-          />
-        ))}
+        {trustedServices
+          .sort((a, b) => a.domain.localeCompare(b.domain))
+          .map((service, index) => (
+            <TrustedServiceListItem
+              index={index}
+              key={service.domain}
+              onDeleteClick={() => {
+                setSelectedIndex(index)
+                setConfirmationPending(true)
+              }}
+              trustedService={service}
+            />
+          ))}
         {trustedServices.length === 0 ? (
           <Typography style={{ opacity: 0.7, textAlign: "center" }}>(No trusted services)</Typography>
         ) : null}

--- a/src/components/AppSettings/TrustedServiceSelectionList.tsx
+++ b/src/components/AppSettings/TrustedServiceSelectionList.tsx
@@ -13,7 +13,20 @@ import { SettingsContext } from "../../context/settings"
 import { useStellarToml } from "../../hooks/stellar"
 import { ActionButton, ConfirmDialog } from "../Dialog/Generic"
 
+const useTrustedServiceListStyles = makeStyles({
+  list: {
+    background: "transparent",
+    paddingBottom: 16
+  },
+  typography: {
+    opacity: 0.7,
+    textAlign: "center"
+  }
+})
+
 function TrustedServiceList() {
+  const classes = useTrustedServiceListStyles()
+
   const { setSetting, trustedServices } = React.useContext(SettingsContext)
   const [confirmationPending, setConfirmationPending] = React.useState(false)
   const [selectedIndex, setSelectedIndex] = React.useState(-1)
@@ -36,7 +49,7 @@ function TrustedServiceList() {
 
   return (
     <>
-      <List style={{ background: "transparent", paddingLeft: 0, paddingRight: 0 }}>
+      <List className={classes.list}>
         {trustedServices
           .sort((a, b) => a.domain.localeCompare(b.domain))
           .map((service, index) => (
@@ -51,7 +64,7 @@ function TrustedServiceList() {
             />
           ))}
         {trustedServices.length === 0 ? (
-          <Typography style={{ opacity: 0.7, textAlign: "center" }}>(No trusted services)</Typography>
+          <Typography className={classes.typography}>(No trusted services)</Typography>
         ) : null}
       </List>
       <ConfirmDialog
@@ -74,9 +87,14 @@ function TrustedServiceList() {
 const useTrustedServiceListItemStyles = makeStyles({
   listItem: {
     background: "#FFFFFF",
-    boxShadow: "0 8px 16px 0 rgba(0, 0, 0, 0.1)",
-    "&:focus": {
-      backgroundColor: "#FFFFFF"
+    boxShadow: "0 8px 12px 0 rgba(0, 0, 0, 0.1)",
+    "&:first-child": {
+      borderTopLeftRadius: 8,
+      borderTopRightRadius: 8
+    },
+    "&:last-child": {
+      borderBottomLeftRadius: 8,
+      borderBottomRightRadius: 8
     }
   },
   cloudAvatar: {

--- a/src/context/settings.tsx
+++ b/src/context/settings.tsx
@@ -18,17 +18,19 @@ interface ContextType {
   biometricLock: boolean
   biometricAvailability: BiometricAvailability
   confirmToC: () => void
+  hideMemos: boolean
   ignoreSignatureRequest: (signatureRequestHash: string) => void
   ignoredSignatureRequests: string[]
   initialized: boolean
   multiSignature: boolean
   multiSignatureServiceURL: string
+  setSetting: (key: keyof Platform.SettingsData, value: any) => void
   showTestnet: boolean
-  hideMemos: boolean
   toggleBiometricLock: () => void
   toggleMultiSignature: () => void
   toggleTestnet: () => void
   toggleHideMemos: () => void
+  trustedServices: TrustedService[]
 }
 
 interface SettingsState extends Platform.SettingsData {
@@ -38,10 +40,11 @@ interface SettingsState extends Platform.SettingsData {
 const initialSettings: SettingsState = {
   agreedToTermsAt: undefined,
   biometricLock: false,
+  hideMemos: false,
   initialized: false,
   multisignature: false,
   testnet: false,
-  hideMemos: false
+  trustedServices: []
 }
 
 const initialIgnoredSignatureRequests: string[] = []
@@ -53,17 +56,19 @@ const SettingsContext = React.createContext<ContextType>({
   biometricLock: initialSettings.biometricLock,
   biometricAvailability: { available: false, enrolled: false },
   confirmToC: () => undefined,
+  hideMemos: initialSettings.hideMemos,
   ignoreSignatureRequest: () => undefined,
   ignoredSignatureRequests: initialIgnoredSignatureRequests,
   initialized: false,
   multiSignature: initialSettings.multisignature,
   multiSignatureServiceURL,
+  setSetting: () => undefined,
   showTestnet: initialSettings.testnet,
-  hideMemos: initialSettings.hideMemos,
   toggleBiometricLock: () => undefined,
   toggleMultiSignature: () => undefined,
   toggleTestnet: () => undefined,
-  toggleHideMemos: () => undefined
+  toggleHideMemos: () => undefined,
+  trustedServices: initialSettings.trustedServices
 })
 
 export function SettingsProvider(props: Props) {
@@ -126,22 +131,30 @@ export function SettingsProvider(props: Props) {
       .catch(trackError)
   }
 
+  const setSetting = (key: keyof Platform.SettingsData, value: any) => {
+    const partial: Partial<Platform.SettingsData> = {}
+    partial[key] = value
+    updateSettings(partial)
+  }
+
   const contextValue: ContextType = {
     agreedToTermsAt: settings.agreedToTermsAt,
     biometricLock: settings.biometricLock,
     biometricAvailability,
     confirmToC,
+    hideMemos: settings.hideMemos,
     ignoreSignatureRequest,
     ignoredSignatureRequests,
     initialized: settings.initialized,
     multiSignature: settings.multisignature,
     multiSignatureServiceURL,
+    setSetting,
     showTestnet: settings.testnet,
-    hideMemos: settings.hideMemos,
     toggleBiometricLock,
     toggleMultiSignature,
     toggleTestnet,
-    toggleHideMemos
+    toggleHideMemos,
+    trustedServices: settings.trustedServices
   }
 
   return <SettingsContext.Provider value={contextValue}>{props.children}</SettingsContext.Provider>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -41,7 +41,7 @@ function SettingsPage() {
 
   return (
     <VerticalLayout height="100%">
-      <Section top brandColored grow={0}>
+      <Section top brandColored grow={0} shrink={0}>
         {headerCard}
       </Section>
       <Section

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -7,6 +7,7 @@ import { Box, VerticalLayout } from "../components/Layout/Box"
 import MainTitle from "../components/MainTitle"
 import { Section } from "../components/Layout/Page"
 import { useIsMobile, useRouter } from "../hooks/userinterface"
+import { matchesRoute } from "../lib/routes"
 import * as routes from "../routes"
 
 // tslint:disable-next-line
@@ -15,6 +16,14 @@ const pkg = require("../../package.json")
 function SettingsPage() {
   const isSmallScreen = useIsMobile()
   const router = useRouter()
+
+  const showSettingsOverview = matchesRoute(router.location.pathname, routes.settings(), true)
+
+  const navigateToAllAccounts = React.useCallback(() => {
+    router.history.push(routes.allAccounts())
+  }, [router.history])
+
+  const navigateToSettingsOverview = React.useCallback(() => router.history.push(routes.settings()), [router.history])
 
   const headerCard = React.useMemo(
     () => (
@@ -28,7 +37,7 @@ function SettingsPage() {
       >
         <CardContent style={{ padding: isSmallScreen ? 8 : undefined, paddingBottom: 8 }}>
           <MainTitle
-            onBack={() => router.history.push(routes.allAccounts())}
+            onBack={showSettingsOverview ? navigateToAllAccounts : navigateToSettingsOverview}
             title="Settings"
             titleColor="inherit"
             style={{ marginTop: -12, marginLeft: 0 }}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -41,7 +41,7 @@ function SettingsPage() {
 
   return (
     <VerticalLayout height="100%">
-      <Section top brandColored grow={0} shrink={0}>
+      <Section top brandColored grow={0}>
         {headerCard}
       </Section>
       <Section

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,6 +14,7 @@ export const exportSecretKey = (accountID: string) => `/account/${accountID}/set
 export const receivePayment = (accountID: string) => `/account/${accountID}/receive`
 export const manageAccountAssets = (accountID: string) => `/account/${accountID}/balances/manage`
 export const manageAccountSigners = (accountID: string) => `/account/${accountID}/settings/signers`
+export const manageTrustedServices = () => "/settings/trusted-services"
 export const settings = () => "/settings"
 export const withdrawAsset = (accountID: string) => `/account/${accountID}/withdraw`
 export const showTransaction = (accountID: string, transactionHash: string) =>


### PR DESCRIPTION
Adds the option to manage trusted services in the app settings.

- [x] Add trusted services to settings context
- [x] Add `<ManageTrustedServicesDialog>`
- [x] Add `/settings/trusted-services` route
- [x] Add `<TrustedServiceSelectionList>` component which shows all currently saved trusted services and offers the possibility to remove them
- [x] Add settings item for opening the trusted service dialog from app settings

 