### PR TITLE
Take open offers into account for trading

### DIFF
--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -18,6 +18,7 @@
     "fetch-account-data-error": "Cannot fetch account data of {{account}} from {{horizon}}",
     "fetch-signature-requests-error": "Fetching signature requests failed: {{response}} \nService: {{service}}",
     "invariant-violation-error": "Invariant violation: {{message}}",
+    "low-reserve-order-error": "Cannot place order because spendable XLM balance is too low.",
     "memo-already-specified-error": "Cannot set a custom memo. Federation record of {{destination}} already specifies memo.",
     "multi-sig-event-stream-double-errored-error": "Multi-signature update event stream double-errored: {{url}}",
     "no-callback-url-error": "Cannot submit back to multi-signature service. Signature request has no callback URL set.",

--- a/src/Assets/components/AssetDetailsDialog.tsx
+++ b/src/Assets/components/AssetDetailsDialog.tsx
@@ -9,7 +9,7 @@ import { makeStyles } from "@material-ui/core/styles"
 import { Account } from "~App/contexts/accounts"
 import { useAccountData, useAssetMetadata, useStellarToml } from "~Generic/hooks/stellar"
 import { useClipboard, useIsMobile } from "~Generic/hooks/userinterface"
-import { parseAssetID } from "~Generic/lib/stellar"
+import { BASE_RESERVE, parseAssetID } from "~Generic/lib/stellar"
 import { openLink } from "~Platform/links"
 import { breakpoints } from "~App/theme"
 import { StellarTomlCurrency } from "~shared/types/stellar-toml"
@@ -80,7 +80,7 @@ const LumenDetails = React.memo(function LumenDetails(props: LumenDetailProps) {
       </Card>
       <Card className={classes.card}>
         <CardContent className={classes.cardContent}>
-          <SpendableBalanceBreakdown account={props.account} accountData={accountData} baseReserve={0.5} />
+          <SpendableBalanceBreakdown account={props.account} accountData={accountData} baseReserve={BASE_RESERVE} />
         </CardContent>
       </Card>
     </>

--- a/src/Generic/lib/stellar.ts
+++ b/src/Generic/lib/stellar.ts
@@ -36,6 +36,9 @@ const MAX_INT64 = "9223372036854775807"
 
 const dedupe = <T>(array: T[]) => Array.from(new Set(array))
 
+// FIXME: Needs to be queried from horizon
+export const BASE_RESERVE = 0.5
+
 export const networkPassphrases = {
   mainnet: "Public Global Stellar Network ; September 2015",
   testnet: "Test SDF Network ; September 2015"
@@ -120,9 +123,6 @@ export function getAccountMinimumBalance(
   accountData: Pick<AccountData, "balances" | "data_attr" | "signers">,
   openOfferCount: number = 0
 ) {
-  // FIXME: Needs to be queried from horizon
-  const baseReserve = BigNumber(0.5)
-
   const trustlineCount = accountData.balances.filter(balance => balance.asset_type !== "native").length
 
   return BigNumber(1)
@@ -130,7 +130,7 @@ export function getAccountMinimumBalance(
     .add(Object.keys(accountData.data_attr).length)
     .add(openOfferCount)
     .add(trustlineCount)
-    .mul(baseReserve)
+    .mul(BASE_RESERVE)
 }
 
 export function getSpendableBalance(accountMinimumBalance: BigNumber, balanceLine?: Horizon.BalanceLine) {

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -21,7 +21,7 @@ import { ReadOnlyTextfield } from "~Generic/components/FormFields"
 import { ActionButton, DialogActionsBox } from "~Generic/components/DialogActions"
 import Portal from "~Generic/components/Portal"
 import { useHorizon } from "~Generic/hooks/stellar"
-import { useLiveOrderbook } from "~Generic/hooks/stellar-subscriptions"
+import { useLiveOrderbook, useLiveAccountOffers } from "~Generic/hooks/stellar-subscriptions"
 import { useIsMobile, RefStateObject } from "~Generic/hooks/userinterface"
 import { AccountData } from "~Generic/lib/account"
 import { CustomError } from "~Generic/lib/errors"
@@ -94,10 +94,18 @@ function TradingForm(props: Props) {
 
   const horizon = useHorizon(props.account.testnet)
   const tradePair = useLiveOrderbook(primaryAsset || Asset.native(), secondaryAsset, props.account.testnet)
+  const openOrders = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
 
   const assets = React.useMemo(() => props.trustlines.map(balancelineToAsset), [props.trustlines])
 
-  const calculation = useCalculation(form.getValues(), tradePair, priceMode, props.accountData, props.primaryAction)
+  const calculation = useCalculation(
+    form.getValues(),
+    tradePair,
+    priceMode,
+    props.accountData,
+    props.primaryAction,
+    openOrders.length
+  )
 
   const {
     maxPrimaryAmount,

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -103,14 +103,14 @@ function TradingForm(props: Props) {
 
   const assets = React.useMemo(() => props.trustlines.map(balancelineToAsset), [props.trustlines])
 
-  const calculation = useCalculation(
-    form.getValues(),
-    tradePair,
+  const calculation = useCalculation({
+    accountData: props.accountData,
+    openOrdersCount: openOrders.length,
     priceMode,
-    props.accountData,
-    props.primaryAction,
-    openOrders.length
-  )
+    primaryAction: props.primaryAction,
+    tradePair,
+    values: form.getValues()
+  })
 
   const {
     maxPrimaryAmount,

--- a/src/Trading/hooks/form.ts
+++ b/src/Trading/hooks/form.ts
@@ -32,6 +32,15 @@ export interface TradingFormValues {
   manualPrice: string
 }
 
+interface CalculationParameters {
+  accountData: AccountData
+  openOrdersCount: number
+  priceMode: "primary" | "secondary"
+  primaryAction: "buy" | "sell"
+  tradePair: FixedOrderbookRecord
+  values: TradingFormValues
+}
+
 interface CalculationResults {
   defaultPrice: string
   effectivePrice: BigNumber
@@ -46,15 +55,9 @@ interface CalculationResults {
   spendableSecondaryBalance: BigNumber
 }
 
-export function useCalculation(
-  values: TradingFormValues,
-  tradePair: FixedOrderbookRecord,
-  priceMode: "primary" | "secondary",
-  accountData: AccountData,
-  primaryAction: "buy" | "sell",
-  openOrders: number
-): CalculationResults {
-  const { manualPrice, primaryAmountString, primaryAsset, secondaryAsset } = values
+export function useCalculation(parameters: CalculationParameters): CalculationResults {
+  const { accountData, openOrdersCount, priceMode, primaryAction, tradePair } = parameters
+  const { manualPrice, primaryAmountString, primaryAsset, secondaryAsset } = parameters.values
 
   const price =
     manualPrice && isValidAmount(manualPrice)
@@ -86,7 +89,7 @@ export function useCalculation(
   const inversePrice = effectivePrice.eq(0) ? BigNumber(0) : BigNumber(1).div(effectivePrice)
   const defaultPrice = bigNumberToInputValue(priceMode === "secondary" ? effectivePrice : inversePrice)
 
-  const minAccountBalance = getAccountMinimumBalance(accountData, openOrders)
+  const minAccountBalance = getAccountMinimumBalance(accountData, openOrdersCount)
 
   const spendablePrimaryBalance = primaryBalance
     ? primaryAction === "sell"

--- a/src/Trading/hooks/form.ts
+++ b/src/Trading/hooks/form.ts
@@ -3,7 +3,7 @@ import { Asset, Horizon } from "stellar-sdk"
 import { AccountData } from "~Generic/lib/account"
 import { formatBalance, BalanceFormattingOptions } from "~Generic/lib/balances"
 import { calculateSpread, FixedOrderbookRecord } from "~Generic/lib/orderbook"
-import { balancelineToAsset, getAccountMinimumBalance, getSpendableBalance } from "~Generic/lib/stellar"
+import { BASE_RESERVE, balancelineToAsset, getAccountMinimumBalance, getSpendableBalance } from "~Generic/lib/stellar"
 import { useConversionOffers } from "./conversion"
 
 export const bigNumberToInputValue = (bignum: BigNumber, overrides?: BalanceFormattingOptions) =>
@@ -15,12 +15,10 @@ function findMatchingBalance(balances: AccountData["balances"], asset: Asset) {
   return balances.find(balance => balancelineToAsset(balance).equals(asset))
 }
 
-const baseReserve = BigNumber(0.5)
-
 function getSpendableBalanceWithoutBaseReserve(accountMinimumBalance: BigNumber, balanceLine: Horizon.BalanceLine) {
   const spendableBalance = getSpendableBalance(accountMinimumBalance, balanceLine).minus(
     // subtract base-reserve when asset_type is native because placing a new order requires 1 * base-reserve XLM
-    BigNumber(balanceLine.asset_type === "native" ? baseReserve : BigNumber(0))
+    BigNumber(balanceLine.asset_type === "native" ? BASE_RESERVE : BigNumber(0))
   )
 
   // return 0 if calculated balance is negative

--- a/src/Trading/hooks/form.ts
+++ b/src/Trading/hooks/form.ts
@@ -3,7 +3,7 @@ import { Asset, Horizon } from "stellar-sdk"
 import { AccountData } from "~Generic/lib/account"
 import { formatBalance, BalanceFormattingOptions } from "~Generic/lib/balances"
 import { calculateSpread, FixedOrderbookRecord } from "~Generic/lib/orderbook"
-import { balancelineToAsset, getAccountMinimumBalance } from "~Generic/lib/stellar"
+import { balancelineToAsset, getAccountMinimumBalance, getSpendableBalance } from "~Generic/lib/stellar"
 import { useConversionOffers } from "./conversion"
 
 export const bigNumberToInputValue = (bignum: BigNumber, overrides?: BalanceFormattingOptions) =>
@@ -13,6 +13,18 @@ export const isValidAmount = (amount: string) => /^[0-9]+([\.,][0-9]+)?$/.test(a
 
 function findMatchingBalance(balances: AccountData["balances"], asset: Asset) {
   return balances.find(balance => balancelineToAsset(balance).equals(asset))
+}
+
+const baseReserve = BigNumber(0.5)
+
+function getSpendableBalanceWithoutBaseReserve(accountMinimumBalance: BigNumber, balanceLine: Horizon.BalanceLine) {
+  const spendableBalance = getSpendableBalance(accountMinimumBalance, balanceLine).minus(
+    // subtract base-reserve when asset_type is native because placing a new order requires 1 * base-reserve XLM
+    BigNumber(balanceLine.asset_type === "native" ? baseReserve : BigNumber(0))
+  )
+
+  // return 0 if calculated balance is negative
+  return spendableBalance.cmp(BigNumber(0)) < 0 ? BigNumber(0) : spendableBalance
 }
 
 export interface TradingFormValues {
@@ -41,7 +53,8 @@ export function useCalculation(
   tradePair: FixedOrderbookRecord,
   priceMode: "primary" | "secondary",
   accountData: AccountData,
-  primaryAction: "buy" | "sell"
+  primaryAction: "buy" | "sell",
+  openOrders: number
 ): CalculationResults {
   const { manualPrice, primaryAmountString, primaryAsset, secondaryAsset } = values
 
@@ -75,14 +88,18 @@ export function useCalculation(
   const inversePrice = effectivePrice.eq(0) ? BigNumber(0) : BigNumber(1).div(effectivePrice)
   const defaultPrice = bigNumberToInputValue(priceMode === "secondary" ? effectivePrice : inversePrice)
 
-  const minAccountBalance = getAccountMinimumBalance(accountData)
+  const minAccountBalance = getAccountMinimumBalance(accountData, openOrders)
 
   const spendablePrimaryBalance = primaryBalance
-    ? BigNumber(primaryBalance.balance).sub(primaryBalance.asset_type === "native" ? minAccountBalance : 0)
+    ? primaryAction === "sell"
+      ? getSpendableBalanceWithoutBaseReserve(minAccountBalance, primaryBalance)
+      : getSpendableBalance(minAccountBalance, primaryBalance)
     : BigNumber(0)
 
   const spendableSecondaryBalance = secondaryBalance
-    ? BigNumber(secondaryBalance.balance).sub(secondaryBalance.asset_type === "native" ? minAccountBalance : 0)
+    ? primaryAction === "buy"
+      ? getSpendableBalanceWithoutBaseReserve(minAccountBalance, secondaryBalance)
+      : getSpendableBalance(minAccountBalance, secondaryBalance)
     : BigNumber(0)
 
   const maxPrimaryAmount =


### PR DESCRIPTION
- [x] Pass amount of open orders to `getAccountMinimumBalance()` for calculation of trading form values so that open orders are considered when calculating minimum balance
- [x] Use `getSpendableBalance()` function which takes `selling_liabilities` into account
- [x] Add `getSpendableBalanceWithoutBaseReserve()` function which subtracts the base-reserve from the spendable balance if it's of type 'native' because issuing an order increases the minimum account balance
- [x] Show error message on submit when user cannot place new orders due to insufficient native balance

Closes #1070. 