### PR TITLE
Make toasts smaller on desktop

### DIFF
--- a/src/components/Toasts/Notification.tsx
+++ b/src/components/Toasts/Notification.tsx
@@ -44,7 +44,10 @@ const useNotificationStyles = makeStyles({
     alignItems: "center",
     display: "flex",
     overflow: "hidden",
-    width: "90vw"
+
+    [theme.breakpoints.down(600)]: {
+      width: "90vw"
+    }
   },
   messageText: {
     textOverflow: "ellipsis",


### PR DESCRIPTION
Looks weird if toasts are almost-full-width when not on mobile.