### PR TITLE
Check and export some more Android build env vars

### DIFF
--- a/cordova/scripts/signing-env-android.sh
+++ b/cordova/scripts/signing-env-android.sh
@@ -7,12 +7,24 @@ if [ -f "./$ENV_FILE" ]; then
   source "./$ENV_FILE"
 fi
 
+if [ -z "$KEYSTORE_LOCATION" ]; then
+  echo "KEYSTORE_LOCATION not set"
+  exit 1
+fi
+
+if [ -z "$SIGNINGKEY_ALIAS" ]; then
+  echo "SIGNINGKEY_ALIAS not set"
+  exit 1
+fi
+
 echo "Keystore Password: "
 read -s KEYSTORE_PASSWORD
 
 echo "Key Password: "
 read -s SIGNINGKEY_PASSWORD
 
+export CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL
+export JAVA_HOME
 export KEYSTORE_LOCATION
 export KEYSTORE_PASSWORD
 export SIGNINGKEY_ALIAS


### PR DESCRIPTION
@ebma Had to extend my `signing-env-android.sh` a bit when I wanted to build the Android APK locally on my machine. Didn't commit the change yet.