### PR TITLE
Hide language selector

### DIFF
--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -1,1 +1,1 @@
-export const availableLanguages = ["en", "zh"] as const
+export const availableLanguages = ["en"] as const


### PR DESCRIPTION
Hides the language selector in the app settings (as other languages are not ready yet).
Removing 'zh' from available languages implicitly hides the language selector because it is only shown when the length of available languages is greater than one.