### PR TITLE
Fix error concerning 'undefined' message on cordova

### DIFF
--- a/src/cordova/app.cordova.ts
+++ b/src/cordova/app.cordova.ts
@@ -181,9 +181,11 @@ function initializeStorage(contentWindow: Window) {
   window.addEventListener("message", async event => {
     const [secureStorage, keyStore] = await initPromise
 
-    const { messageType } = event.data
-    const payload = { args: event.data.args, callID: event.data.callID }
-    handleMessageEvent(messageType, payload, contentWindow, secureStorage, keyStore)
+    if (event.data && event.data.callID && event.data.messageType) {
+      const { messageType } = event.data
+      const payload = { args: event.data.args, callID: event.data.callID }
+      handleMessageEvent(messageType, payload, contentWindow, secureStorage, keyStore)
+    }
   })
 
   storageInitialization = initPromise.then(([secureStorage]) => secureStorage)

--- a/src/cordova/ipc.ts
+++ b/src/cordova/ipc.ts
@@ -21,6 +21,10 @@ export async function handleMessageEvent<Message extends keyof IPC.MessageType>(
 ) {
   const { args, callID } = payload
 
+  if (!messageType) {
+    throw Error("Missing messageType on call to handleMessageEvent() (defined in ipc.ts)")
+  }
+
   const messageHandler = commandHandlers[messageType]
   if (messageHandler) {
     try {


### PR DESCRIPTION
Check the availability of `messageType` on received messages before handling them.
The error message was thrown because the `app:ready` message event does not have a `messageType` associated with it but was passed to the handler anyways.