### PR TITLE
Give open orders some better labelling

### DIFF
--- a/i18n/locales/en/account.json
+++ b/i18n/locales/en/account.json
@@ -172,6 +172,7 @@
   "transaction-review": {
     "action": {
       "confirm": "Confirm",
+      "cancel-order": "Cancel order",
       "dismiss": "Dismiss",
       "inspect": "Inspect",
       "show-more": "Show more details"

--- a/i18n/locales/en/operations.json
+++ b/i18n/locales/en/operations.json
@@ -34,7 +34,7 @@
   "manage-buy-offer": {
     "title": {
       "create": "Create buy order",
-      "delete": "Delete buy order",
+      "delete": "Buy order",
       "update": "Update buy order"
     }
   },
@@ -50,7 +50,7 @@
   "manage-sell-offer": {
     "title": {
       "create": "Create sell order",
-      "delete": "Delete sell order",
+      "delete": "Sell order",
       "update": "Update sell order"
     }
   },

--- a/src/TransactionReview/components/ReviewForm.tsx
+++ b/src/TransactionReview/components/ReviewForm.tsx
@@ -1,3 +1,4 @@
+import BigNumber from "big.js"
 import nanoid from "nanoid"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -115,6 +116,12 @@ function TxConfirmationForm(props: Props) {
   const DismissIcon = React.useMemo(() => <CloseIcon style={{ fontSize: "140%" }} />, [])
   const ConfirmIcon = React.useMemo(() => <CheckIcon />, [])
 
+  const isOrderCancellation = props.transaction.operations.every(
+    op =>
+      (op.type === "manageBuyOffer" && BigNumber(op.buyAmount).eq(0)) ||
+      (op.type === "manageSellOffer" && BigNumber(op.amount).eq(0))
+  )
+
   const showLoadingIndicator = React.useCallback(() => {
     setLoading(true)
   }, [])
@@ -164,7 +171,9 @@ function TxConfirmationForm(props: Props) {
               onClick={showLoadingIndicator}
               type="submit"
             >
-              {t("account.transaction-review.action.confirm")}
+              {isOrderCancellation
+                ? t("account.transaction-review.action.cancel-order")
+                : t("account.transaction-review.action.confirm")}
             </ActionButton>
           )}
           {props.disabled && !props.signatureRequest ? (


### PR DESCRIPTION
Title: "Buy order" / "Sell order"
Button: "Cancel order"

Was titled "Delete {buy,sell} order" and "Confirm" before. Looked weird / was a bit confusing as those two messages together made sense, but they appear far away from another.