### PR TITLE
Prepare optional installation of Solar as SEP-7 protocol handler

### DIFF
--- a/electron/src/bootstrap.ts
+++ b/electron/src/bootstrap.ts
@@ -5,6 +5,3 @@ app.name = "Solar Wallet"
 
 // Needs to match the value in electron-build.yml
 app.setAppUserModelId("io.solarwallet.app")
-
-// Disabled until we actually ship SEP-7 support
-// app.setAsDefaultProtocolClient("web+stellar")

--- a/electron/src/protocol-handler.ts
+++ b/electron/src/protocol-handler.ts
@@ -1,12 +1,27 @@
 import { app } from "electron"
 import events from "events"
 import { createMainWindow, getOpenWindows, trackWindow } from "./window"
+import { expose } from "./ipc/_ipc"
+import { Messages } from "./shared/ipc"
 
 const urlEventEmitter = new events.EventEmitter()
 const urlEventChannel = "deeplink:url"
 
 let urlEventQueue: string[] = []
 let isWindowReady = false
+
+expose(Messages.IsDefaultProtocolClient, () => {
+  return app.isDefaultProtocolClient("web+stellar")
+})
+
+expose(Messages.IsDifferentHandlerInstalled, () => {
+  const name = app.getApplicationNameForProtocol("web+stellar://") // '://' is needed here
+  return Boolean(name)
+})
+
+expose(Messages.SetAsDefaultProtocolClient, () => {
+  return app.setAsDefaultProtocolClient("web+stellar")
+})
 
 export function subscribe(subscribeCallback: (...args: any[]) => void) {
   urlEventEmitter.on(urlEventChannel, subscribeCallback)

--- a/electron/src/protocol-handler.ts
+++ b/electron/src/protocol-handler.ts
@@ -20,7 +20,9 @@ expose(Messages.IsDifferentHandlerInstalled, () => {
 })
 
 expose(Messages.SetAsDefaultProtocolClient, () => {
-  return app.setAsDefaultProtocolClient("web+stellar")
+  // Disabled until we actually ship SEP-7 support
+  // return app.setAsDefaultProtocolClient("web+stellar")
+  return false
 })
 
 export function subscribe(subscribeCallback: (...args: any[]) => void) {

--- a/i18n/locales/en/app-settings.json
+++ b/i18n/locales/en/app-settings.json
@@ -44,6 +44,15 @@
         }
       }
     },
+    "protocol-handler": {
+      "text": {
+        "primary": "Handle Stellar protocol requests",
+        "secondary": {
+          "default": "Solar is handling all Stellar links",
+          "non-default": "Make Solar handle all Stellar URIs"
+        }
+      }
+    },
     "testnet": {
       "text": {
         "primary": "Show Testnet Accounts",

--- a/i18n/locales/en/app.json
+++ b/i18n/locales/en/app.json
@@ -63,6 +63,15 @@
           "text": "Solar will now show notifications"
         },
         "message": "Enable app notifications"
+      },
+      "protocol-handler": {
+        "error": "Could not register Solar as default handler.",
+        "message": "Do you want Solar to handle interactive Stellar links on this computer (recommended)?",
+        "success": "Successfully registered Solar as default handler.",
+        "tooltip": {
+          "dismiss": "Dismiss",
+          "install": "Install"
+        }
       }
     }
   },

--- a/shared/ipc.ts
+++ b/shared/ipc.ts
@@ -16,6 +16,9 @@ export const Messages: IPC.MessageType = {
   OpenLink: "OpenLink",
 
   DeepLinkURL: "DeepLinkURL",
+  IsDefaultProtocolClient: "IsDefaultProtocolClient",
+  IsDifferentHandlerInstalled: "IsDifferentHandlerInstalled",
+  SetAsDefaultProtocolClient: "SetAsDefaultProtocolClient",
 
   CheckUpdateAvailability: "CheckUpdateAvailability",
   StartUpdate: "StartUpdate",

--- a/shared/types/ipc.d.ts
+++ b/shared/types/ipc.d.ts
@@ -24,6 +24,9 @@ declare namespace IPC {
     OpenLink: "OpenLink"
 
     DeepLinkURL: "DeepLinkURL"
+    IsDefaultProtocolClient: "IsDefaultProtocolClient"
+    IsDifferentHandlerInstalled: "IsDifferentHandlerInstalled"
+    SetAsDefaultProtocolClient: "SetAsDefaultProtocolClient"
 
     CheckUpdateAvailability: "CheckUpdateAvailability"
     StartUpdate: "StartUpdate"
@@ -62,6 +65,9 @@ declare namespace IPC {
     [Messages.OpenLink]: (href: string) => void
 
     [Messages.DeepLinkURL]: () => string
+    [Messages.IsDefaultProtocolClient]: () => boolean
+    [Messages.IsDifferentHandlerInstalled]: () => boolean
+    [Messages.SetAsDefaultProtocolClient]: () => boolean
 
     [Messages.CheckUpdateAvailability]: () => boolean
     [Messages.StartUpdate]: () => void

--- a/src/App/components/AccountListView.tsx
+++ b/src/App/components/AccountListView.tsx
@@ -14,6 +14,7 @@ import MainTitle from "~Generic/components/MainTitle"
 import { useIsMobile, useRouter } from "~Generic/hooks/userinterface"
 import getUpdater from "~Platform/updater"
 import AppNotificationPermission from "~Toasts/components/AppNotificationPermission"
+import ProtocolHandlerPermission from "~Toasts/components/ProtocolHandlerPermission"
 import { AccountsContext } from "../contexts/accounts"
 import { NotificationsContext, trackError } from "../contexts/notifications"
 import { SettingsContext } from "../contexts/settings"
@@ -143,6 +144,9 @@ function AllAccountsPage() {
             onCreateTestnetAccount={() => router.history.push(routes.newAccount(true))}
           />
           <AppNotificationPermission />
+          {process.env.PLATFORM === "linux" || process.env.PLATFORM === "darwin" || process.env.PLATFORM === "win32" ? (
+            <ProtocolHandlerPermission />
+          ) : null}
         </VerticalLayout>
       </DialogBody>
       <TermsAndConditions

--- a/src/AppSettings/components/AppSettings.tsx
+++ b/src/AppSettings/components/AppSettings.tsx
@@ -8,6 +8,7 @@ import * as routes from "~App/routes"
 import { useIsMobile, useRouter } from "~Generic/hooks/userinterface"
 import { matchesRoute } from "~Generic/lib/routes"
 import Carousel from "~Layout/components/Carousel"
+import { isDefaultProtocolClient, setAsDefaultProtocolClient } from "~platform/protocol-handler"
 import ManageTrustedServicesDialog from "./ManageTrustedServicesDialog"
 import {
   BiometricLockSetting,
@@ -15,7 +16,8 @@ import {
   LanguageSetting,
   MultiSigSetting,
   TestnetSetting,
-  TrustedServicesSetting
+  TrustedServicesSetting,
+  ProtocolHandlerSetting
 } from "./Settings"
 
 const SettingsDialogs = React.memo(function SettingsDialogs() {
@@ -29,6 +31,8 @@ function AppSettings() {
   const isSmallScreen = useIsMobile()
   const router = useRouter()
   const { i18n } = useTranslation()
+
+  const [isDefaultHandler, setIsDefaultHandler] = React.useState<boolean>(false)
 
   const showSettingsOverview = matchesRoute(router.location.pathname, routes.settings(), true)
 
@@ -53,6 +57,12 @@ function AppSettings() {
     [i18n, settings]
   )
 
+  isDefaultProtocolClient().then(setIsDefaultHandler)
+
+  const setDefaultClient = React.useCallback(() => {
+    setAsDefaultProtocolClient().then(success => setIsDefaultHandler(success))
+  }, [setIsDefaultHandler])
+
   return (
     <Carousel current={showSettingsOverview ? 0 : 1}>
       <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
@@ -73,6 +83,7 @@ function AppSettings() {
         />
         <HideMemoSetting onToggle={settings.toggleHideMemos} value={settings.hideMemos} />
         <MultiSigSetting onToggle={settings.toggleMultiSignature} value={settings.multiSignature} />
+        <ProtocolHandlerSetting isDefaultHandler={isDefaultHandler} onClick={setDefaultClient} />
         {trustedServicesEnabled ? <TrustedServicesSetting onClick={navigateToTrustedServices} /> : undefined}
       </List>
       <SettingsDialogs />

--- a/src/AppSettings/components/AppSettings.tsx
+++ b/src/AppSettings/components/AppSettings.tsx
@@ -39,6 +39,7 @@ function AppSettings() {
   const { accounts } = React.useContext(AccountsContext)
   const settings = React.useContext(SettingsContext)
   const trustedServicesEnabled = process.env.TRUSTED_SERVICES && process.env.TRUSTED_SERVICES === "enabled"
+  const protocolHandlerEnabled = process.env.REQUEST_HANDLER && process.env.REQUEST_HANDLER === "enabled"
 
   const getEffectiveLanguage = <L extends string | undefined, F extends any>(lang: L, fallback: F) => {
     return availableLanguages.indexOf(lang as any) > -1 ? lang : fallback
@@ -83,7 +84,11 @@ function AppSettings() {
         />
         <HideMemoSetting onToggle={settings.toggleHideMemos} value={settings.hideMemos} />
         <MultiSigSetting onToggle={settings.toggleMultiSignature} value={settings.multiSignature} />
-        <ProtocolHandlerSetting isDefaultHandler={isDefaultHandler} onClick={setDefaultClient} />
+        {protocolHandlerEnabled ? (
+          <ProtocolHandlerSetting isDefaultHandler={isDefaultHandler} onClick={setDefaultClient} />
+        ) : (
+          undefined
+        )}
         {trustedServicesEnabled ? <TrustedServicesSetting onClick={navigateToTrustedServices} /> : undefined}
       </List>
       <SettingsDialogs />

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -203,3 +203,27 @@ export const TrustedServicesSetting = React.memo(function TrustedServicesSetting
     />
   )
 })
+
+interface ProtocolHandlerSettingProps {
+  onClick: () => void
+  isDefaultHandler: boolean
+}
+
+export const ProtocolHandlerSetting = React.memo(function ProtocolHandlerSetting(props: ProtocolHandlerSettingProps) {
+  const classes = useSettingsStyles(props)
+  const { t } = useTranslation()
+
+  return (
+    <AppSettingsItem
+      disabled={props.isDefaultHandler}
+      icon={<TestnetIcon className={classes.icon} />}
+      onClick={props.onClick}
+      primaryText={
+        props.isDefaultHandler ? "Solar is handling all Stellar links" : "Make Solar handle all Stellar URIs"
+      }
+      secondaryText={
+        props.isDefaultHandler ? "" : "Click to make Solar the default handler for Stellar requests on this computer"
+      }
+    />
+  )
+})

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -8,6 +8,7 @@ import { makeStyles } from "@material-ui/core/styles"
 import ArrowRightIcon from "@material-ui/icons/KeyboardArrowRight"
 import FingerprintIcon from "@material-ui/icons/Fingerprint"
 import GroupIcon from "@material-ui/icons/Group"
+import ProtocolHandlerIcon from "@material-ui/icons/AddCircleOutline"
 import LanguageIcon from "@material-ui/icons/Language"
 import MessageIcon from "@material-ui/icons/Message"
 import TestnetIcon from "@material-ui/icons/MoneyOff"
@@ -216,13 +217,13 @@ export const ProtocolHandlerSetting = React.memo(function ProtocolHandlerSetting
   return (
     <AppSettingsItem
       disabled={props.isDefaultHandler}
-      icon={<TestnetIcon className={classes.icon} />}
+      icon={<ProtocolHandlerIcon className={classes.icon} />}
       onClick={props.onClick}
-      primaryText={
-        props.isDefaultHandler ? "Solar is handling all Stellar links" : "Make Solar handle all Stellar URIs"
-      }
+      primaryText={t("app-settings.settings.protocol-handler.text.primary")}
       secondaryText={
-        props.isDefaultHandler ? "" : "Click to make Solar the default handler for Stellar requests on this computer"
+        props.isDefaultHandler
+          ? t("app-settings.settings.protocol-handler.text.secondary.default")
+          : t("app-settings.settings.protocol-handler.text.secondary.non-default")
       }
     />
   )

--- a/src/Platform/ipc/web.ts
+++ b/src/Platform/ipc/web.ts
@@ -63,6 +63,16 @@ callHandlers[Messages.ShowNotification] = (localNotification: LocalNotification)
   })
 }
 
+let isDefault = false
+let differentHandler = true
+callHandlers[Messages.IsDifferentHandlerInstalled] = () => differentHandler
+callHandlers[Messages.IsDefaultProtocolClient] = () => isDefault
+callHandlers[Messages.SetAsDefaultProtocolClient] = () => {
+  isDefault = true
+  differentHandler = false
+  return true
+}
+
 const defaultTestingKeys: KeysData<PublicKeyData> = {
   "1": {
     metadata: {

--- a/src/Platform/protocol-handler.ts
+++ b/src/Platform/protocol-handler.ts
@@ -1,6 +1,18 @@
-import { subscribeToMessages } from "./ipc"
+import { call, subscribeToMessages } from "./ipc"
 import { Messages } from "../../shared/ipc"
 
 export function subscribeToDeepLinkURLs(callback: (url: string) => void) {
   return subscribeToMessages(Messages.DeepLinkURL, callback)
+}
+
+export function isDefaultProtocolClient() {
+  return call(Messages.IsDefaultProtocolClient)
+}
+
+export function isDifferentHandlerInstalled() {
+  return call(Messages.IsDifferentHandlerInstalled)
+}
+
+export function setAsDefaultProtocolClient() {
+  return call(Messages.SetAsDefaultProtocolClient)
 }

--- a/src/Toasts/components/ProtocolHandlerPermission.tsx
+++ b/src/Toasts/components/ProtocolHandlerPermission.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import IconButton from "@material-ui/core/IconButton"
 import Grow from "@material-ui/core/Grow"
 import SnackbarContent from "@material-ui/core/SnackbarContent"
@@ -31,17 +32,18 @@ const PermissionNotification = React.memo(function PermissionNotification(props:
   const { onHide } = props
   const { showNotification } = React.useContext(NotificationsContext)
   const theme = useTheme()
+  const { t } = useTranslation()
 
   const requestPermission = React.useCallback(() => {
     setAsDefaultProtocolClient().then(success => {
       if (success) {
-        showNotification("success", "Successfully registered Solar as default handler.")
+        showNotification("success", t("app.notification.permission.protocol-handler.success"))
       } else {
-        showNotification("error", "Could not register Solar as default handler.")
+        showNotification("error", t("app.notification.permission.protocol-handler.error"))
       }
       onHide()
     })
-  }, [showNotification, onHide])
+  }, [onHide, showNotification, t])
 
   const dismiss = React.useCallback(() => {
     setNotificationDismissed()
@@ -54,14 +56,14 @@ const PermissionNotification = React.memo(function PermissionNotification(props:
         message={
           <HorizontalLayout alignItems="center">
             <span style={{ ...theme.typography.button, marginLeft: 8 }}>
-              Do you want Solar to handle interactive Stellar links on this computer (recommended)?
+              {t("app.notification.permission.protocol-handler.message")}
             </span>
-            <Tooltip title="Install">
+            <Tooltip title={t("app.notification.permission.protocol-handler.tooltip.install")}>
               <IconButton onClick={requestPermission} style={{ color: "inherit" }}>
                 <CheckIcon />
               </IconButton>
             </Tooltip>
-            <Tooltip title="Dismiss">
+            <Tooltip title={t("app.notification.permission.protocol-handler.tooltip.dismiss")}>
               <IconButton onClick={dismiss} style={{ color: "inherit" }}>
                 <CloseIcon />
               </IconButton>

--- a/src/Toasts/components/ProtocolHandlerPermission.tsx
+++ b/src/Toasts/components/ProtocolHandlerPermission.tsx
@@ -1,0 +1,114 @@
+import React from "react"
+import IconButton from "@material-ui/core/IconButton"
+import Grow from "@material-ui/core/Grow"
+import SnackbarContent from "@material-ui/core/SnackbarContent"
+import Tooltip from "@material-ui/core/Tooltip"
+import { useTheme } from "@material-ui/core/styles"
+import CloseIcon from "@material-ui/icons/Close"
+import CheckIcon from "@material-ui/icons/Check"
+import { NotificationsContext } from "~App/contexts/notifications"
+import { HorizontalLayout } from "~Layout/components/Box"
+import {
+  isDefaultProtocolClient,
+  isDifferentHandlerInstalled,
+  setAsDefaultProtocolClient
+} from "~platform/protocol-handler"
+
+function isNotificationDismissed() {
+  return localStorage.getItem("protocol-handler-notification-dismissed") !== null
+}
+
+function setNotificationDismissed() {
+  localStorage.setItem("protocol-handler-notification-dismissed", "true")
+}
+
+interface PermissionNotificationProps {
+  onHide: () => void
+  open: boolean
+}
+
+const PermissionNotification = React.memo(function PermissionNotification(props: PermissionNotificationProps) {
+  const { onHide } = props
+  const { showNotification } = React.useContext(NotificationsContext)
+  const theme = useTheme()
+
+  const requestPermission = React.useCallback(() => {
+    setAsDefaultProtocolClient().then(success => {
+      if (success) {
+        showNotification("success", "Successfully registered Solar as default handler.")
+      } else {
+        showNotification("error", "Could not register Solar as default handler.")
+      }
+      onHide()
+    })
+  }, [showNotification, onHide])
+
+  const dismiss = React.useCallback(() => {
+    setNotificationDismissed()
+    onHide()
+  }, [onHide])
+
+  return (
+    <Grow in={props.open}>
+      <SnackbarContent
+        message={
+          <HorizontalLayout alignItems="center">
+            <span style={{ ...theme.typography.button, marginLeft: 8 }}>
+              Do you want Solar to handle interactive Stellar links on this computer (recommended)?
+            </span>
+            <Tooltip title="Install">
+              <IconButton onClick={requestPermission} style={{ color: "inherit" }}>
+                <CheckIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Dismiss">
+              <IconButton onClick={dismiss} style={{ color: "inherit" }}>
+                <CloseIcon />
+              </IconButton>
+            </Tooltip>
+          </HorizontalLayout>
+        }
+        style={{
+          display: "flex",
+          alignItems: "center",
+          background: "white",
+          color: theme.palette.text.primary,
+          cursor: "pointer",
+          flexGrow: 0,
+          justifyContent: "center"
+        }}
+      />
+    </Grow>
+  )
+})
+
+function ProtocolHandlerPermission() {
+  const [showPermissionNotification, setShowPermissionNotification] = React.useState(false)
+
+  React.useEffect(() => {
+    if (isNotificationDismissed()) {
+      return
+    }
+
+    isDefaultProtocolClient().then(isDefault => {
+      if (isDefault) {
+        setShowPermissionNotification(false)
+      } else {
+        isDifferentHandlerInstalled().then(isDifferentInstalled => {
+          if (!isDifferentInstalled) {
+            setAsDefaultProtocolClient()
+            setShowPermissionNotification(false)
+          } else {
+            setShowPermissionNotification(true)
+          }
+        })
+      }
+    })
+  }, [])
+
+  const hidePermissionNotification = React.useCallback(() => setShowPermissionNotification(false), [])
+
+  return <PermissionNotification onHide={hidePermissionNotification} open={showPermissionNotification} />
+}
+
+export default React.memo(ProtocolHandlerPermission)


### PR DESCRIPTION
- [x] Add IPC message types for protocol client state 
- [x] Implement protocol handler IPC for electron and web
- [x] Add `<ProtocolHandlerPermission>` component that shows a notification asking the user if he wants to use Solar for handling stellar requests (desktop only)
- [x] Add app settings item for installing Solar as protocol handler for stellar requests (hidden behind a env-var feature flag for now)

The implementation of `SetAsDefaultProtocolClient` call in electron is just a dummy since Solar does not have a sufficient SEP-7 support yet.

Closes #957.