### PR TITLE
Fix user not able to send max amount in payment view

### DIFF
--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -223,7 +223,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
         inputRef={form.register({
           required: t<string>("payment.validation.no-price"),
           pattern: { value: /^[0-9]+(\.[0-9]+)?$/, message: t<string>("payment.validation.invalid-price") },
-          validate: value => BigNumber(value).lt(spendableBalance) || t<string>("payment.validation.not-enough-funds")
+          validate: value => BigNumber(value).lte(spendableBalance) || t<string>("payment.validation.not-enough-funds")
         })}
         label={form.errors.amount ? form.errors.amount.message : "Amount"}
         margin="normal"


### PR DESCRIPTION
Fixes a bug where the user is not able to send the maximum spendable amount of his asset.