### PR TITLE
Fix inconsistent labelling of orders containing XLM

### DIFF
--- a/src/Account/components/OfferList.tsx
+++ b/src/Account/components/OfferList.tsx
@@ -27,18 +27,36 @@ function createDismissalTransaction(
   accountData: AccountData,
   offer: ServerApi.OfferRecord
 ): Promise<Transaction> {
-  return createTransaction(
-    [
-      Operation.manageSellOffer({
-        offerId: offer.id,
-        amount: "0",
-        buying: offerAssetToAsset(offer.buying),
-        price: offer.price,
-        selling: offerAssetToAsset(offer.selling)
-      })
-    ],
-    { accountData, horizon, walletAccount: account }
-  )
+  const buying = offerAssetToAsset(offer.buying)
+  const selling = offerAssetToAsset(offer.selling)
+
+  if (selling.isNative()) {
+    return createTransaction(
+      [
+        Operation.manageBuyOffer({
+          offerId: offer.id,
+          buyAmount: "0",
+          buying,
+          price: offer.price,
+          selling
+        })
+      ],
+      { accountData, horizon, walletAccount: account }
+    )
+  } else {
+    return createTransaction(
+      [
+        Operation.manageSellOffer({
+          offerId: offer.id,
+          amount: "0",
+          buying,
+          price: offer.price,
+          selling
+        })
+      ],
+      { accountData, horizon, walletAccount: account }
+    )
+  }
 }
 
 interface OfferListItemProps {

--- a/src/Account/components/TransactionList.tsx
+++ b/src/Account/components/TransactionList.tsx
@@ -60,14 +60,6 @@ function OfferDescription(props: {
   const { t } = useTranslation()
   let prefix: string
 
-  if (amount.eq(0)) {
-    return (
-      <>
-        Delete offer: Sell {selling.code} for {buying.code}
-      </>
-    )
-  }
-
   if (offerId === "0") {
     prefix = `${t("account.transactions.transaction-list.offer-description.prefix.default")}: `
   } else if (amount.eq(0)) {
@@ -82,25 +74,25 @@ function OfferDescription(props: {
       {props.type === "manageBuyOffer"
         ? t(
             "account.transactions.transaction-list.offer-description.buy",
-            `Buy ${formatBalance(amount.toString())} ${buying.code} for ${formatBalance(
-              amount.mul(price).toString()
-            )} ${selling.code}`,
+            `Buy ${amount.eq(0) ? "" : formatBalance(amount.toString())} ${buying.code} for ${
+              amount.eq(0) ? "" : formatBalance(amount.mul(price).toString())
+            } ${selling.code}`,
             {
-              buyingAmount: formatBalance(amount.toString()),
+              buyingAmount: amount.eq(0) ? "" : formatBalance(amount.toString()),
               buyingCode: buying.code,
-              sellingAmount: formatBalance(amount.mul(price).toString()),
+              sellingAmount: amount.eq(0) ? "" : formatBalance(amount.mul(price).toString()),
               sellingCode: selling.code
             }
           )
         : t(
             "account.transactions.transaction-list.offer-description.sell",
-            `Sell ${formatBalance(amount.toString())} ${selling.code} for ${formatBalance(
-              amount.mul(price).toString()
-            )} ${buying.code}`,
+            `Sell ${amount.eq(0) ? "" : formatBalance(amount.toString())} ${selling.code} for ${
+              amount.eq(0) ? "" : formatBalance(amount.mul(price).toString())
+            } ${buying.code}`,
             {
-              buyingAmount: formatBalance(amount.mul(price).toString()),
+              buyingAmount: amount.eq(0) ? "" : formatBalance(amount.mul(price).toString()),
               buyingCode: buying.code,
-              sellingAmount: formatBalance(amount.toString()),
+              sellingAmount: amount.eq(0) ? "" : formatBalance(amount.toString()),
               sellingCode: selling.code
             }
           )}

--- a/src/TransactionReview/components/Operations.tsx
+++ b/src/TransactionReview/components/Operations.tsx
@@ -309,19 +309,48 @@ function ManageOfferOperation(props: ManageOfferOperationProps) {
         : t("operations.manage-sell-offer.title.update")
 
     return offer ? (
+      props.operation.type === "manageBuyOffer" ? (
+        <SummaryItem heading={props.hideHeading ? undefined : heading}>
+          <SummaryDetailsField
+            label={t("operations.manage-offer.summary.buy")}
+            value={
+              <SingleBalance
+                assetCode={offerAssetToAsset(offer.buying).getCode()}
+                balance={String(BigNumber(offer.amount).mul(offer.price))}
+              />
+            }
+          />
+          <SummaryDetailsField
+            label={t("operations.manage-offer.summary.sell")}
+            value={<SingleBalance assetCode={offerAssetToAsset(offer.selling).getCode()} balance={offer.amount} />}
+          />
+        </SummaryItem>
+      ) : (
+        <SummaryItem heading={props.hideHeading ? undefined : heading}>
+          <SummaryDetailsField
+            label={t("operations.manage-offer.summary.sell")}
+            value={<SingleBalance assetCode={offerAssetToAsset(offer.selling).getCode()} balance={offer.amount} />}
+          />
+          <SummaryDetailsField
+            label={t("operations.manage-offer.summary.buy")}
+            value={
+              <SingleBalance
+                assetCode={offerAssetToAsset(offer.buying).getCode()}
+                balance={String(BigNumber(offer.amount).mul(offer.price))}
+              />
+            }
+          />
+        </SummaryItem>
+      )
+    ) : props.operation.type === "manageBuyOffer" ? (
       <SummaryItem heading={props.hideHeading ? undefined : heading}>
         <SummaryDetailsField
-          label={t("operations.manage-offer.summary.sell")}
-          value={<SingleBalance assetCode={offerAssetToAsset(offer.selling).getCode()} balance={offer.amount} />}
+          label={t("operations.manage-offer.summary.buy")}
+          value={<SingleBalance assetCode={buying.code} balance={String(buyAmount)} />}
         />
         <SummaryDetailsField
-          label={t("operations.manage-offer.summary.buy")}
-          value={
-            <SingleBalance
-              assetCode={offerAssetToAsset(offer.buying).getCode()}
-              balance={String(BigNumber(offer.amount).mul(offer.price))}
-            />
-          }
+          label={t("operations.manage-offer.summary.sell")}
+          value={<SingleBalance assetCode={selling.code} balance={String(sellAmount)} />}
         />
       </SummaryItem>
     ) : (


### PR DESCRIPTION
Fixes inconsistencies regarding descriptions and titles of orders that contain XLM as selling asset.
While we use 'Buy xxx for XLM' as order description when an open order contains XLM as  'selling' asset the description of a canceled order and the order details did not adhere to this pattern.

- [x] Show 'Buy order' instead of 'Sell order' as title when clicking on an open order with XLM as selling asset
- [x] Remove unnecessary early return in `OfferDescription` and reuse existing text text for canceled orders (don't show amount if it's equal to 0 because this is our criteria for canceled orders)
- [x] Change alignment of 'Buy'/'Sell' summary details fields when XLM is selling asset (i.e. put 'Buy' before 'Sell' when selling XLM)