### PR TITLE
Show info for empty search results in 'Add Asset' dialog

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -92,6 +92,10 @@
           "one-asset": "One matching asset",
           "more-than-one-asset": "{{amount}} matching assets"
         }
+      },
+      "no-result": {
+        "primary": "No matching asset",
+        "secondary": "No asset or issuer matches your search"
       }
     },
     "search-field": {

--- a/src/components/AccountAssets/AddAssetDialog.tsx
+++ b/src/components/AccountAssets/AddAssetDialog.tsx
@@ -98,6 +98,11 @@ const useSearchResultStyles = makeStyles({
     background: "white",
     borderRadius: 8,
     height: searchResultRowHeight
+  },
+  noResultItem: {
+    background: "white",
+    borderRadius: 8,
+    height: searchResultRowHeight
   }
 })
 
@@ -167,8 +172,27 @@ function createSearchResultRow(
     )
   }
 
-  SearchResultRow.count = itemRenderMap.length
-  return SearchResultRow
+  function NoResultRow() {
+    const classes = useSearchResultStyles()
+    const { t } = useTranslation()
+
+    return (
+      <ListItem key={0} className={classes.noResultItem}>
+        <ListItemText
+          primary={t("add-asset.item.no-result.primary")}
+          secondary={t("add-asset.item.no-result.secondary")}
+        />
+      </ListItem>
+    )
+  }
+
+  if (itemRenderMap.length > 0) {
+    SearchResultRow.count = itemRenderMap.length
+    return SearchResultRow
+  } else {
+    NoResultRow.count = 1
+    return NoResultRow
+  }
 }
 
 const useAddAssetStyles = makeStyles({


### PR DESCRIPTION
Shows an info item in the list of search results in the 'Add Asset' dialog when no asset matches the users input. This improves the UX since this note clearly indicates that the search is done.

<img width="344" alt="Screenshot 2020-02-19 at 13 36 23" src="https://user-images.githubusercontent.com/6690623/74835170-12a23a00-531d-11ea-9744-f4319b28b1dc.png">
