### PR TITLE
Explicit timeouts for tx submission preparation requests

### DIFF
--- a/src/lib/promise.ts
+++ b/src/lib/promise.ts
@@ -1,0 +1,11 @@
+export const delay = (timeoutMs: number) => new Promise(resolve => setTimeout(resolve, timeoutMs))
+
+export async function applyTimeout<T, E>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  getTimeoutResult: () => E = () => {
+    throw Error(`Promise timed out after ${timeoutMs}ms`)
+  }
+): Promise<T | E> {
+  return Promise.race([promise, delay(timeoutMs).then(() => getTimeoutResult())])
+}


### PR DESCRIPTION
Explicitly fail with meaningful error message if one of the preparatory requests takes too long (like fetching latest fee stats, syncing time with horizon or fetching latest source account data).