### PR TITLE
Fix no error message shown when importing wrong secret key

### DIFF
--- a/src/AccountCreation/components/NewAccountSettings.tsx
+++ b/src/AccountCreation/components/NewAccountSettings.tsx
@@ -43,7 +43,11 @@ function NewAccountSettings(props: NewAccountSettingsProps) {
   return (
     <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
       {props.accountCreation.import ? (
-        <SecretKeyImport onEnterSecretKey={updateSecretKey} secretKey={props.accountCreation.secretKey || ""} />
+        <SecretKeyImport
+          error={props.errors.secretKey}
+          onEnterSecretKey={updateSecretKey}
+          secretKey={props.accountCreation.secretKey || ""}
+        />
       ) : null}
       <PasswordSetting
         error={props.errors.password}


### PR DESCRIPTION
Fixes a bug where no error message was shown when trying to import a wrong secret key in the account creation form.