### PR TITLE
Change KeyboardResizeMode preference to native

### DIFF
--- a/cordova/config/config.template
+++ b/cordova/config/config.template
@@ -116,7 +116,7 @@
     <preference name="DisallowOverscroll" value="true" />
     <preference name="HideKeyboardFormAccessoryBar" value="false" />
     <preference name="KeyboardResize" value="true" />
-    <preference name="KeyboardResizeMode" value="body" />
+    <preference name="KeyboardResizeMode" value="native" />
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="SplashScreenDelay" value="$SPLASH_SCREEN_DELAY" />
     <preference name="SwiftVersion" value="5.0" />


### PR DESCRIPTION
This change fixes the issue that one cannot scroll below input fields when the keyboard is shown on iOS devices with a smaller screen. 

Closes #960. 