### PR TITLE
Fix Carousel not shown properly in initial state

### DIFF
--- a/src/components/Layout/Carousel.tsx
+++ b/src/components/Layout/Carousel.tsx
@@ -37,14 +37,37 @@ interface CarouselProps {
 
 function Carousel(props: CarouselProps) {
   const classes = useCarouselStyles(props)
+
+  // workaround to prevent misalignment of children on initial render
+  const refs: Array<React.RefObject<HTMLDivElement>> = props.children.map(() => React.createRef<HTMLDivElement>())
+  React.useEffect(() => {
+    refs.forEach((ref, index) => {
+      if (ref.current) {
+        ref.current.style.visibility = index === props.current ? "visible" : "hidden"
+      }
+    })
+
+    setTimeout(() => {
+      refs.forEach(ref => {
+        if (ref.current) {
+          ref.current.style.visibility = "visible"
+        }
+      })
+    }, 0)
+  }, [props.current])
+
   return (
     <div className={classes.root}>
       <div className={classes.sledge}>
         {props.children.map((content, index) => (
           <div
+            ref={refs[index]}
             key={index}
             className={[classes.slide, index === props.current ? classes.active : ""].join(" ")}
-            style={{ flex: "0 0 100%", transform: `translateX(${-100 * props.current}%)` }}
+            style={{
+              flex: "0 0 100%",
+              transform: `translateX(${-100 * props.current}%)`
+            }}
           >
             {content}
           </div>


### PR DESCRIPTION
Introduces a workaround to fix a bug where the children of  the `Carousel` in the `TradingDialog` were misaligned on initial render .

This bug might have occurred because the dimension of the `<TradingForm>` changed shortly after the initial render but this is just a guess.

It's fixed by setting the visibility of all children except the 'current' to `hidden` at first and changing it back to `visible` after a short timeout.