### PR TITLE
Fix 'wrong-password-error' not handled properly

### DIFF
--- a/src/components/TransactionSender.tsx
+++ b/src/components/TransactionSender.tsx
@@ -171,8 +171,10 @@ class TransactionSender extends React.Component<Props, State> {
     } catch (error) {
       if (isWrongPasswordError(error)) {
         this.setState({ passwordError: error })
+        return
+      } else {
+        throw error
       }
-      throw error
     }
 
     try {

--- a/src/cordova/keystore.ts
+++ b/src/cordova/keystore.ts
@@ -1,6 +1,7 @@
 import { KeyStore } from "key-store"
 import { Transaction, Keypair, Networks } from "stellar-sdk"
 import { Messages } from "../shared/ipc"
+import { WrongPasswordError } from "../lib/errors"
 import { CommandHandlers, expose } from "./ipc"
 
 export const commandHandlers: CommandHandlers = {
@@ -99,6 +100,6 @@ async function respondWithSignedTransaction(
       .toXDR()
       .toString("base64")
   } catch (error) {
-    throw Object.assign(new Error("Wrong password."), { name: "WrongPasswordError" })
+    throw WrongPasswordError()
   }
 }

--- a/src/platform/ipc.cordova.ts
+++ b/src/platform/ipc.cordova.ts
@@ -22,7 +22,7 @@ export function call<Message extends keyof IPC.MessageType>(
         unsubscribe()
 
         if ("error" in message && message.error) {
-          reject(Error(message.error.message))
+          reject(Object.assign(Error(message.error.message), { name: message.error.name }))
         } else {
           resolve((message as any).result)
         }

--- a/src/platform/ipc.electron.ts
+++ b/src/platform/ipc.electron.ts
@@ -21,7 +21,7 @@ export function call<Message extends keyof IPC.MessageType>(
       unsubscribe()
 
       if ("error" in message && message.error) {
-        reject(Error(message.error.message))
+        reject(Object.assign(Error(message.error.message), { name: message.error.name }))
       } else {
         resolve((message as ElectronIPCCallResultMessage).result)
       }

--- a/src/platform/ipc.web.ts
+++ b/src/platform/ipc.web.ts
@@ -1,6 +1,7 @@
 import { createStore, KeysData } from "key-store"
 import { Networks, Keypair, Transaction } from "stellar-sdk"
 import { Messages } from "../shared/ipc"
+import { WrongPasswordError } from "../lib/errors"
 
 type CallHandler = (...args: any) => any
 
@@ -141,7 +142,7 @@ function initKeyStore() {
         .toXDR()
         .toString("base64")
     } catch (error) {
-      throw Object.assign(new Error("Wrong password."), { name: "WrongPasswordError" })
+      throw WrongPasswordError()
     }
   }
 


### PR DESCRIPTION
Fixes a bug where the `WrongPasswordError` was re-thrown in the `TransactionSender` so that an uncaught promise rejection occurred.
