### PR TITLE
Fix wrong calculation of spendable balance

### DIFF
--- a/src/Assets/components/BalanceDetailsDialog.tsx
+++ b/src/Assets/components/BalanceDetailsDialog.tsx
@@ -13,7 +13,7 @@ import { useIsMobile, useRouter } from "~Generic/hooks/userinterface"
 import { useLiveAccountData, useLiveAccountOffers } from "~Generic/hooks/stellar-subscriptions"
 import { AccountData } from "~Generic/lib/account"
 import { matchesRoute } from "~Generic/lib/routes"
-import { stringifyAsset, getAccountMinimumBalance } from "~Generic/lib/stellar"
+import { stringifyAsset, getAccountMinimumBalance, getSpendableBalance } from "~Generic/lib/stellar"
 import { sortBalances } from "~Generic/lib/balances"
 import MainTitle from "~Generic/components/MainTitle"
 import ViewLoading from "~Generic/components/ViewLoading"
@@ -101,9 +101,10 @@ const NativeBalanceItems = React.memo(function NativeBalanceItems(props: NativeB
           ...props.balance,
           balance: BigNumber(props.balance.balance).eq(0)
             ? "0"
-            : BigNumber(props.balance.balance)
-                .minus(getAccountMinimumBalance(props.accountData, props.openOffers.length))
-                .toString()
+            : getSpendableBalance(
+                getAccountMinimumBalance(props.accountData, props.openOffers.length),
+                props.balance
+              ).toString()
         }}
         hideLogo
         onClick={() => props.onOpenAssetDetails(Asset.native())}

--- a/src/Assets/components/SpendableBalanceBreakdown.tsx
+++ b/src/Assets/components/SpendableBalanceBreakdown.tsx
@@ -161,7 +161,7 @@ function SpendableBalanceBreakdown(props: Props) {
     <List style={{ padding: 0 }}>
       <BreakdownHeadline right={t("account.balance-details.spendable-balances.headline")} />
       <BreakdownItem
-        amount={rawBalance.toFixed(1)}
+        amount={rawBalance.toFixed(4)}
         primary={t("account.balance-details.spendable-balances.total-balance.primary")}
         secondary={t("account.balance-details.spendable-balances.total-balance.secondary")}
         style={props.style}

--- a/src/Generic/lib/stellar.ts
+++ b/src/Generic/lib/stellar.ts
@@ -133,6 +133,17 @@ export function getAccountMinimumBalance(
     .mul(baseReserve)
 }
 
+export function getSpendableBalance(accountMinimumBalance: BigNumber, balanceLine?: Horizon.BalanceLine) {
+  if (balanceLine !== undefined) {
+    const fullBalance = BigNumber(balanceLine.balance)
+    return balanceLine.asset_type === "native"
+      ? fullBalance.minus(accountMinimumBalance).minus(balanceLine.selling_liabilities)
+      : fullBalance.minus(balanceLine.selling_liabilities)
+  } else {
+    return BigNumber(0)
+  }
+}
+
 export function getAssetsFromBalances(balances: Horizon.BalanceLine[]) {
   return balances.map(balance =>
     balance.asset_type === "native"

--- a/src/Payment/components/PaymentDialog.tsx
+++ b/src/Payment/components/PaymentDialog.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Asset, Server, Transaction } from "stellar-sdk"
 import { Account } from "~App/contexts/accounts"
 import { trackError } from "~App/contexts/notifications"
-import { useLiveAccountData } from "~Generic/hooks/stellar-subscriptions"
+import { useLiveAccountData, useLiveAccountOffers } from "~Generic/hooks/stellar-subscriptions"
 import { useDialogActions } from "~Generic/hooks/userinterface"
 import { AccountData } from "~Generic/lib/account"
 import { getAssetsFromBalances } from "~Generic/lib/stellar"
@@ -20,6 +20,7 @@ interface Props {
   accountData: AccountData
   horizon: Server
   onClose: () => void
+  openOrdersCount: number
   sendTransaction: (transaction: Transaction) => Promise<any>
 }
 
@@ -73,6 +74,7 @@ function PaymentDialog(props: Props) {
         actionsRef={dialogActionsRef}
         onCancel={props.onClose}
         onSubmit={handleSubmit}
+        openOrdersCount={props.openOrdersCount}
         testnet={props.account.testnet}
         trustedAssets={trustedAssets}
         txCreationPending={txCreationPending}
@@ -83,6 +85,8 @@ function PaymentDialog(props: Props) {
 
 function ConnectedPaymentDialog(props: Pick<Props, "account" | "onClose">) {
   const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
+  const openOrders = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
+
   const closeAfterTimeout = () => {
     // Close automatically a second after successful submission
     setTimeout(() => props.onClose(), 1000)
@@ -90,7 +94,13 @@ function ConnectedPaymentDialog(props: Pick<Props, "account" | "onClose">) {
   return (
     <TransactionSender account={props.account} onSubmissionCompleted={closeAfterTimeout}>
       {({ horizon, sendTransaction }) => (
-        <PaymentDialog {...props} accountData={accountData} horizon={horizon} sendTransaction={sendTransaction} />
+        <PaymentDialog
+          {...props}
+          accountData={accountData}
+          horizon={horizon}
+          openOrdersCount={openOrders.length}
+          sendTransaction={sendTransaction}
+        />
       )}
     </TransactionSender>
   )


### PR DESCRIPTION
- [x] Move calculation of spendable balance to `lib/stellar.ts`
- [x] Fix incorrect spendable balance shown in balances overview
- [x] Fix incorrect spendable balance shown in payment form
- [x] Round the number shown as 'Total balance' in spendable balance breakdown to 4 decimals instead of 1 because the calculation might appear wrong as depicted in this picture:
<img width="841" alt="Screenshot 2020-05-04 at 16 42 44" src="https://user-images.githubusercontent.com/6690623/81059028-f18ac780-8ecf-11ea-9bf4-16dc23c17deb.png">

Closes #1071.