### PR TITLE
Prevent merging account if there are trustlines or orders left

### DIFF
--- a/i18n/locales/en/account-settings.json
+++ b/i18n/locales/en/account-settings.json
@@ -24,7 +24,18 @@
       "1": "Are you sure you want to delete the account \"{{accountName}}?\"",
       "2": " Make sure to backup your private key or merge the funds into another account of yours, since there are still funds left!"
     },
-    "title": "Confirm Account Deletion"
+    "title": "Confirm Account Deletion",
+    "warning-dialog": {
+      "close": {
+        "label": "OK"
+      }
+    },
+    "warnings": {
+      "cannot-merge": {
+        "text": "Cannot merge account yet. First you need to cancel all open trading orders and remove all assets.",
+        "title": "Manual action required"
+      }
+    }
   },
   "custom-trustline": {
     "action": {

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -10,6 +10,7 @@ export interface AccountData {
   inflation_destination?: string
   paging_token: AccountResponse["paging_token"]
   signers: Horizon.AccountSigner[]
+  subentry_count: number
   thresholds: Horizon.AccountThresholds
 }
 
@@ -25,6 +26,7 @@ export const createEmptyAccountData = (accountID: string): AccountData => ({
   id: accountID,
   paging_token: "",
   signers: [],
+  subentry_count: 0,
   thresholds: {
     low_threshold: 0,
     med_threshold: 0,


### PR DESCRIPTION
Fixes #961. Not the ideal solution, but definitely better than just running into a horizon error.