### PR TITLE
Fix i18n key of CustomError

### DIFF
--- a/src/Generic/lib/errors.ts
+++ b/src/Generic/lib/errors.ts
@@ -99,7 +99,7 @@ function toKebabCase(value: string) {
 }
 
 export function getErrorTranslation(error: Error, t: TFunction): string {
-  const key = `error.${toKebabCase(error.name)}`
+  const key = `generic.error.${toKebabCase(error.name)}`
   const params = CustomError.isCustomError(error) ? pick(error, error.__extraProps || []) : undefined
 
   const fallback = error.message


### PR DESCRIPTION
The key for translated error messages is not correct anymore since we put the errors into the `generic.json` file.