### PR TITLE
Fix trading form misaligned and without preselected asset

### DIFF
--- a/src/Layout/components/Carousel.tsx
+++ b/src/Layout/components/Carousel.tsx
@@ -36,6 +36,8 @@ export interface CarouselProps {
   current: number
 }
 
+// You must NOT use the autoFocus prop in children of the Carousel as this
+// might cause unexpected behaviour (see https://github.com/satoshipay/solar/issues/1069)
 function Carousel(props: CarouselProps) {
   const classes = useCarouselStyles(props)
 

--- a/src/Layout/components/Carousel.tsx
+++ b/src/Layout/components/Carousel.tsx
@@ -37,41 +37,13 @@ export interface CarouselProps {
 }
 
 function Carousel(props: CarouselProps) {
-  const { current } = props
   const classes = useCarouselStyles(props)
-
-  // workaround to prevent misalignment of children on initial render
-  const refs: Array<React.RefObject<HTMLDivElement>> = props.children.map(() => React.createRef<HTMLDivElement>())
-  React.useEffect(() => {
-    refs.forEach((ref, index) => {
-      if (ref.current) {
-        ref.current.style.visibility = index === current ? "visible" : "hidden"
-      }
-    })
-
-    setTimeout(() => {
-      refs.forEach(ref => {
-        if (ref.current) {
-          ref.current.style.visibility = "visible"
-        }
-      })
-    }, 0)
-
-    setTimeout(() => {
-      refs.forEach(ref => {
-        if (ref.current) {
-          ref.current.style.visibility = "visible"
-        }
-      })
-    }, 500)
-  }, [current, refs])
 
   return (
     <div className={classes.root}>
       <div className={classes.sledge}>
         {props.children.map((content, index) => (
           <div
-            ref={refs[index]}
             key={index}
             className={[classes.slide, index === props.current ? classes.active : ""].join(" ")}
             style={{

--- a/src/Layout/components/Carousel.tsx
+++ b/src/Layout/components/Carousel.tsx
@@ -36,8 +36,12 @@ export interface CarouselProps {
   current: number
 }
 
-// You must NOT use the autoFocus prop in children of the Carousel as this
-// might cause unexpected behaviour (see https://github.com/satoshipay/solar/issues/1069)
+/**
+ * IMPORTANT:
+ * You must NOT use the `autoFocus` prop in children of the Carousel as this
+ * might cause the Carousel to get stuck in an invalid scroll position (see
+ * https://github.com/satoshipay/solar/issues/1069)
+ */
 function Carousel(props: CarouselProps) {
   const classes = useCarouselStyles(props)
 

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -204,7 +204,6 @@ function TradingForm(props: Props) {
             as={
               <AssetSelector
                 assets={assets}
-                autoFocus={Boolean(process.env.PLATFORM !== "ios" && !props.initialPrimaryAsset)}
                 inputError={form.errors.primaryAsset && form.errors.primaryAsset.message}
                 label={
                   props.primaryAction === "buy"
@@ -225,7 +224,6 @@ function TradingForm(props: Props) {
             }}
           />
           <TextField
-            autoFocus={Boolean(process.env.PLATFORM !== "ios" && props.initialPrimaryAsset)}
             name="primaryAmountString"
             inputRef={form.register({
               required: t<string>("trading.validation.primary-amount-missing"),

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -92,6 +92,12 @@ function TradingForm(props: Props) {
   const sendTransaction = props.sendTransaction
   const { primaryAsset, secondaryAsset } = form.watch()
 
+  React.useEffect(() => {
+    if (!primaryAsset && props.initialPrimaryAsset) {
+      form.setValue("primaryAsset", props.initialPrimaryAsset)
+    }
+  }, [form, primaryAsset, props.initialPrimaryAsset])
+
   const horizon = useHorizon(props.account.testnet)
   const tradePair = useLiveOrderbook(primaryAsset || Asset.native(), secondaryAsset, props.account.testnet)
 

--- a/src/TransferService/components/FormBuilder.tsx
+++ b/src/TransferService/components/FormBuilder.tsx
@@ -7,7 +7,6 @@ import { formatDescriptionText, formatIdentifier } from "../util/formatters"
 import FormLayout from "./FormLayout"
 
 interface FormBuilderFieldProps {
-  autoFocus?: boolean
   descriptor: TransferInfoFields[""]
   name: string
   onChange: (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => void
@@ -28,7 +27,6 @@ export function FormBuilderField(props: FormBuilderFieldProps) {
   if (choices) {
     return (
       <TextField
-        autoFocus={props.autoFocus}
         helperText={formattedDescription}
         label={formattedName}
         onChange={props.onChange}
@@ -47,7 +45,6 @@ export function FormBuilderField(props: FormBuilderFieldProps) {
   } else {
     return (
       <TextField
-        autoFocus={props.autoFocus}
         helperText={formattedDescription}
         label={formattedName}
         onChange={props.onChange}

--- a/src/TransferService/components/NoWithdrawableAssets.tsx
+++ b/src/TransferService/components/NoWithdrawableAssets.tsx
@@ -23,7 +23,6 @@ function NoWithdrawableAssets(props: Props) {
       <Portal desktop="inline" target={props.actionsRef.element}>
         <DialogActionsBox>
           <ActionButton
-            autoFocus
             onClick={() => router.history.push(routes.manageAccountAssets(props.account.id))}
             type="primary"
           >

--- a/src/TransferService/components/TransferDetailsForm.tsx
+++ b/src/TransferService/components/TransferDetailsForm.tsx
@@ -225,7 +225,6 @@ function TransferDetailsForm(props: TransferDetailsFormProps) {
         <FormLayout>
           {fields.dest ? (
             <FormBuilderField
-              autoFocus={process.env.PLATFORM !== "ios" && props.active}
               name={t("transfer-service.transfer-details.body.destination.name")}
               descriptor={fields.dest || {}}
               onChange={event => setFormValue("dest", event.target.value)}

--- a/src/TransferService/components/TransferTransactionDetails.tsx
+++ b/src/TransferService/components/TransferTransactionDetails.tsx
@@ -111,7 +111,6 @@ function TransferTransactionDetails(props: TransferTransactionDetailsProps) {
         ) : null}
         <PriceInput
           assetCode={asset.getCode()}
-          autoFocus
           disabled={minAmount && minAmount.gt(balance)}
           error={minAmount && minAmount.gt(balance)}
           label={


### PR DESCRIPTION
Due the `autoFocus` property of the input elements of the trading form the browser was trying to bring them into view which caused the form being visible when actually the main actions are supposed to be visible. But this was pretty hard to find because the input fields did not always get focused.

Furthermore sometimes on first render of the trading form the `initialPrimaryAsset` prop is undefined but changes shortly afterwards. Since `react-hook-form` is taking care of our values and we pass the default values only once we need to check for changes of the `initialPrimaryAsset` prop.

Fixes #1069.