### PR TITLE
Use react-hook-form to highlight invalid input in trading view

### DIFF
--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -4,6 +4,7 @@ import AppSettings from "./locales/en/app-settings.json"
 import CreateAccount from "./locales/en/create-account.json"
 import Generic from "./locales/en/generic.json"
 import Operations from "./locales/en/operations.json"
+import Trading from "./locales/en/trading.json"
 
 const translations = {
   "account-settings": AccountSettings,
@@ -11,7 +12,8 @@ const translations = {
   "app-settings": AppSettings,
   "create-account": CreateAccount,
   generic: Generic,
-  operations: Operations
+  operations: Operations,
+  trading: Trading
 } as const
 
 export default translations

--- a/i18n/locales/en/trading.json
+++ b/i18n/locales/en/trading.json
@@ -1,0 +1,50 @@
+{
+  "actions": {
+    "submit": "Place order"
+  },
+  "advanced": {
+    "header": "Advanced"
+  },
+  "header": "",
+  "inputs": {
+    "estimated-costs": {
+      "label": {
+        "buy": "Estimated costs",
+        "sell": "Estimated return"
+      }
+    },
+    "primary-amount": {
+      "label": {
+        "buy": "Amount to buy",
+        "sell": "Amount to sell"
+      },
+      "max-button": {
+        "label": "Max"
+      },
+      "placeholder": "Max. {{amount}}"
+    },
+    "primary-asset-selector": {
+      "label": {
+        "buy": "You buy",
+        "sell": "You sell"
+      }
+    },
+    "secondary-asset-selector": {
+      "label": {
+        "buy": "Spend",
+        "sell": "Receive"
+      }
+    }
+  },
+  "validation": {
+    "primary-amount-missing": "No amount specified.",
+    "primary-asset-missing": "No asset selected.",
+    "secondary-asset-missing": "No asset selected.",
+    "invalid-amount": "Invalid amount specified.",
+    "invalid-price": "Invalid price"
+  },
+  "warning": {
+    "title": "Warning",
+    "message": "The spread between buying and selling price is about {{spread}}%."
+  }
+}

--- a/i18n/locales/en/trading.json
+++ b/i18n/locales/en/trading.json
@@ -1,11 +1,21 @@
 {
   "actions": {
+    "add-asset": "Add asset",
     "submit": "Place order"
+  },
+  "action-selection": {
+    "buy": {
+      "description": "Buy some amount of an asset on the distributed exchange",
+      "label": "Buy asset"
+    },
+    "sell": {
+      "description": "Trade some amount of an asset for another one",
+      "label": "Sell asset"
+    }
   },
   "advanced": {
     "header": "Advanced"
   },
-  "header": "",
   "inputs": {
     "estimated-costs": {
       "label": {
@@ -35,6 +45,11 @@
         "sell": "Receive"
       }
     }
+  },
+  "no-assets-info": "This account does not use any assets other than Stellar Lumens yet.",
+  "title": "Trade",
+  "trading-price": {
+    "label": "Price (limit)"
   },
   "validation": {
     "primary-amount-missing": "No amount specified.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,8 +6132,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -6771,7 +6770,7 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
@@ -9092,8 +9091,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -10937,8 +10935,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -15948,7 +15945,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -18148,8 +18144,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nunjucks": {
       "version": "3.2.1",
@@ -18293,6 +18288,15 @@
           "optional": true,
           "requires": {
             "is-number": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "requires": {
+            "decamelize": "^1.1.1",
+            "string-width": "^1.0.1"
           }
         }
       }
@@ -18569,7 +18573,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -21267,6 +21271,11 @@
         }
       }
     },
+    "react-hook-form": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.0.3.tgz",
+      "integrity": "sha512-6EqRWATbyXTJdtoaUDp6/2WbH9NOaPUAjsygw12nbU1yK6+x12paMJPf1eLxqT1muSvVe2G8BPqdeidqIL7bmg=="
+    },
     "react-hotkeys": {
       "version": "2.0.0-pre4",
       "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0-pre4.tgz",
@@ -23344,7 +23353,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -23463,7 +23471,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "isomorphic-fetch": "^2.2.1",
     "key-store": "^1.1.0",
     "nanoid": "^2.1.1",
+    "react-hook-form": "^5.0.3",
     "stellar-sdk": "^4.0.0"
   },
   "devDependencies": {

--- a/src/components/Form/AssetSelector.tsx
+++ b/src/components/Form/AssetSelector.tsx
@@ -80,7 +80,7 @@ interface AssetSelectorProps {
   margin?: TextFieldProps["margin"]
   minWidth?: number | string
   name?: string
-  onChange: (asset: Asset) => void
+  onChange?: (asset: Asset) => void
   showXLM?: boolean
   style?: React.CSSProperties
   testnet: boolean
@@ -106,7 +106,9 @@ function AssetSelector(props: AssetSelectorProps) {
       const matchingAsset = assets.find(asset => asset.equals(child.props.asset))
 
       if (matchingAsset) {
-        onChange(matchingAsset)
+        if (onChange) {
+          onChange(matchingAsset)
+        }
       } else {
         // tslint:disable-next-line no-console
         console.error(

--- a/src/components/Form/AssetSelector.tsx
+++ b/src/components/Form/AssetSelector.tsx
@@ -75,9 +75,11 @@ interface AssetSelectorProps {
   disabledAssets?: Asset[]
   disableUnderline?: boolean
   helperText?: TextFieldProps["helperText"]
+  inputError?: string
   label?: TextFieldProps["label"]
   margin?: TextFieldProps["margin"]
   minWidth?: number | string
+  name?: string
   onChange: (asset: Asset) => void
   showXLM?: boolean
   style?: React.CSSProperties
@@ -119,10 +121,12 @@ function AssetSelector(props: AssetSelectorProps) {
     <TextField
       autoFocus={props.autoFocus}
       className={props.className}
+      error={Boolean(props.inputError)}
       helperText={props.helperText}
-      label={props.label}
+      label={props.inputError ? props.inputError : props.label}
       margin={props.margin}
       onChange={handleChange as any}
+      name={props.name}
       placeholder="Select an asset"
       select
       style={{ flexShrink: 0, ...props.style }}

--- a/src/components/Trading/MainActionSelection.tsx
+++ b/src/components/Trading/MainActionSelection.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import AddIcon from "@material-ui/icons/Add"
 import RemoveIcon from "@material-ui/icons/Remove"
 import MainSelectionButton from "../Form/MainSelectionButton"
@@ -14,18 +15,20 @@ const MainActionSelection = React.forwardRef(function MainActionSelection(
   props: Props,
   ref: React.Ref<HTMLDivElement>
 ) {
+  const { t } = useTranslation()
+
   return (
     <HorizontalLayout ref={ref} justifyContent="space-evenly" margin="48px 0 24px" padding="0 8px" wrap="wrap">
       <MainSelectionButton
-        label="Buy asset"
-        description={"Buy some amount of an asset on the distributed exchange"}
+        label={t("trading.action-selection.buy.label")}
+        description={t("trading.action-selection.buy.description")}
         gutterBottom
         onClick={props.onSelectBuy}
         Icon={AddIcon}
       />
       <MainSelectionButton
-        label="Sell asset"
-        description={"Trade some amount of an asset for another one"}
+        label={t("trading.action-selection.sell.label")}
+        description={t("trading.action-selection.sell.description")}
         gutterBottom
         onClick={props.onSelectSell}
         Icon={RemoveIcon}

--- a/src/components/Trading/TradingDialog.tsx
+++ b/src/components/Trading/TradingDialog.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import { Asset, Horizon, Server, Transaction } from "stellar-sdk"
 import Box from "@material-ui/core/Box"
 import Typography from "@material-ui/core/Typography"
@@ -42,6 +43,7 @@ function TradingDialog(props: TradingDialogProps) {
   const dialogActionsRef = useDialogActions()
   const router = useRouter()
   const [preselectedAsset, setPreselectedAsset] = React.useState<Asset | undefined>()
+  const { t } = useTranslation()
 
   React.useEffect(() => {
     const asset = getAssetFromPath(router.location.pathname)
@@ -113,7 +115,7 @@ function TradingDialog(props: TradingDialogProps) {
   const LinkToManageAssets = React.useMemo(
     () => (
       <Box margin="32px 0 0" textAlign="center">
-        <Typography>This account does not use any assets other than Stellar Lumens yet.</Typography>
+        <Typography>{t("trading.no-assets-info")}</Typography>
         <Portal target={dialogActionsRef.element}>
           <DialogActionsBox>
             <ActionButton
@@ -121,20 +123,20 @@ function TradingDialog(props: TradingDialogProps) {
               onClick={() => router.history.push(routes.manageAccountAssets(props.account.id))}
               type="primary"
             >
-              Add asset
+              {t("trading.actions.add-asset")}
             </ActionButton>
           </DialogActionsBox>
         </Portal>
       </Box>
     ),
-    [dialogActionsRef, props.account, router]
+    [dialogActionsRef, props.account, router, t]
   )
 
   return (
     <DialogBody
       top={
         <>
-          <MainTitle title="Trade" onBack={primaryAction ? clearPrimaryAction : props.onClose} />
+          <MainTitle title={t("trading.title")} onBack={primaryAction ? clearPrimaryAction : props.onClose} />
           <ScrollableBalances account={props.account} compact />
         </>
       }

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -313,7 +313,6 @@ function TradingForm(props: Props) {
                 }
                 minWidth={75}
                 showXLM
-                onChange={() => undefined}
                 style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
                 testnet={props.account.testnet}
                 value={primaryAsset}
@@ -394,7 +393,6 @@ function TradingForm(props: Props) {
                 }
                 minWidth={75}
                 showXLM
-                onChange={() => undefined}
                 style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
                 testnet={props.account.testnet}
                 value={secondaryAsset}

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -438,19 +438,22 @@ function TradingForm(props: Props) {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails className={classes.expansionPanelDetails}>
             <Controller
-              as={TradingPrice}
+              as={
+                <TradingPrice
+                  defaultPrice={!form.formState.touched.manualPrice ? defaultPrice : undefined}
+                  inputError={form.errors.manualPrice && form.errors.manualPrice.message}
+                  onSetPriceDenotedIn={setPriceMode}
+                  price={effectivePrice}
+                  priceDenotedIn={priceMode}
+                  primaryAsset={primaryAsset}
+                  secondaryAsset={secondaryAsset}
+                  selectOnFocus
+                  style={{ flexGrow: 1, maxWidth: 250, width: "55%" }}
+                />
+              }
               control={form.control}
-              defaultPrice={!form.formState.touched.manualPrice ? defaultPrice : undefined}
-              inputError={form.errors.manualPrice && form.errors.manualPrice.message}
               name="manualPrice"
-              onSetPriceDenotedIn={setPriceMode}
-              price={effectivePrice}
-              priceDenotedIn={priceMode}
-              primaryAsset={primaryAsset}
               rules={{ validate: value => isValidAmount(value) || t<string>("trading.validation.invalid-price") }}
-              secondaryAsset={secondaryAsset}
-              selectOnFocus
-              style={{ flexGrow: 1, maxWidth: 250, width: "55%" }}
               valueName="manualPrice"
             />
           </ExpansionPanelDetails>

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -296,23 +296,19 @@ function TradingForm(props: Props) {
       >
         <HorizontalLayout margin="8px 0">
           <Controller
-            as={
-              <AssetSelector
-                assets={assets}
-                autoFocus={Boolean(process.env.PLATFORM !== "ios" && !props.initialPrimaryAsset)}
-                inputError={errors.primaryAsset && errors.primaryAsset.message}
-                label={props.primaryAction === "buy" ? "You buy" : "You sell"}
-                minWidth={75}
-                showXLM
-                onChange={() => undefined}
-                style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
-                testnet={props.account.testnet}
-                value={primaryAsset}
-              />
-            }
+            as={AssetSelector}
+            assets={assets}
+            autoFocus={Boolean(process.env.PLATFORM !== "ios" && !props.initialPrimaryAsset)}
             control={control}
+            inputError={errors.primaryAsset && errors.primaryAsset.message}
+            label={props.primaryAction === "buy" ? "You buy" : "You sell"}
+            minWidth={75}
             name="primaryAsset"
             rules={{ required: "No asset selected" }}
+            showXLM
+            style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
+            testnet={props.account.testnet}
+            value={primaryAsset}
           />
           <TextField
             autoFocus={Boolean(process.env.PLATFORM !== "ios" && props.initialPrimaryAsset)}
@@ -367,21 +363,17 @@ function TradingForm(props: Props) {
         </HorizontalLayout>
         <HorizontalLayout margin="8px 0 32px">
           <Controller
-            as={
-              <AssetSelector
-                assets={assets}
-                label={props.primaryAction === "buy" ? "Spend" : "Receive"}
-                minWidth={75}
-                showXLM
-                onChange={() => undefined}
-                style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
-                testnet={props.account.testnet}
-                value={secondaryAsset}
-              />
-            }
+            as={AssetSelector}
+            assets={assets}
             control={control}
+            label={props.primaryAction === "buy" ? "Spend" : "Receive"}
+            minWidth={75}
             name="secondaryAsset"
             rules={{ required: "No asset selected." }}
+            showXLM
+            style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
+            testnet={props.account.testnet}
+            value={secondaryAsset}
           />
           <ReadOnlyTextfield
             disableUnderline

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -224,7 +224,7 @@ function TradingForm(props: Props) {
   }
 
   const setPrimaryAmountToMax = () => {
-    form.setValue("primaryAmount", maxPrimaryAmount.toFixed(7))
+    form.setValue("primaryAmountString", maxPrimaryAmount.toFixed(7))
   }
 
   const submitForm = React.useCallback(async () => {

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -301,25 +301,29 @@ function TradingForm(props: Props) {
       >
         <HorizontalLayout margin="8px 0">
           <Controller
-            as={AssetSelector}
-            assets={assets}
-            autoFocus={Boolean(process.env.PLATFORM !== "ios" && !props.initialPrimaryAsset)}
-            control={form.control}
-            inputError={form.errors.primaryAsset && form.errors.primaryAsset.message}
-            label={
-              props.primaryAction === "buy"
-                ? t("trading.inputs.primary-asset-selector.label.buy")
-                : t("trading.inputs.primary-asset-selector.label.sell")
+            as={
+              <AssetSelector
+                assets={assets}
+                autoFocus={Boolean(process.env.PLATFORM !== "ios" && !props.initialPrimaryAsset)}
+                inputError={form.errors.primaryAsset && form.errors.primaryAsset.message}
+                label={
+                  props.primaryAction === "buy"
+                    ? t("trading.inputs.primary-asset-selector.label.buy")
+                    : t("trading.inputs.primary-asset-selector.label.sell")
+                }
+                minWidth={75}
+                showXLM
+                onChange={() => undefined}
+                style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
+                testnet={props.account.testnet}
+                value={primaryAsset}
+              />
             }
-            minWidth={75}
+            control={form.control}
             name="primaryAsset"
             rules={{
               required: t<string>("trading.validation.primary-asset-missing")
             }}
-            showXLM
-            style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
-            testnet={props.account.testnet}
-            value={primaryAsset}
           />
           <TextField
             autoFocus={Boolean(process.env.PLATFORM !== "ios" && props.initialPrimaryAsset)}
@@ -380,21 +384,25 @@ function TradingForm(props: Props) {
         </HorizontalLayout>
         <HorizontalLayout margin="8px 0 32px">
           <Controller
-            as={AssetSelector}
-            assets={assets}
-            control={form.control}
-            label={
-              props.primaryAction === "buy"
-                ? t("trading.inputs.secondary-asset-selector.label.buy")
-                : t("trading.inputs.secondary-asset-selector.label.sell")
+            as={
+              <AssetSelector
+                assets={assets}
+                label={
+                  props.primaryAction === "buy"
+                    ? t("trading.inputs.secondary-asset-selector.label.buy")
+                    : t("trading.inputs.secondary-asset-selector.label.sell")
+                }
+                minWidth={75}
+                showXLM
+                onChange={() => undefined}
+                style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
+                testnet={props.account.testnet}
+                value={secondaryAsset}
+              />
             }
-            minWidth={75}
+            control={form.control}
             name="secondaryAsset"
             rules={{ required: t<string>("trading.validation.secondary-asset-missing") }}
-            showXLM
-            style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
-            testnet={props.account.testnet}
-            value={secondaryAsset}
           />
           <ReadOnlyTextfield
             disableUnderline

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -1,5 +1,6 @@
 import BigNumber from "big.js"
 import React from "react"
+import { useForm, Controller } from "react-hook-form"
 import { Asset, Horizon, Transaction, Operation } from "stellar-sdk"
 import Button from "@material-ui/core/Button"
 import ExpansionPanel from "@material-ui/core/ExpansionPanel"
@@ -18,7 +19,8 @@ import { useHorizon } from "../../hooks/stellar"
 import { useLiveOrderbook } from "../../hooks/stellar-subscriptions"
 import { useIsMobile, RefStateObject } from "../../hooks/userinterface"
 import { AccountData } from "../../lib/account"
-import { calculateSpread } from "../../lib/orderbook"
+import { calculateSpread, FixedOrderbookRecord } from "../../lib/orderbook"
+import { createTransaction } from "../../lib/transaction"
 import { balancelineToAsset, getAccountMinimumBalance } from "../../lib/stellar"
 import { formatBalance, BalanceFormattingOptions } from "../Account/AccountBalances"
 import { ActionButton, DialogActionsBox } from "../Dialog/Generic"
@@ -26,10 +28,9 @@ import AssetSelector from "../Form/AssetSelector"
 import { ReadOnlyTextfield } from "../Form/FormFields"
 import { Box, HorizontalLayout, VerticalLayout } from "../Layout/Box"
 import { warningColor } from "../../theme"
-import { useConversionOffers } from "./hooks"
 import Portal from "../Portal"
+import { useConversionOffers } from "./hooks"
 import TradingPrice from "./TradingPrice"
-import { createTransaction } from "../../lib/transaction"
 
 const bigNumberToInputValue = (bignum: BigNumber, overrides?: BalanceFormattingOptions) =>
   formatBalance(bignum, { minimumSignificants: 3, maximumSignificants: 9, ...overrides })
@@ -67,9 +68,98 @@ const useStyles = makeStyles({
   }
 })
 
-interface ManualPrice {
-  error?: Error
-  value?: string
+interface CalculationResults {
+  defaultPrice: string
+  effectivePrice: BigNumber
+  maxPrimaryAmount: BigNumber
+  minAccountBalance: BigNumber
+  primaryAmount: BigNumber
+  primaryBalance: Horizon.BalanceLine | undefined
+  relativeSpread: number
+  secondaryAmount: BigNumber
+  secondaryBalance: Horizon.BalanceLine | undefined
+  spendablePrimaryBalance: BigNumber
+  spendableSecondaryBalance: BigNumber
+}
+
+const useCalculation = (
+  values: TradingFormValues,
+  tradePair: FixedOrderbookRecord,
+  priceMode: "primary" | "secondary",
+  accountData: AccountData,
+  primaryAction: "buy" | "sell"
+): CalculationResults => {
+  const { manualPrice, primaryAmountString, primaryAsset, secondaryAsset } = values
+
+  const price =
+    manualPrice && isValidAmount(manualPrice)
+      ? priceMode === "secondary"
+        ? BigNumber(manualPrice)
+        : BigNumber(manualPrice).eq(0) // prevent division by zero
+        ? BigNumber(0)
+        : BigNumber(1).div(manualPrice)
+      : BigNumber(0)
+
+  const primaryAmount =
+    primaryAmountString && isValidAmount(primaryAmountString) ? BigNumber(primaryAmountString) : BigNumber(0)
+
+  const primaryBalance = primaryAsset ? findMatchingBalance(accountData.balances, primaryAsset) : undefined
+  const secondaryBalance = secondaryAsset ? findMatchingBalance(accountData.balances, secondaryAsset) : undefined
+
+  const { worstPriceOfBestMatches } = useConversionOffers(
+    primaryAction === "buy" ? tradePair.asks : tradePair.bids,
+    primaryAmount.gt(0) ? primaryAmount : BigNumber(0.01),
+    primaryAction === "sell"
+  )
+
+  const { relativeSpread } = calculateSpread(tradePair.asks, tradePair.bids)
+  const bestPrice = worstPriceOfBestMatches && worstPriceOfBestMatches.gt(0) ? worstPriceOfBestMatches : undefined
+  const effectivePrice = price.gt(0) ? price : bestPrice || BigNumber(0)
+  const secondaryAmount = primaryAmount.mul(effectivePrice)
+
+  // prevent division by zero
+  const inversePrice = effectivePrice.eq(0) ? BigNumber(0) : BigNumber(1).div(effectivePrice)
+  const defaultPrice = bigNumberToInputValue(priceMode === "secondary" ? effectivePrice : inversePrice)
+
+  const minAccountBalance = getAccountMinimumBalance(accountData)
+
+  const spendablePrimaryBalance = primaryBalance
+    ? BigNumber(primaryBalance.balance).sub(primaryBalance.asset_type === "native" ? minAccountBalance : 0)
+    : BigNumber(0)
+
+  const spendableSecondaryBalance = secondaryBalance
+    ? BigNumber(secondaryBalance.balance).sub(secondaryBalance.asset_type === "native" ? minAccountBalance : 0)
+    : BigNumber(0)
+
+  const maxPrimaryAmount =
+    primaryAction === "buy"
+      ? spendableSecondaryBalance.gt(0) && effectivePrice.gt(0)
+        ? BigNumber(spendableSecondaryBalance).div(effectivePrice)
+        : BigNumber(0)
+      : spendablePrimaryBalance.gt(0)
+      ? BigNumber(spendablePrimaryBalance)
+      : BigNumber(0)
+
+  return {
+    defaultPrice,
+    effectivePrice,
+    maxPrimaryAmount,
+    minAccountBalance,
+    primaryAmount,
+    primaryBalance,
+    relativeSpread,
+    secondaryAmount,
+    secondaryBalance,
+    spendablePrimaryBalance,
+    spendableSecondaryBalance
+  }
+}
+
+interface TradingFormValues {
+  primaryAsset: Asset | undefined
+  primaryAmountString: string
+  secondaryAsset: Asset
+  manualPrice: string
 }
 
 interface Props {
@@ -85,97 +175,55 @@ interface Props {
 }
 
 function TradingForm(props: Props) {
-  const { sendTransaction } = props
   const classes = useStyles()
   const isSmallScreen = useIsMobile()
   const isSmallHeightScreen = useMediaQuery("(max-height: 500px)")
   const isSmallScreenXY = isSmallScreen || isSmallHeightScreen
 
-  const [primaryAsset, setPrimaryAsset] = React.useState<Asset | undefined>(props.initialPrimaryAsset)
-  const [primaryAmountString, setPrimaryAmountString] = React.useState("")
-  const [secondaryAsset, setSecondaryAsset] = React.useState<Asset>(Asset.native())
-  const [manualPrice, setManualPrice] = React.useState<ManualPrice>({})
-  const [priceMode, setPriceMode] = React.useState<"primary" | "secondary">("secondary")
   const [expanded, setExpanded] = React.useState(false)
+  const [priceMode, setPriceMode] = React.useState<"primary" | "secondary">("secondary")
+
+  const { control, errors, formState, getValues, handleSubmit, register, setValue, triggerValidation, watch } = useForm<
+    TradingFormValues
+  >({
+    defaultValues: {
+      primaryAsset: props.initialPrimaryAsset,
+      primaryAmountString: "",
+      secondaryAsset: Asset.native(),
+      manualPrice: "0"
+    }
+  })
+
+  const sendTransaction = props.sendTransaction
+  const { primaryAsset, secondaryAsset } = watch()
 
   const horizon = useHorizon(props.account.testnet)
   const tradePair = useLiveOrderbook(primaryAsset || Asset.native(), secondaryAsset, props.account.testnet)
 
-  const price =
-    manualPrice.value && isValidAmount(manualPrice.value)
-      ? priceMode === "secondary"
-        ? BigNumber(manualPrice.value)
-        : BigNumber(manualPrice.value).eq(0) // prevent division by zero
-        ? BigNumber(0)
-        : BigNumber(1).div(manualPrice.value)
-      : BigNumber(0)
-
-  const primaryAmount =
-    primaryAmountString && isValidAmount(primaryAmountString) ? BigNumber(primaryAmountString) : BigNumber(0)
-
-  const primaryBalance = primaryAsset ? findMatchingBalance(props.accountData.balances, primaryAsset) : undefined
-  const secondaryBalance = secondaryAsset ? findMatchingBalance(props.accountData.balances, secondaryAsset) : undefined
-
-  const updatePrice = (newPriceAmount: string) => {
-    setManualPrice(prev => ({
-      error: isValidAmount(newPriceAmount) ? undefined : prev.error,
-      value: newPriceAmount
-    }))
-  }
-
-  const validatePrice = React.useCallback(() => {
-    setManualPrice(prev => ({
-      error: prev.value && !isValidAmount(prev.value) ? Error("Invalid price") : undefined,
-      value: prev.value
-    }))
-  }, [])
-
-  const { worstPriceOfBestMatches } = useConversionOffers(
-    props.primaryAction === "buy" ? tradePair.asks : tradePair.bids,
-    primaryAmount.gt(0) ? primaryAmount : BigNumber(0.01),
-    props.primaryAction === "sell"
-  )
-
-  const { relativeSpread } = calculateSpread(tradePair.asks, tradePair.bids)
-  const bestPrice = worstPriceOfBestMatches && worstPriceOfBestMatches.gt(0) ? worstPriceOfBestMatches : undefined
-  const effectivePrice = price.gt(0) ? price : bestPrice || BigNumber(0)
-  const secondaryAmount = primaryAmount.mul(effectivePrice)
-
-  // prevent division by zero
-  const inversePrice = effectivePrice.eq(0) ? BigNumber(0) : BigNumber(1).div(effectivePrice)
-  const defaultPrice = bigNumberToInputValue(priceMode === "secondary" ? effectivePrice : inversePrice)
-
-  const sellingAmount = props.primaryAction === "sell" ? primaryAmount : secondaryAmount
-  const sellingBalance: { balance: string } = (props.primaryAction === "sell" ? primaryBalance : secondaryBalance) || {
-    balance: "0"
-  }
-
-  const minAccountBalance = getAccountMinimumBalance(props.accountData)
-
-  const spendablePrimaryBalance = primaryBalance
-    ? BigNumber(primaryBalance.balance).sub(primaryBalance.asset_type === "native" ? minAccountBalance : 0)
-    : BigNumber(0)
-
-  const spendableSecondaryBalance = secondaryBalance
-    ? BigNumber(secondaryBalance.balance).sub(secondaryBalance.asset_type === "native" ? minAccountBalance : 0)
-    : BigNumber(0)
-
   const assets = React.useMemo(() => props.trustlines.map(balancelineToAsset), [props.trustlines])
 
-  const maxPrimaryAmount =
-    props.primaryAction === "buy"
-      ? spendableSecondaryBalance.gt(0) && effectivePrice.gt(0)
-        ? BigNumber(spendableSecondaryBalance).div(effectivePrice)
-        : BigNumber(0)
-      : spendablePrimaryBalance.gt(0)
-      ? BigNumber(spendablePrimaryBalance)
-      : BigNumber(0)
+  const calculation = useCalculation(getValues(), tradePair, priceMode, props.accountData, props.primaryAction)
 
-  const isDisabled =
-    !primaryAsset || primaryAmount.lte(0) || sellingAmount.gt(sellingBalance.balance) || effectivePrice.lte(0)
+  const {
+    maxPrimaryAmount,
+    primaryBalance,
+    defaultPrice,
+    effectivePrice,
+    primaryAmount,
+    relativeSpread,
+    secondaryAmount,
+    secondaryBalance,
+    spendablePrimaryBalance,
+    spendableSecondaryBalance
+  } = calculation
+
+  if (formState.touched.primaryAmountString) {
+    // trigger delayed validation to make sure that primaryAmountString is validated with latest calculation results
+    setTimeout(() => triggerValidation("primaryAmountString"), 0)
+  }
 
   const setPrimaryAmountToMax = () => {
-    setPrimaryAmountString(maxPrimaryAmount.toFixed(7))
+    setValue("primaryAmount", maxPrimaryAmount.toFixed(7))
   }
 
   const submitForm = React.useCallback(async () => {
@@ -247,25 +295,40 @@ function TradingForm(props: Props) {
         width="100%"
       >
         <HorizontalLayout margin="8px 0">
-          <AssetSelector
-            assets={assets}
-            autoFocus={Boolean(process.env.PLATFORM !== "ios" && !props.initialPrimaryAsset)}
-            label={props.primaryAction === "buy" ? "You buy" : "You sell"}
-            onChange={setPrimaryAsset}
-            minWidth={75}
-            showXLM
-            style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
-            testnet={props.account.testnet}
-            value={primaryAsset}
+          <Controller
+            as={
+              <AssetSelector
+                assets={assets}
+                autoFocus={Boolean(process.env.PLATFORM !== "ios" && !props.initialPrimaryAsset)}
+                inputError={errors.primaryAsset && errors.primaryAsset.message}
+                label={props.primaryAction === "buy" ? "You buy" : "You sell"}
+                minWidth={75}
+                showXLM
+                onChange={() => undefined}
+                style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
+                testnet={props.account.testnet}
+                value={primaryAsset}
+              />
+            }
+            control={control}
+            name="primaryAsset"
+            rules={{ required: "No asset selected" }}
           />
           <TextField
             autoFocus={Boolean(process.env.PLATFORM !== "ios" && props.initialPrimaryAsset)}
-            error={
-              primaryAmount.lt(0) ||
-              (primaryAmountString.length > 0 && primaryAmount.eq(0)) ||
-              (props.primaryAction === "sell" && primaryBalance && primaryAmount.gt(spendablePrimaryBalance)) ||
-              (props.primaryAction === "buy" && secondaryBalance && secondaryAmount.gt(spendableSecondaryBalance))
-            }
+            name="primaryAmountString"
+            inputRef={register({
+              required: "No amount specified!",
+              validate: value => {
+                const amountInvalid =
+                  primaryAmount.lt(0) ||
+                  (value.length > 0 && primaryAmount.eq(0)) ||
+                  (props.primaryAction === "sell" && primaryBalance && primaryAmount.gt(spendablePrimaryBalance)) ||
+                  (props.primaryAction === "buy" && secondaryBalance && secondaryAmount.gt(spendableSecondaryBalance))
+                return !amountInvalid || "Invalid amount specified!"
+              }
+            })}
+            error={Boolean(errors.primaryAmountString)}
             inputProps={{
               pattern: "[0-9]*",
               inputMode: "decimal",
@@ -289,25 +352,36 @@ function TradingForm(props: Props) {
                   </InputAdornment>
                 )
             }}
-            label={props.primaryAction === "buy" ? "Amount to buy" : "Amount to sell"}
-            onChange={event => setPrimaryAmountString(event.target.value)}
+            label={
+              errors.primaryAmountString && errors.primaryAmountString.message
+                ? errors.primaryAmountString.message
+                : props.primaryAction === "buy"
+                ? "Amount to buy"
+                : "Amount to sell"
+            }
             placeholder={`Max. ${bigNumberToInputValue(maxPrimaryAmount)}`}
             required
             style={{ flexGrow: 1, flexShrink: 1, width: "55%" }}
             type="number"
-            value={primaryAmountString}
           />
         </HorizontalLayout>
         <HorizontalLayout margin="8px 0 32px">
-          <AssetSelector
-            assets={assets}
-            label={props.primaryAction === "buy" ? "Spend" : "Receive"}
-            minWidth={75}
-            onChange={setSecondaryAsset}
-            showXLM
-            style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
-            testnet={props.account.testnet}
-            value={secondaryAsset}
+          <Controller
+            as={
+              <AssetSelector
+                assets={assets}
+                label={props.primaryAction === "buy" ? "Spend" : "Receive"}
+                minWidth={75}
+                showXLM
+                onChange={() => undefined}
+                style={{ flexGrow: 1, marginRight: 24, maxWidth: 150, width: "25%" }}
+                testnet={props.account.testnet}
+                value={secondaryAsset}
+              />
+            }
+            control={control}
+            name="secondaryAsset"
+            rules={{ required: "No asset selected." }}
           />
           <ReadOnlyTextfield
             disableUnderline
@@ -340,17 +414,20 @@ function TradingForm(props: Props) {
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails className={classes.expansionPanelDetails}>
-            <TradingPrice
-              inputError={manualPrice.error}
-              manualPrice={manualPrice.value !== undefined ? manualPrice.value : defaultPrice}
-              onBlur={validatePrice}
-              onChange={updatePrice}
+            <Controller
+              as={TradingPrice}
+              control={control}
+              defaultPrice={!formState.touched.manualPrice ? defaultPrice : undefined}
+              inputError={errors.manualPrice && new Error(errors.manualPrice.message)}
+              name="manualPrice"
               onSetPriceDenotedIn={setPriceMode}
               price={effectivePrice}
               priceDenotedIn={priceMode}
               primaryAsset={primaryAsset}
+              rules={{ validate: value => isValidAmount(value) || "Invalid price" }}
               secondaryAsset={secondaryAsset}
               style={{ flexGrow: 1, maxWidth: 250, width: "55%" }}
+              valueName="manualPrice"
             />
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -363,7 +440,7 @@ function TradingForm(props: Props) {
         ) : null}
         <Portal target={props.dialogActionsRef.element}>
           <DialogActionsBox desktopStyle={{ marginTop: 32 }}>
-            <ActionButton disabled={isDisabled} icon={<GavelIcon />} onClick={submitForm} type="primary">
+            <ActionButton icon={<GavelIcon />} onClick={handleSubmit(submitForm)} type="primary">
               Place order
             </ActionButton>
           </DialogActionsBox>

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -426,6 +426,7 @@ function TradingForm(props: Props) {
               primaryAsset={primaryAsset}
               rules={{ validate: value => isValidAmount(value) || "Invalid price" }}
               secondaryAsset={secondaryAsset}
+              selectOnFocus
               style={{ flexGrow: 1, maxWidth: 250, width: "55%" }}
               valueName="manualPrice"
             />

--- a/src/components/Trading/TradingForm.tsx
+++ b/src/components/Trading/TradingForm.tsx
@@ -410,7 +410,7 @@ function TradingForm(props: Props) {
               as={TradingPrice}
               control={control}
               defaultPrice={!formState.touched.manualPrice ? defaultPrice : undefined}
-              inputError={errors.manualPrice && new Error(errors.manualPrice.message)}
+              inputError={errors.manualPrice && errors.manualPrice.message}
               name="manualPrice"
               onSetPriceDenotedIn={setPriceMode}
               price={effectivePrice}

--- a/src/components/Trading/TradingPrice.tsx
+++ b/src/components/Trading/TradingPrice.tsx
@@ -1,5 +1,6 @@
 import BigNumber from "big.js"
 import React from "react"
+import { useTranslation } from "react-i18next"
 import { Asset } from "stellar-sdk"
 import InputAdornment from "@material-ui/core/InputAdornment"
 import MenuItem from "@material-ui/core/MenuItem"
@@ -23,6 +24,7 @@ interface TradingPriceProps {
 
 const TradingPrice = React.forwardRef(function TradingPrice(props: TradingPriceProps, ref: React.Ref<HTMLDivElement>) {
   const isDisabled = !props.primaryAsset || !props.secondaryAsset
+  const { t } = useTranslation()
 
   const endAdornment = (
     <InputAdornment position="end">
@@ -53,7 +55,7 @@ const TradingPrice = React.forwardRef(function TradingPrice(props: TradingPriceP
       InputProps={{ endAdornment }}
       inputRef={ref}
       error={Boolean(props.inputError)}
-      label={props.inputError ? props.inputError : "Price (limit)"}
+      label={props.inputError ? props.inputError : t("trading.trading-price.label")}
       onBlur={props.onBlur}
       onChange={props.onChange}
       onFocus={props.selectOnFocus ? event => event.target.select() : undefined}

--- a/src/components/Trading/TradingPrice.tsx
+++ b/src/components/Trading/TradingPrice.tsx
@@ -17,6 +17,7 @@ interface TradingPriceProps {
   priceDenotedIn: "primary" | "secondary"
   primaryAsset: Asset | undefined
   secondaryAsset: Asset | undefined
+  selectOnFocus?: boolean
   style?: React.CSSProperties
 }
 
@@ -55,6 +56,7 @@ const TradingPrice = React.forwardRef(function TradingPrice(props: TradingPriceP
       label={props.inputError ? props.inputError.message : "Price (limit)"}
       onBlur={props.onBlur}
       onChange={props.onChange}
+      onFocus={props.selectOnFocus ? event => event.target.select() : undefined}
       style={props.style}
       type="number"
       value={props.defaultPrice ? props.defaultPrice : props.manualPrice}

--- a/src/components/Trading/TradingPrice.tsx
+++ b/src/components/Trading/TradingPrice.tsx
@@ -7,10 +7,11 @@ import Select from "@material-ui/core/Select"
 import TextField from "@material-ui/core/TextField"
 
 interface TradingPriceProps {
+  defaultPrice?: string
   inputError?: Error
   manualPrice?: string
   onBlur?: () => void
-  onChange: (priceString: string) => void
+  onChange: (event: React.ChangeEvent) => void
   onSetPriceDenotedIn: (denotedIn: "primary" | "secondary") => void
   price: BigNumber
   priceDenotedIn: "primary" | "secondary"
@@ -19,7 +20,7 @@ interface TradingPriceProps {
   style?: React.CSSProperties
 }
 
-function TradingPrice(props: TradingPriceProps) {
+const TradingPrice = React.forwardRef(function TradingPrice(props: TradingPriceProps, ref: React.Ref<HTMLDivElement>) {
   const isDisabled = !props.primaryAsset || !props.secondaryAsset
 
   const endAdornment = (
@@ -49,15 +50,16 @@ function TradingPrice(props: TradingPriceProps) {
         min: "0.0000001"
       }}
       InputProps={{ endAdornment }}
+      inputRef={ref}
       error={Boolean(props.inputError)}
       label={props.inputError ? props.inputError.message : "Price (limit)"}
       onBlur={props.onBlur}
-      onChange={event => props.onChange(event.target.value)}
+      onChange={props.onChange}
       style={props.style}
       type="number"
-      value={props.manualPrice}
+      value={props.defaultPrice ? props.defaultPrice : props.manualPrice}
     />
   )
-}
+})
 
 export default React.memo(TradingPrice)

--- a/src/components/Trading/TradingPrice.tsx
+++ b/src/components/Trading/TradingPrice.tsx
@@ -11,7 +11,7 @@ interface TradingPriceProps {
   inputError?: string
   manualPrice?: string
   onBlur?: () => void
-  onChange: (event: React.ChangeEvent) => void
+  onChange?: (event: React.ChangeEvent) => void
   onSetPriceDenotedIn: (denotedIn: "primary" | "secondary") => void
   price: BigNumber
   priceDenotedIn: "primary" | "secondary"

--- a/src/components/Trading/TradingPrice.tsx
+++ b/src/components/Trading/TradingPrice.tsx
@@ -8,7 +8,7 @@ import TextField from "@material-ui/core/TextField"
 
 interface TradingPriceProps {
   defaultPrice?: string
-  inputError?: Error
+  inputError?: string
   manualPrice?: string
   onBlur?: () => void
   onChange: (event: React.ChangeEvent) => void
@@ -53,7 +53,7 @@ const TradingPrice = React.forwardRef(function TradingPrice(props: TradingPriceP
       InputProps={{ endAdornment }}
       inputRef={ref}
       error={Boolean(props.inputError)}
-      label={props.inputError ? props.inputError.message : "Price (limit)"}
+      label={props.inputError ? props.inputError : "Price (limit)"}
       onBlur={props.onBlur}
       onChange={props.onChange}
       onFocus={props.selectOnFocus ? event => event.target.select() : undefined}


### PR DESCRIPTION
Supersedes #881.

- [x] Add `react-hook-form` dependency
- [x] Add inputError and name prop to `AssetSelector`
- [x] Make TradingPrice accept a `defaultPrice` prop 
- [x] Move calculation into separate hook outside of `TradingForm` component 
- [x] Use `react-hook-form` for form validation

The `defaultPrice` prop was necessary because `react-hook-form` is handling value changes so that 
`manualPrice={manualPrice.value !== undefined ? manualPrice.value : defaultPrice}` won't work anymore. The `defaultPrice` will only be passed to the TradingPrice component if it has not been 'touched' yet which means that the user did change the content of that field.

Closes #875