### PR TITLE
Listen for update-already-running error

### DIFF
--- a/electron/src/ipc/updater.ts
+++ b/electron/src/ipc/updater.ts
@@ -95,11 +95,20 @@ async function startUpdatingWithoutInfo() {
 }
 
 async function startUpdating(version: string) {
-  const downloadingNotification = showDownloadingNotification(version)
+  autoUpdater.on("error", error => {
+    if (error.message.includes("already running")) {
+      throw Object.assign(new Error("Update is already running!"), { name: "UpdateAlreadyRunningError" })
+    } else {
+      // re-throw
+      throw error
+    }
+  })
+
   autoUpdater.checkForUpdates()
+  const downloadingNotification = showDownloadingNotification(version)
 
   await new Promise(resolve => {
-    // will only be called on signed mac applications
+    // will not be called on unsigned mac applications
     autoUpdater.once("update-downloaded", resolve)
   })
 

--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -36,6 +36,7 @@
     "unexpected-state-error": "Encountered unexpected state: {{state}}",
     "unexpected-response-type-error": "Unexpected response type: {{type}} / ${dataType}",
     "unknown-error": "An unknown error occured.",
+    "update-already-running-error": "Update is already running!",
     "wrong-password-error": "Wrong password.",
     "wrong-request-start-error": "Expected request to start with 'web+stellar:'",
     "submission-error": {


### PR DESCRIPTION
Catch errors thrown by `autoUpdater` and check if it was thrown because the update is already running. Throw an error with a better message in that case.
Subscribing to errors of `autoUpdater` will prevent from exceptions being thrown and shown in the alert window of the application.

Closes #1110. 