### PR TITLE
Fix infinite re-render of trading form

### DIFF
--- a/src/Generic/hooks/stellar-subscriptions.ts
+++ b/src/Generic/hooks/stellar-subscriptions.ts
@@ -190,7 +190,8 @@ export function useLiveOrderbook(selling: Asset, buying: Asset, testnet: boolean
         return netWorker.subscribeToOrderbook(horizonURL, stringifyAsset(selling), stringifyAsset(buying))
       }
     }
-  }, [buying, horizonURL, netWorker, selling])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stringifyAsset(buying), horizonURL, netWorker, stringifyAsset(selling)])
 
   return useDataSubscription(applyOrderbookUpdate, get, set, observe)
 }


### PR DESCRIPTION
Fixes the infinite re-render of the trading form by stringifying the assets in the dependency list.