### PR TITLE
Delay navigation after successful trading submission

### DIFF
--- a/src/Trading/components/TradingDialog.tsx
+++ b/src/Trading/components/TradingDialog.tsx
@@ -149,10 +149,13 @@ function TradingDialog(props: TradingDialogProps) {
 
 function TradingDialogContainer(props: Pick<TradingDialogProps, "account" | "onClose">) {
   const router = useRouter()
-  const navigateToAssets = () => router.history.push(routes.account(props.account.id))
+  const navigateToAccount = () =>
+    setTimeout(() => {
+      router.history.push(routes.account(props.account.id))
+    }, 1000)
 
   return (
-    <TransactionSender account={props.account} onSubmissionCompleted={navigateToAssets}>
+    <TransactionSender account={props.account} onSubmissionCompleted={navigateToAccount}>
       {txContext => <TradingDialog {...props} {...txContext} />}
     </TransactionSender>
   )


### PR DESCRIPTION
This delays the navigation back to the account by 1 second so that the submission progress stays visible for showing the success.