### PR TITLE
Fix co-signing notification shown when awaiting additional signatures

### DIFF
--- a/src/App/components/DesktopNotifications.tsx
+++ b/src/App/components/DesktopNotifications.tsx
@@ -109,16 +109,21 @@ function DesktopNotifications() {
   const handleNewSignatureRequest = React.useCallback(
     (signatureRequest: SignatureRequest) => {
       const signersHavingSigned = signatureRequest._embedded.signers.filter(signer => signer.has_signed)
+      const signersNotHavingSigned = signatureRequest._embedded.signers.filter(signer => !signer.has_signed)
+      const accountPublicKeys = accounts.map(account => account.publicKey)
 
-      showNotification(
-        {
-          title: "New transaction to co-sign",
-          text: `From ${signersHavingSigned.map(signer => signer.account_id).join(", ")}`
-        },
-        () => router.history.push(routes.allAccounts())
-      )
+      // only show notification when a local account has to co-sign
+      if (signersNotHavingSigned.some(signer => accountPublicKeys.includes(signer.account_id))) {
+        showNotification(
+          {
+            title: "New transaction to co-sign",
+            text: `From ${signersHavingSigned.map(signer => signer.account_id).join(", ")}`
+          },
+          () => router.history.push(routes.allAccounts())
+        )
+      }
     },
-    [router.history]
+    [accounts, router.history]
   )
 
   React.useEffect(() => {


### PR DESCRIPTION
Only show the 'New transaction to co-sign' notification when a local account is a signer who hasn't signed yet.

Closes #1057.