### PR TITLE
Ignore custom SEP-6 fields when using SEP-24 implementation

### DIFF
--- a/src/components/TransferService/TransferDetailsForm.tsx
+++ b/src/components/TransferService/TransferDetailsForm.tsx
@@ -3,6 +3,7 @@ import nanoid from "nanoid"
 import React from "react"
 import { Asset } from "stellar-sdk"
 import { AssetTransferInfo } from "@satoshipay/stellar-transfer"
+import { useStellarToml } from "../../hooks/stellar"
 import { RefStateObject } from "../../hooks/userinterface"
 import { useLoadingState } from "../../hooks/util"
 import theme from "../../theme"
@@ -136,6 +137,7 @@ function TransferDetailsForm(props: TransferDetailsFormProps) {
   const [submissionState, handleSubmission] = useLoadingState({ throwOnError: true })
 
   const assetInfo = props.assetTransferInfos.find(info => info.asset.equals(props.state.asset))
+  const stellarToml = useStellarToml(props.state.transferServer.domain)
 
   const [formValues, setFormValues] = React.useState<FormValues>(
     (props.state.formValues as Record<string, string>) || {}
@@ -173,7 +175,8 @@ function TransferDetailsForm(props: TransferDetailsFormProps) {
     }
   })()
 
-  const fields = methodMetadata && methodMetadata.fields ? methodMetadata.fields : {}
+  const isSEP24Anchor = Boolean(stellarToml && stellarToml.TRANSFER_SERVER_SEP0024)
+  const fields = methodMetadata && methodMetadata.fields && !isSEP24Anchor ? methodMetadata.fields : {}
 
   const automaticallySetValues = ["account", "asset_code", "type"]
   const emailField = fields.email || fields.email_address

--- a/src/types/stellar-toml.ts
+++ b/src/types/stellar-toml.ts
@@ -55,5 +55,7 @@ export type StellarToml = Partial<{
   DOCUMENTATION: StellarTomlIssuer
   PRINCIPALS: StellarTomlPrincipal[]
   SIGNING_KEY?: string
+  TRANSFER_SERVER?: string
+  TRANSFER_SERVER_SEP0024?: string
   URI_REQUEST_SIGNING_KEY?: string
 }>


### PR DESCRIPTION
Prevents showing a bunch of input fields to the user even though we are using the interactive flow of a SEP-24 transfer server.