### PR TITLE
Optimistically update accounts on changeTrust & setOptions ops

### DIFF
--- a/src/components/TransactionSender.tsx
+++ b/src/components/TransactionSender.tsx
@@ -1,7 +1,7 @@
 import { TFunction } from "i18next"
 import React from "react"
 import { Translation } from "react-i18next"
-import { Server, Transaction } from "stellar-sdk"
+import { Networks, Server, Transaction } from "stellar-sdk"
 import Zoom from "@material-ui/core/Zoom"
 import { Account } from "../context/accounts"
 import { SettingsContext, SettingsContextType } from "../context/settings"
@@ -206,16 +206,21 @@ class TransactionSender extends React.Component<Props, State> {
 
   submitTransactionToHorizon = async (signedTransaction: Transaction) => {
     const { netWorker } = await workers
+
+    const network = this.props.account.testnet ? Networks.TESTNET : Networks.PUBLIC
     const txEnvelopeXdr = signedTransaction
       .toEnvelope()
       .toXDR()
       .toString("base64")
-    const promise = netWorker.submitTransaction(String(this.props.horizon.serverURL), txEnvelopeXdr).then(response => {
-      if (response.status !== 200) {
-        throw explainSubmissionErrorResponse(response, this.props.t)
-      }
-      return response
-    })
+
+    const promise = netWorker
+      .submitTransaction(String(this.props.horizon.serverURL), txEnvelopeXdr, network)
+      .then(response => {
+        if (response.status !== 200) {
+          throw explainSubmissionErrorResponse(response, this.props.t)
+        }
+        return response
+      })
 
     this.setSubmissionPromise(promise)
     this.setState({ submissionType: SubmissionType.default })

--- a/src/workers/_util/optimistic-updates.ts
+++ b/src/workers/_util/optimistic-updates.ts
@@ -1,0 +1,51 @@
+// tslint:disable member-ordering
+import { Observable, Subject } from "observable-fns"
+import { Horizon } from "stellar-sdk"
+
+export interface OptimisticUpdate<BaseDataT> {
+  apply<T extends BaseDataT>(base: T): T
+  effectsAccountID: string
+  horizonURL: string
+  title: string
+  transactionHash: string
+}
+
+export type OptimisticAccountUpdate = OptimisticUpdate<Horizon.AccountResponse>
+
+const createAccountCacheKey = (horizonURL: string, accountID: string) => `${horizonURL}/accounts/${accountID}`
+
+const optimisticAccountDataUpdates = new Map<string, OptimisticAccountUpdate[]>()
+const optimisticAccountDataSubject = new Subject<OptimisticUpdate<Horizon.AccountResponse>>()
+
+export function addAccountUpdates(optimisticUpdates: OptimisticAccountUpdate[]) {
+  for (const optimisticUpdate of optimisticUpdates) {
+    const selector = createAccountCacheKey(optimisticUpdate.horizonURL, optimisticUpdate.effectsAccountID)
+    const prevUpdates = optimisticAccountDataUpdates.get(selector) || []
+
+    optimisticAccountDataUpdates.set(selector, [...prevUpdates, optimisticUpdate])
+    optimisticAccountDataSubject.next(optimisticUpdate)
+  }
+}
+
+export function getAccountUpdates(horizonURL: string, accountID: string): OptimisticAccountUpdate[] {
+  const selector = createAccountCacheKey(horizonURL, accountID)
+  return optimisticAccountDataUpdates.get(selector) || []
+}
+
+export function newOptimisticAccountUpdates(): Observable<OptimisticAccountUpdate> {
+  return Observable.from(optimisticAccountDataSubject)
+}
+
+export function removeStaleAccountUpdates(horizonURL: string, latestTransactionHashs: string[]) {
+  for (const selector of optimisticAccountDataUpdates.keys()) {
+    const prevOptimisticUpdates = optimisticAccountDataUpdates.get(selector)!
+    const nextOptimisticUpdates = prevOptimisticUpdates.filter(
+      optUpdate =>
+        !(optUpdate.horizonURL === horizonURL && latestTransactionHashs.indexOf(optUpdate.transactionHash) > -1)
+    )
+
+    if (nextOptimisticUpdates.length !== prevOptimisticUpdates.length) {
+      optimisticAccountDataUpdates.set(selector, nextOptimisticUpdates)
+    }
+  }
+}

--- a/src/workers/net-worker/optimistic-updates/change-trust.ts
+++ b/src/workers/net-worker/optimistic-updates/change-trust.ts
@@ -1,0 +1,69 @@
+import BigNumber from "big.js"
+import { Horizon, Operation, Transaction } from "stellar-sdk"
+import { balancelineToAsset } from "../../../lib/stellar"
+import { OptimisticUpdate } from "../../_util/optimistic-updates"
+
+function addTrustline(
+  horizonURL: string,
+  operation: Operation.ChangeTrust,
+  transaction: Transaction
+): OptimisticUpdate<Horizon.AccountResponse> {
+  return {
+    apply<T extends Horizon.AccountResponse>(prevAccountData: T): T {
+      const newBalance: Horizon.BalanceLineAsset = {
+        asset_code: operation.line.code,
+        asset_issuer: operation.line.issuer,
+        asset_type: "credit_alphanum12",
+        balance: "0",
+        buying_liabilities: "0",
+        is_authorized: false,
+        last_modified_ledger: 0,
+        limit: operation.limit,
+        selling_liabilities: "0"
+      }
+      return {
+        ...prevAccountData,
+        balances: prevAccountData.balances.some(bal => balancelineToAsset(bal).equals(operation.line))
+          ? prevAccountData.balances
+          : [...prevAccountData.balances, newBalance]
+      }
+    },
+    effectsAccountID: operation.source || transaction.source,
+    horizonURL,
+    title: `Remove trustline for ${operation.line.code}`,
+    transactionHash: transaction.hash().toString("hex")
+  }
+}
+
+function removeTrustline(
+  horizonURL: string,
+  operation: Operation.ChangeTrust,
+  transaction: Transaction
+): OptimisticUpdate<Horizon.AccountResponse> {
+  return {
+    apply(prevAccountData) {
+      return {
+        ...prevAccountData,
+        balances: prevAccountData.balances.filter(balance => !balancelineToAsset(balance).equals(operation.line))
+      }
+    },
+    effectsAccountID: operation.source || transaction.source,
+    horizonURL,
+    title: `Remove trustline for ${operation.line.code}`,
+    transactionHash: transaction.hash().toString("hex")
+  }
+}
+
+function changeTrust(
+  horizonURL: string,
+  operation: Operation.ChangeTrust,
+  transaction: Transaction
+): Array<OptimisticUpdate<Horizon.AccountResponse>> {
+  if (BigNumber(operation.limit).eq(0)) {
+    return [removeTrustline(horizonURL, operation, transaction)]
+  } else {
+    return [addTrustline(horizonURL, operation, transaction)]
+  }
+}
+
+export default changeTrust

--- a/src/workers/net-worker/optimistic-updates/index.ts
+++ b/src/workers/net-worker/optimistic-updates/index.ts
@@ -1,0 +1,47 @@
+import { Horizon, Operation, Transaction } from "stellar-sdk"
+import {
+  addAccountUpdates,
+  getAccountUpdates,
+  newOptimisticAccountUpdates,
+  removeStaleAccountUpdates,
+  OptimisticAccountUpdate,
+  OptimisticUpdate
+} from "../../_util/optimistic-updates"
+import handleChangeTrust from "./change-trust"
+import handleSetOptions from "./set-options"
+
+export { OptimisticAccountUpdate, newOptimisticAccountUpdates }
+
+function fromOperation(
+  horizonURL: string,
+  operation: Operation,
+  transaction: Transaction
+): Array<OptimisticUpdate<Horizon.AccountResponse>> {
+  if (operation.type === "changeTrust") {
+    return handleChangeTrust(horizonURL, operation, transaction)
+  } else if (operation.type === "setOptions") {
+    return handleSetOptions(horizonURL, operation, transaction)
+  } else {
+    return []
+  }
+}
+
+export function handleSubmittedTransaction(horizonURL: string, transaction: Transaction) {
+  for (const operation of transaction.operations) {
+    const optimisticUpdates = fromOperation(horizonURL, operation, transaction)
+    addAccountUpdates(optimisticUpdates)
+  }
+}
+
+export function optimisticallyUpdateAccountData<AccountData extends Horizon.AccountResponse>(
+  horizonURL: string,
+  accountData: AccountData
+): AccountData {
+  const optimisticUpdates = getAccountUpdates(horizonURL, accountData.account_id)
+
+  return optimisticUpdates.reduce((updatedAccountData, update) => update.apply(updatedAccountData), accountData)
+}
+
+export function removeStaleOptimisticUpdates(horizonURL: string, latestTransactionHashs: string[]) {
+  removeStaleAccountUpdates(horizonURL, latestTransactionHashs)
+}

--- a/src/workers/net-worker/optimistic-updates/set-options.ts
+++ b/src/workers/net-worker/optimistic-updates/set-options.ts
@@ -1,0 +1,140 @@
+import { Horizon, Operation, Signer, Transaction } from "stellar-sdk"
+import { OptimisticUpdate } from "../../_util/optimistic-updates"
+
+function addSigner(
+  horizonURL: string,
+  operation: Operation.SetOptions,
+  signer: Signer.Ed25519PublicKey,
+  transaction: Transaction
+): OptimisticUpdate<Horizon.AccountResponse> {
+  return {
+    apply(prevAccountData) {
+      return {
+        ...prevAccountData,
+        signers: [
+          ...prevAccountData.signers,
+          {
+            type: "ed25519_public_key",
+            key: signer.ed25519PublicKey,
+            weight: signer.weight!
+          }
+        ]
+      }
+    },
+    effectsAccountID: operation.source || transaction.source,
+    horizonURL,
+    title: `Add signer ${signer.ed25519PublicKey} (weight ${signer.weight})`,
+    transactionHash: transaction.hash().toString("hex")
+  }
+}
+
+function removeSigner(
+  horizonURL: string,
+  operation: Operation.SetOptions,
+  signer: Signer.Ed25519PublicKey,
+  transaction: Transaction
+): OptimisticUpdate<Horizon.AccountResponse> {
+  return {
+    apply(prevAccountData) {
+      return {
+        ...prevAccountData,
+        signers: prevAccountData.signers.filter(
+          prevSigner => !(prevSigner.type === "ed25519_public_key" && prevSigner.key === signer.ed25519PublicKey)
+        )
+      }
+    },
+    effectsAccountID: operation.source || transaction.source,
+    horizonURL,
+    title: `Remove signer ${signer.ed25519PublicKey}`,
+    transactionHash: transaction.hash().toString("hex")
+  }
+}
+
+function setMasterWeight(
+  horizonURL: string,
+  operation: Operation.SetOptions,
+  masterWeight: number,
+  transaction: Transaction
+): OptimisticUpdate<Horizon.AccountResponse> {
+  const accountID = operation.source || transaction.source
+  return {
+    apply(prevAccountData) {
+      return {
+        ...prevAccountData,
+        signers: prevAccountData.signers.map(signer => {
+          if (signer.type === "ed25519_public_key" && signer.key === accountID) {
+            return {
+              ...signer,
+              weight: masterWeight
+            }
+          } else {
+            return signer
+          }
+        })
+      }
+    },
+    effectsAccountID: accountID,
+    horizonURL,
+    title: `Set master key weight: ${operation.masterWeight}`,
+    transactionHash: transaction.hash().toString("hex")
+  }
+}
+
+function setThresholds(
+  horizonURL: string,
+  operation: Operation.SetOptions,
+  transaction: Transaction
+): OptimisticUpdate<Horizon.AccountResponse> {
+  return {
+    apply(prevAccountData) {
+      const thresholds = { ...prevAccountData.thresholds }
+
+      if (operation.lowThreshold !== undefined) {
+        thresholds.low_threshold = operation.lowThreshold
+      }
+      if (operation.medThreshold !== undefined) {
+        thresholds.med_threshold = operation.medThreshold
+      }
+      if (operation.highThreshold !== undefined) {
+        thresholds.high_threshold = operation.highThreshold
+      }
+      return {
+        ...prevAccountData,
+        thresholds
+      }
+    },
+    effectsAccountID: operation.source || transaction.source,
+    horizonURL,
+    title: `Set thresholds: ${operation.lowThreshold}/${operation.medThreshold}/${operation.highThreshold}`,
+    transactionHash: transaction.hash().toString("hex")
+  }
+}
+
+function setAccountOptions(
+  horizonURL: string,
+  operation: Operation.SetOptions,
+  transaction: Transaction
+): Array<OptimisticUpdate<Horizon.AccountResponse>> {
+  const updates: Array<OptimisticUpdate<Horizon.AccountResponse>> = []
+  const { signer } = operation
+
+  if (signer && "ed25519PublicKey" in signer && typeof signer.weight === "number" && signer.weight > 0) {
+    updates.push(addSigner(horizonURL, operation, signer, transaction))
+  } else if (signer && "ed25519PublicKey" in signer && typeof signer.weight === "number" && signer.weight === 0) {
+    updates.push(removeSigner(horizonURL, operation, signer, transaction))
+  } else if (
+    operation.lowThreshold !== undefined ||
+    operation.medThreshold !== undefined ||
+    operation.highThreshold !== undefined
+  ) {
+    updates.push(setThresholds(horizonURL, operation, transaction))
+  }
+
+  if (operation.masterWeight !== undefined) {
+    updates.push(setMasterWeight(horizonURL, operation, operation.masterWeight, transaction))
+  }
+
+  return updates
+}
+
+export default setAccountOptions

--- a/src/workers/net-worker/stellar-network.ts
+++ b/src/workers/net-worker/stellar-network.ts
@@ -1,14 +1,21 @@
 import "eventsource"
 import throttle from "lodash.throttle"
-import { flatMap, map, multicast, Observable } from "observable-fns"
+import { filter, flatMap, map, merge, multicast, Observable } from "observable-fns"
 import PromiseQueue from "p-queue"
 import qs from "qs"
-import { Asset, Horizon, ServerApi } from "stellar-sdk"
+import { Asset, Horizon, Networks, ServerApi, Transaction } from "stellar-sdk"
 import pkg from "../../../package.json"
 import { Cancellation } from "../../lib/errors"
 import { parseAssetID } from "../../lib/stellar"
 import { max } from "../../lib/strings"
 import { createReconnectingSSE } from "../_util/event-source"
+import {
+  handleSubmittedTransaction,
+  newOptimisticAccountUpdates,
+  optimisticallyUpdateAccountData,
+  removeStaleOptimisticUpdates,
+  OptimisticAccountUpdate
+} from "./optimistic-updates/index"
 import { parseJSONResponse } from "../_util/rest"
 import { resetSubscriptions, subscribeToUpdatesAndPoll } from "../_util/subscription"
 import { ServiceID } from "./errors"
@@ -102,12 +109,16 @@ export function resetAllSubscriptions() {
   resetSubscriptions()
 }
 
-export async function submitTransaction(horizonURL: string, txEnvelopeXdr: string) {
+export async function submitTransaction(horizonURL: string, txEnvelopeXdr: string, network: Networks) {
   const url = new URL(`/transactions`, horizonURL)
 
   const response = await fetch(String(url) + "?" + qs.stringify({ tx: txEnvelopeXdr }), {
     method: "POST"
   })
+
+  if (response.status === 200) {
+    handleSubmittedTransaction(horizonURL, new Transaction(txEnvelopeXdr, network))
+  }
 
   return {
     status: response.status,
@@ -282,7 +293,22 @@ function subscribeToAccountUncached(horizonURL: string, accountID: string) {
         return Boolean(update && (!latestSnapshot || createSnapshot(update) !== latestSnapshot))
       },
       subscribeToUpdates() {
-        return subscribeToAccountEffects(horizonURL, accountID).pipe(map(() => fetchAccountData(horizonURL, accountID)))
+        const handleNewOptimisticUpdate = (newOptimisticUpdate: OptimisticAccountUpdate) => {
+          const accountData = accountDataCache.get(cacheKey)
+
+          if (newOptimisticUpdate.effectsAccountID === accountID && newOptimisticUpdate.horizonURL === horizonURL) {
+            return accountData ? optimisticallyUpdateAccountData(horizonURL, accountData) : accountData
+          } else {
+            return accountData
+          }
+        }
+        return merge(
+          subscribeToAccountEffects(horizonURL, accountID).pipe(map(() => fetchAccountData(horizonURL, accountID))),
+          newOptimisticAccountUpdates().pipe(
+            map(handleNewOptimisticUpdate),
+            filter(accountData => Boolean(accountData))
+          )
+        )
       }
     },
     serviceID
@@ -500,7 +526,10 @@ export interface PaginationOptions {
   order?: "asc" | "desc"
 }
 
-export async function fetchAccountData(horizonURL: string, accountID: string) {
+export async function fetchAccountData(
+  horizonURL: string,
+  accountID: string
+): Promise<Horizon.AccountResponse & { home_domain: string | undefined } | null> {
   const url = new URL(`/accounts/${accountID}?${qs.stringify(identification)}`, horizonURL)
   const response = await fetchQueue.add(() => fetch(String(url) + "?" + qs.stringify(identification)), { priority: 0 })
 
@@ -508,7 +537,8 @@ export async function fetchAccountData(horizonURL: string, accountID: string) {
     return null
   }
 
-  return parseJSONResponse<Horizon.AccountResponse & { home_domain: string | undefined }>(response)
+  const accountData = await parseJSONResponse<Horizon.AccountResponse & { home_domain: string | undefined }>(response)
+  return optimisticallyUpdateAccountData(horizonURL, accountData)
 }
 
 export async function fetchLatestAccountEffect(horizonURL: string, accountID: string) {
@@ -567,7 +597,10 @@ export async function fetchAccountTransactions(
     }
   }
 
-  return parseJSONResponse<CollectionPage<Horizon.TransactionResponse>>(response)
+  const collection = await parseJSONResponse<CollectionPage<Horizon.TransactionResponse>>(response)
+
+  removeStaleOptimisticUpdates(horizonURL, collection._embedded.records.map(record => record.hash))
+  return collection
 }
 
 export async function fetchAccountOpenOrders(horizonURL: string, accountID: string, options: PaginationOptions = {}) {


### PR DESCRIPTION
Implements the basics of #217. Updates accounts' signers, trustlines and thresholds optimistically.