### PR TITLE
Disable app.setAsDefaultProtocolClient() for now

### DIFF
--- a/electron/src/bootstrap.ts
+++ b/electron/src/bootstrap.ts
@@ -1,5 +1,7 @@
 import { app } from "electron"
+
 // Needs to match the value in electron-build.yml
 app.setAppUserModelId("io.solarwallet.app")
 
-app.setAsDefaultProtocolClient("web+stellar")
+// Disabled until we actually ship SEP-7 support
+// app.setAsDefaultProtocolClient("web+stellar")


### PR DESCRIPTION
Until we actually roll-out SEP-7 support.