### PR TITLE
Fix fingerprint dialog called twice

### DIFF
--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -13,6 +13,7 @@
     },
     "bad-response-error": "Bad response ({{status}}) from {{server}} server",
     "bad-transaction-error": "Bad transaction given. Expected a Transaction or TransactionRecord, but got: {{transaction}}",
+    "bio-auth-test-canceled": "Biometric authentication canceled",
     "expected-json-response-error": "Expected {{url}} to return a JSON response. Content type was {{contentType}} instead.",
     "existing-account-error": "An account with that name does already exist.",
     "fetch-account-data-error": "Cannot fetch account data of {{account}} from {{horizon}}",

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -64,6 +64,7 @@ export const BiometricLockSetting = React.memo(function BiometricLockSetting(pro
   return (
     <AppSettingsItem
       actions={
+        // pass empty onChange handler to prevent calling onToggle twice
         <SettingsToggle checked={props.enrolled && props.value} disabled={!props.enrolled} onChange={() => undefined} />
       }
       icon={<FingerprintIcon className={classes.icon} />}

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -64,7 +64,7 @@ export const BiometricLockSetting = React.memo(function BiometricLockSetting(pro
   return (
     <AppSettingsItem
       actions={
-        <SettingsToggle checked={props.enrolled && props.value} disabled={!props.enrolled} onChange={props.onToggle} />
+        <SettingsToggle checked={props.enrolled && props.value} disabled={!props.enrolled} onChange={() => undefined} />
       }
       icon={<FingerprintIcon className={classes.icon} />}
       onClick={props.enrolled ? props.onToggle : undefined}

--- a/src/Platform/bio-auth.ts
+++ b/src/Platform/bio-auth.ts
@@ -1,3 +1,4 @@
+import { CustomError } from "~Generic/lib/errors"
 import { Messages } from "../shared/ipc"
 import { call } from "./ipc"
 
@@ -15,7 +16,7 @@ export function testBiometricAuth(message: string) {
         resolve()
       }
     } else {
-      reject("Confirmation dismissed by user.")
+      reject(CustomError("BioAuthTestCanceledError", "Biometric authentication canceled"))
     }
   })
 }


### PR DESCRIPTION
Only use `props.onToggle` as `onClick` handler for the whole item instead of using it for item and `<SettingsToggle>`. Otherwise it would be called twice when the toggle is clicked.
(`onChange` is a required prop of `<SettingsToggle>` so `() => undefined` is passed instead)

Reject the bio-auth test with a `CustomError` to prevent an uncaught promise being thrown by `getErrorTranslation()`.

Closes #1077.