### PR TITLE
Show disabled biometric authentication in settings view if available

### DIFF
--- a/electron/src/ipc/bio-auth.ts
+++ b/electron/src/ipc/bio-auth.ts
@@ -1,4 +1,4 @@
-import { expose } from "./_ipc"
 import { Messages } from "../shared/ipc"
+import { expose } from "./_ipc"
 
-expose(Messages.BioAuthAvailable, () => false)
+expose(Messages.BioAuthAvailable, () => ({ available: false }))

--- a/electron/src/ipc/bio-auth.ts
+++ b/electron/src/ipc/bio-auth.ts
@@ -1,4 +1,4 @@
 import { Messages } from "../shared/ipc"
 import { expose } from "./_ipc"
 
-expose(Messages.BioAuthAvailable, () => ({ available: false }))
+expose(Messages.BioAuthAvailable, () => ({ available: false, enrolled: false }))

--- a/shared/types/ipc.d.ts
+++ b/shared/types/ipc.d.ts
@@ -52,7 +52,7 @@ declare namespace IPC {
     [Messages.ShowSplashScreen]: () => void
     [Messages.HideSplashScreen]: () => void
 
-    [Messages.BioAuthAvailable]: () => boolean
+    [Messages.BioAuthAvailable]: () => BiometricAvailabilityResult
     [Messages.TestBioAuth]: () => string | undefined
 
     [Messages.NotificationPermission]: () => NotificationPermission

--- a/shared/types/ipc.d.ts
+++ b/shared/types/ipc.d.ts
@@ -52,7 +52,7 @@ declare namespace IPC {
     [Messages.ShowSplashScreen]: () => void
     [Messages.HideSplashScreen]: () => void
 
-    [Messages.BioAuthAvailable]: () => BiometricAvailabilityResult
+    [Messages.BioAuthAvailable]: () => BiometricAvailability
     [Messages.TestBioAuth]: () => string | undefined
 
     [Messages.NotificationPermission]: () => NotificationPermission

--- a/shared/types/platform.d.ts
+++ b/shared/types/platform.d.ts
@@ -12,3 +12,9 @@ declare namespace NodeJS {
     browser?: boolean
   }
 }
+
+interface BiometricAvailabilityResult {
+  available: boolean
+  code?: number
+  message?: string
+}

--- a/shared/types/platform.d.ts
+++ b/shared/types/platform.d.ts
@@ -13,8 +13,7 @@ declare namespace NodeJS {
   }
 }
 
-interface BiometricAvailabilityResult {
+interface BiometricAvailability {
   available: boolean
-  code?: number
-  message?: string
+  enrolled: boolean
 }

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -55,7 +55,7 @@ function AppSettings() {
             primaryText="Biometric authentication"
             secondaryText={
               !settings.biometricAvailability.enrolled
-                ? "Cannot be enabled because you are not enrolled in biometric authentication"
+                ? "Configure biometric authentication in your operating system settings"
                 : settings.biometricLock
                 ? "Biometric authentication is enabled"
                 : "Biometric authentication is disabled"

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -36,25 +36,45 @@ function AppSettings() {
   const { accounts } = React.useContext(AccountsContext)
   const settings = React.useContext(SettingsContext)
 
+  const [biometricAuthAvailable, setBiometricAuthAvailable] = React.useState(false)
+  const [biometricAuthEnrolled, setBiometricAuthEnrolled] = React.useState(false)
+
+  React.useEffect(() => {
+    if (settings.biometricAuthAvailability.available) {
+      setBiometricAuthAvailable(true)
+      setBiometricAuthEnrolled(true)
+    } else {
+      // code -106 means 'BIOMETRIC_NOT_ENROLLED' (cordova fingerprint plugin)
+      // hence biometric auth is available but not currently set up
+      if (settings.biometricAuthAvailability.code === -106) {
+        setBiometricAuthAvailable(true)
+      }
+    }
+  }, [settings.biometricAuthAvailability])
+
   const hasTestnetAccount = accounts.some(account => account.testnet)
 
   return (
     <>
       <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
-        {settings.biometricLockUsable ? (
+        {biometricAuthAvailable ? (
           <AppSettingsItem
             actions={
               <SettingsToggle
-                checked={settings.biometricLock && settings.biometricLockUsable}
-                disabled={!settings.biometricLockUsable}
+                checked={settings.biometricLock && biometricAuthEnrolled}
+                disabled={!biometricAuthEnrolled}
                 onChange={settings.toggleBiometricLock}
               />
             }
             icon={<FingerprintIcon style={{ fontSize: "100%" }} />}
-            onClick={settings.toggleBiometricLock}
+            onClick={biometricAuthEnrolled ? settings.toggleBiometricLock : undefined}
             primaryText="Biometric authentication"
             secondaryText={
-              settings.biometricLock ? "Biometric authentication is enabled" : "Biometric authentication is disabled"
+              !biometricAuthEnrolled
+                ? "Cannot be enabled because you are not enrolled in biometric authentication"
+                : settings.biometricLock
+                ? "Biometric authentication is enabled"
+                : "Biometric authentication is disabled"
             }
           />
         ) : null}

--- a/src/components/AppSettings/AppSettings.tsx
+++ b/src/components/AppSettings/AppSettings.tsx
@@ -36,41 +36,25 @@ function AppSettings() {
   const { accounts } = React.useContext(AccountsContext)
   const settings = React.useContext(SettingsContext)
 
-  const [biometricAuthAvailable, setBiometricAuthAvailable] = React.useState(false)
-  const [biometricAuthEnrolled, setBiometricAuthEnrolled] = React.useState(false)
-
-  React.useEffect(() => {
-    if (settings.biometricAuthAvailability.available) {
-      setBiometricAuthAvailable(true)
-      setBiometricAuthEnrolled(true)
-    } else {
-      // code -106 means 'BIOMETRIC_NOT_ENROLLED' (cordova fingerprint plugin)
-      // hence biometric auth is available but not currently set up
-      if (settings.biometricAuthAvailability.code === -106) {
-        setBiometricAuthAvailable(true)
-      }
-    }
-  }, [settings.biometricAuthAvailability])
-
   const hasTestnetAccount = accounts.some(account => account.testnet)
 
   return (
     <>
       <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
-        {biometricAuthAvailable ? (
+        {settings.biometricAvailability.available ? (
           <AppSettingsItem
             actions={
               <SettingsToggle
-                checked={settings.biometricLock && biometricAuthEnrolled}
-                disabled={!biometricAuthEnrolled}
+                checked={settings.biometricLock && settings.biometricAvailability.enrolled}
+                disabled={!settings.biometricAvailability.enrolled}
                 onChange={settings.toggleBiometricLock}
               />
             }
             icon={<FingerprintIcon style={{ fontSize: "100%" }} />}
-            onClick={biometricAuthEnrolled ? settings.toggleBiometricLock : undefined}
+            onClick={settings.biometricAvailability.enrolled ? settings.toggleBiometricLock : undefined}
             primaryText="Biometric authentication"
             secondaryText={
-              !biometricAuthEnrolled
+              !settings.biometricAvailability.enrolled
                 ? "Cannot be enabled because you are not enrolled in biometric authentication"
                 : settings.biometricLock
                 ? "Biometric authentication is enabled"

--- a/src/context/settings.tsx
+++ b/src/context/settings.tsx
@@ -15,7 +15,7 @@ interface Props {
 interface ContextType {
   agreedToTermsAt: string | undefined
   biometricLock: boolean
-  biometricAuthAvailability: BiometricAvailabilityResult
+  biometricAvailability: BiometricAvailability
   confirmToC: () => void
   ignoreSignatureRequest: (signatureRequestHash: string) => void
   ignoredSignatureRequests: string[]
@@ -50,7 +50,7 @@ const multiSignatureServiceURL = process.env.MULTISIG_SERVICE || "https://multis
 const SettingsContext = React.createContext<ContextType>({
   agreedToTermsAt: initialSettings.agreedToTermsAt,
   biometricLock: initialSettings.biometricLock,
-  biometricAuthAvailability: { available: false },
+  biometricAvailability: { available: false, enrolled: false },
   confirmToC: () => undefined,
   ignoreSignatureRequest: () => undefined,
   ignoredSignatureRequests: initialIgnoredSignatureRequests,
@@ -68,8 +68,9 @@ const SettingsContext = React.createContext<ContextType>({
 export function SettingsProvider(props: Props) {
   const [ignoredSignatureRequests, setIgnoredSignatureRequests] = React.useState(initialIgnoredSignatureRequests)
   const [settings, setSettings] = React.useState<SettingsState>(initialSettings)
-  const [biometricAuthAvailability, setBiometricAuthAvailability] = React.useState<BiometricAvailabilityResult>({
-    available: false
+  const [biometricAvailability, setBiometricAvailability] = React.useState<BiometricAvailability>({
+    available: false,
+    enrolled: false
   })
 
   React.useEffect(() => {
@@ -80,7 +81,7 @@ export function SettingsProvider(props: Props) {
       })
       .catch(trackError)
 
-    isBiometricAuthAvailable().then(setBiometricAuthAvailability)
+    isBiometricAuthAvailable().then(setBiometricAvailability)
 
     // Can't really cancel loading the settings
     const unsubscribe = () => undefined
@@ -126,7 +127,7 @@ export function SettingsProvider(props: Props) {
   const contextValue: ContextType = {
     agreedToTermsAt: settings.agreedToTermsAt,
     biometricLock: settings.biometricLock,
-    biometricAuthAvailability,
+    biometricAvailability,
     confirmToC,
     ignoreSignatureRequest,
     ignoredSignatureRequests,

--- a/src/context/settings.tsx
+++ b/src/context/settings.tsx
@@ -15,7 +15,7 @@ interface Props {
 interface ContextType {
   agreedToTermsAt: string | undefined
   biometricLock: boolean
-  biometricLockUsable: boolean
+  biometricAuthAvailability: BiometricAvailabilityResult
   confirmToC: () => void
   ignoreSignatureRequest: (signatureRequestHash: string) => void
   ignoredSignatureRequests: string[]
@@ -50,7 +50,7 @@ const multiSignatureServiceURL = process.env.MULTISIG_SERVICE || "https://multis
 const SettingsContext = React.createContext<ContextType>({
   agreedToTermsAt: initialSettings.agreedToTermsAt,
   biometricLock: initialSettings.biometricLock,
-  biometricLockUsable: false,
+  biometricAuthAvailability: { available: false },
   confirmToC: () => undefined,
   ignoreSignatureRequest: () => undefined,
   ignoredSignatureRequests: initialIgnoredSignatureRequests,
@@ -68,7 +68,9 @@ const SettingsContext = React.createContext<ContextType>({
 export function SettingsProvider(props: Props) {
   const [ignoredSignatureRequests, setIgnoredSignatureRequests] = React.useState(initialIgnoredSignatureRequests)
   const [settings, setSettings] = React.useState<SettingsState>(initialSettings)
-  const [biometricLockUsable, setBiometricLockUsable] = React.useState(false)
+  const [biometricAuthAvailability, setBiometricAuthAvailability] = React.useState<BiometricAvailabilityResult>({
+    available: false
+  })
 
   React.useEffect(() => {
     Promise.all([loadIgnoredSignatureRequestHashes(), loadSettings()])
@@ -78,9 +80,7 @@ export function SettingsProvider(props: Props) {
       })
       .catch(trackError)
 
-    isBiometricAuthAvailable().then(available => {
-      setBiometricLockUsable(available)
-    })
+    isBiometricAuthAvailable().then(setBiometricAuthAvailability)
 
     // Can't really cancel loading the settings
     const unsubscribe = () => undefined
@@ -126,7 +126,7 @@ export function SettingsProvider(props: Props) {
   const contextValue: ContextType = {
     agreedToTermsAt: settings.agreedToTermsAt,
     biometricLock: settings.biometricLock,
-    biometricLockUsable,
+    biometricAuthAvailability,
     confirmToC,
     ignoreSignatureRequest,
     ignoredSignatureRequests,

--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -16,7 +16,7 @@ import { registerNotificationHandler } from "./notifications"
 const iframe = document.getElementById("walletframe") as HTMLIFrameElement
 
 let bioAuthInProgress: Promise<void> | undefined
-let bioAuthAvailablePromise: Promise<BiometricAvailabilityResult>
+let bioAuthAvailablePromise: Promise<BiometricAvailability>
 let isBioAuthAvailable = false
 
 let lastNativeInteractionTime: number = 0

--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -16,7 +16,7 @@ import { registerNotificationHandler } from "./notifications"
 const iframe = document.getElementById("walletframe") as HTMLIFrameElement
 
 let bioAuthInProgress: Promise<void> | undefined
-let bioAuthAvailablePromise: Promise<boolean>
+let bioAuthAvailablePromise: Promise<BiometricAvailabilityResult>
 let isBioAuthAvailable = false
 
 let lastNativeInteractionTime: number = 0
@@ -75,7 +75,8 @@ function onDeviceReady() {
   // getCurrentSettings() won't be reliable
   initializeStorage(contentWindow)
     .then(async () => {
-      isBioAuthAvailable = await bioAuthAvailablePromise
+      const bioAuthAvailabilityResult = await bioAuthAvailablePromise
+      isBioAuthAvailable = bioAuthAvailabilityResult.available
 
       if (isBioAuthEnabled()) {
         await authenticate(contentWindow)
@@ -235,8 +236,8 @@ function setupBioAuthTestHandler() {
 function setupBioAuthAvailableHandler() {
   const messageHandler = async () => {
     const checkAuthAvailability = async () => {
-      const authAvailable = await isBiometricAuthAvailable()
-      return authAvailable
+      const authAvailableResult = await isBiometricAuthAvailable()
+      return authAvailableResult
       // sendSuccessResponse(contentWindow, event, authAvailable)
     }
 

--- a/src/cordova/bio-auth.ts
+++ b/src/cordova/bio-auth.ts
@@ -1,6 +1,13 @@
 export async function isBiometricAuthAvailable() {
-  return new Promise<boolean>(resolve => {
-    Fingerprint.isAvailable(() => resolve(true), () => resolve(false))
+  return new Promise<BiometricAvailabilityResult>(resolve => {
+    Fingerprint.isAvailable(
+      result => {
+        resolve({ available: true, message: result })
+      },
+      error => {
+        resolve({ available: false, message: error.message, code: error.code })
+      }
+    )
   })
 }
 

--- a/src/cordova/bio-auth.ts
+++ b/src/cordova/bio-auth.ts
@@ -1,11 +1,17 @@
 export async function isBiometricAuthAvailable() {
-  return new Promise<BiometricAvailabilityResult>(resolve => {
+  return new Promise<BiometricAvailability>(resolve => {
     Fingerprint.isAvailable(
-      result => {
-        resolve({ available: true, message: result })
+      () => {
+        resolve({ available: true, enrolled: true })
       },
       error => {
-        resolve({ available: false, message: error.message, code: error.code })
+        // code -106 means 'BIOMETRIC_NOT_ENROLLED' (cordova fingerprint plugin)
+        // hence biometric auth is available but not currently set up
+        if (error.code === -106) {
+          resolve({ available: true, enrolled: false })
+        } else {
+          resolve({ available: false, enrolled: false })
+        }
       }
     )
   })

--- a/src/platform/ipc.web.ts
+++ b/src/platform/ipc.web.ts
@@ -157,7 +157,7 @@ function initSettings() {
     hideMemos: false
   }
 
-  callHandlers[Messages.BioAuthAvailable] = () => false
+  callHandlers[Messages.BioAuthAvailable] = () => ({ available: false })
 
   callHandlers[Messages.ReadSettings] = () => settings
   callHandlers[Messages.StoreSettings] = (updatedSettings: Partial<Platform.SettingsData>) => {

--- a/src/platform/ipc.web.ts
+++ b/src/platform/ipc.web.ts
@@ -157,7 +157,7 @@ function initSettings() {
     hideMemos: false
   }
 
-  callHandlers[Messages.BioAuthAvailable] = () => ({ available: false })
+  callHandlers[Messages.BioAuthAvailable] = () => ({ available: false, enrolled: false })
 
   callHandlers[Messages.ReadSettings] = () => settings
   callHandlers[Messages.StoreSettings] = (updatedSettings: Partial<Platform.SettingsData>) => {

--- a/src/platform/settings.ts
+++ b/src/platform/settings.ts
@@ -2,7 +2,7 @@ import { call } from "./ipc"
 import { Messages } from "../shared/ipc"
 
 interface SettingsStore {
-  biometricAuthAvailable(): Promise<BiometricAvailabilityResult>
+  biometricAuthAvailable(): Promise<BiometricAvailability>
   loadIgnoredSignatureRequestHashes(): Promise<string[]>
   loadSettings(): Promise<Partial<Platform.SettingsData>>
   saveIgnoredSignatureRequestHashes(updatedSignatureRequestHashes: string[]): void

--- a/src/platform/settings.ts
+++ b/src/platform/settings.ts
@@ -2,7 +2,7 @@ import { call } from "./ipc"
 import { Messages } from "../shared/ipc"
 
 interface SettingsStore {
-  biometricLockAvailable(): Promise<boolean>
+  biometricAuthAvailable(): Promise<BiometricAvailabilityResult>
   loadIgnoredSignatureRequestHashes(): Promise<string[]>
   loadSettings(): Promise<Partial<Platform.SettingsData>>
   saveIgnoredSignatureRequestHashes(updatedSignatureRequestHashes: string[]): void
@@ -10,7 +10,7 @@ interface SettingsStore {
 }
 
 const implementation: SettingsStore = {
-  biometricLockAvailable: () => call(Messages.BioAuthAvailable),
+  biometricAuthAvailable: () => call(Messages.BioAuthAvailable),
   loadIgnoredSignatureRequestHashes: () => call(Messages.ReadIgnoredSignatureRequestHashes),
   saveIgnoredSignatureRequestHashes: updatedSignatureRequestHashes =>
     call(Messages.StoreIgnoredSignatureRequestHashes, updatedSignatureRequestHashes),
@@ -18,7 +18,7 @@ const implementation: SettingsStore = {
   saveSettings: settingsUpdate => call(Messages.StoreSettings, settingsUpdate)
 }
 
-export const biometricLockAvailable = implementation.biometricLockAvailable
+export const isBiometricAuthAvailable = implementation.biometricAuthAvailable
 
 export const loadIgnoredSignatureRequestHashes = implementation.loadIgnoredSignatureRequestHashes
 export const saveIgnoredSignatureRequestHashes = implementation.saveIgnoredSignatureRequestHashes


### PR DESCRIPTION
Shows the option for biometric authentication on devices that have a biometric authentication mechanism available but not currently enrolled.

Checks for the [BIOMETRIC_NOT_ENROLLED](https://github.com/NiklasMerz/cordova-plugin-fingerprint-aio#constants) error code from the 'biometric-auth-availability' request because this indicates that it is available but not enabled.

Changes some variable names containing `biometricLock` to `biometricAuth` to make it more clear that the auth mechanism is meant. So now `biometricLock` is always referring to the lock itself and `biometricAuth` and `biometricAvailability` are referring to the biometric authentication in general.

[Preview](https://user-images.githubusercontent.com/6690623/73379407-f15fa800-42a0-11ea-9e71-c2a5c1670bb9.png)

Closes #931.