### PR TITLE
Replace hardcoded strings in receive payment

### DIFF
--- a/i18n/locales/en/account-settings.json
+++ b/i18n/locales/en/account-settings.json
@@ -78,7 +78,8 @@
         "paragraph-1": "The secret key backup is the only way to recover your funds if you forget your password or cannot access your device anymore.",
         "paragraph-2": "Write down the key or print it. Keep it in a safe place and do not share it with anyone."
       },
-      "secret-key": "Write down the key on paper and store it in a safe place."
+      "secret-key": "Write down the key on paper and store it in a safe place.",
+      "tap-to-copy": "Tap to copy"
     },
     "textfield": {
       "password": {

--- a/i18n/locales/en/payment.json
+++ b/i18n/locales/en/payment.json
@@ -23,7 +23,7 @@
       "placeholder": "Max. {{amount}}"
     }
   },
-  "title": "Send funds",
+  "title": { "send": "Send funds", "receive": "Receive Funds" },
   "validation": {
     "memo-required": "Set a memo when sending funds to {{destination}}",
     "memo-too-long": "Memo too long.",

--- a/src/Account/components/KeyExportBox.tsx
+++ b/src/Account/components/KeyExportBox.tsx
@@ -1,5 +1,6 @@
 import QRCode from "qrcode.react"
 import React from "react"
+import { useTranslation } from "react-i18next"
 import Typography from "@material-ui/core/Typography"
 import { useClipboard } from "~Generic/hooks/userinterface"
 import { Box, VerticalLayout } from "~Layout/components/Box"
@@ -13,6 +14,7 @@ interface Props {
 function KeyExportBox(props: Props) {
   const clipboard = useClipboard()
   const copyToClipboard = React.useCallback(() => clipboard.copyToClipboard(props.export), [clipboard, props.export])
+  const { t } = useTranslation()
 
   return (
     <VerticalLayout alignItems="center" justifyContent="center">
@@ -22,7 +24,7 @@ function KeyExportBox(props: Props) {
         </Box>
         <Box margin="16px auto">
           <Typography align="center" style={{ display: props.hideTapToCopy ? "none" : undefined, marginBottom: 12 }}>
-            Tap to copy:
+            {t("account-settings.export-key.info.tap-to-copy")}:
           </Typography>
           <Typography
             align="center"

--- a/src/Payment/components/ReceivePaymentDialog.tsx
+++ b/src/Payment/components/ReceivePaymentDialog.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import { Account } from "~App/contexts/accounts"
 import { useIsMobile } from "~Generic/hooks/userinterface"
 import { Box } from "~Layout/components/Box"
@@ -13,8 +14,10 @@ interface Props {
 
 function ReceivePaymentDialog(props: Props) {
   const isSmallScreen = useIsMobile()
+  const { t } = useTranslation()
+
   return (
-    <DialogBody top={<MainTitle onBack={props.onClose} title="Receive Funds" />}>
+    <DialogBody top={<MainTitle onBack={props.onClose} title={t("payment.title.receive")} />}>
       <Box width="100%" margin="32px auto">
         <KeyExportBox export={props.account.publicKey} size={isSmallScreen ? 192 : 256} />
       </Box>


### PR DESCRIPTION
Based on #1035.

Replaces hardcoded strings in `<ReceivePaymentDialog>` and `<KeyExportBox>`.

