### PR TITLE
Fix crash on FeeBumpTransaction in transaction history

### DIFF
--- a/src/Account/components/TransactionList.tsx
+++ b/src/Account/components/TransactionList.tsx
@@ -1,7 +1,7 @@
 import BigNumber from "big.js"
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Asset, Horizon, Networks, Operation, Transaction, TransactionBuilder, FeeBumpTransaction } from "stellar-sdk"
+import { Asset, FeeBumpTransaction, Horizon, Networks, Operation, Transaction, TransactionBuilder } from "stellar-sdk"
 import HumanTime from "react-human-time"
 import Collapse from "@material-ui/core/Collapse"
 import List from "@material-ui/core/List"
@@ -501,9 +501,11 @@ function TransactionList(props: TransactionListProps) {
       return null
     }
 
+    const network = props.account.testnet ? Networks.TESTNET : Networks.PUBLIC
     const txResponse = props.transactions.find(recentTx => recentTx.hash === openedTxHash)
+
     let tx = txResponse
-      ? TransactionBuilder.fromXDR(txResponse.envelope_xdr, props.account.testnet ? Networks.TESTNET : Networks.PUBLIC)
+      ? TransactionBuilder.fromXDR(txResponse.envelope_xdr, network)
       : null
 
     if (tx instanceof FeeBumpTransaction) {


### PR DESCRIPTION
Restores the transaction using `TransactionBuilder.fromXDR()` and passes the `innerTransaction`  to other components if the transaction is a `FeeBumpTransaction`.
This is just a quick fix and should be complemented by future changes which add an `ErrorBoundary` around list items and display some UI to indicate that it's a `FeeBumpTransaction.`

Closes #1107.