### PR TITLE
Use carousel in AccountSettings

### DIFF
--- a/src/Account/components/AccountView.tsx
+++ b/src/Account/components/AccountView.tsx
@@ -213,7 +213,11 @@ const AccountPageContent = React.memo(function AccountPageContent(props: Account
 
   const handleBackNavigation = React.useCallback(() => {
     if (props.account && matchesRoute(router.location.pathname, routes.accountSettings(props.account.id))) {
-      router.history.push(routes.account(props.account.id))
+      if (matchesRoute(router.location.pathname, routes.accountSettings(props.account.id) + "/*")) {
+        router.history.push(routes.accountSettings(props.account.id))
+      } else {
+        router.history.push(routes.account(props.account.id))
+      }
     } else if (showAccountCreation && accountToBackup) {
       setAccountToBackup(null)
     } else if (showAccountCreation) {

--- a/src/AccountSettings/components/AccountDeletionDialog.tsx
+++ b/src/AccountSettings/components/AccountDeletionDialog.tsx
@@ -14,11 +14,14 @@ import { useLiveAccountData } from "~Generic/hooks/stellar-subscriptions"
 import { useIsMobile, useIsSmallMobile } from "~Generic/hooks/userinterface"
 import { ActionButton, ConfirmDialog, DialogActionsBox } from "~Generic/components/DialogActions"
 import MainTitle from "~Generic/components/MainTitle"
-import ScrollableBalances from "~Generic/components/ScrollableBalances"
 import MergeIcon from "~Icons/components/Merge"
 import DialogBody from "~Layout/components/DialogBody"
 import { HorizontalLayout } from "~Layout/components/Box"
 import TransactionSender from "~Transaction/components/TransactionSender"
+
+const redText: React.CSSProperties = {
+  color: "red"
+}
 
 interface DeletionConfirmationDialogProps {
   merging: boolean
@@ -207,16 +210,13 @@ function AccountDeletionDialog(props: AccountDeletionDialogProps) {
       background={<WarnIcon style={{ fontSize: 160 }} />}
       noMaxWidth
       top={
-        <>
-          <MainTitle
-            hideBackButton
-            title={<span>{t("account-settings.account-deletion.title")}</span>}
-            titleColor="inherit"
-            onBack={props.onClose}
-            style={{ marginTop: 0, marginLeft: 0 }}
-          />
-          <ScrollableBalances account={props.account} compact />
-        </>
+        <MainTitle
+          hideBackButton
+          title={<span style={redText}>{t("account-settings.account-deletion.title")}</span>}
+          titleColor="inherit"
+          onBack={props.onClose}
+          style={{ marginTop: 0, marginLeft: 0 }}
+        />
       }
       actions={
         <DialogActionsBox>

--- a/src/AccountSettings/components/AccountDeletionDialog.tsx
+++ b/src/AccountSettings/components/AccountDeletionDialog.tsx
@@ -7,18 +7,18 @@ import Switch from "@material-ui/core/Switch"
 import Typography from "@material-ui/core/Typography"
 import DeleteIcon from "@material-ui/icons/Delete"
 import WarnIcon from "@material-ui/icons/Warning"
+import AccountSelectionList from "~Account/components/AccountSelectionList"
 import { Account, AccountsContext } from "~App/contexts/accounts"
 import { createTransaction } from "~Generic/lib/transaction"
 import { useLiveAccountData } from "~Generic/hooks/stellar-subscriptions"
 import { useIsMobile, useIsSmallMobile } from "~Generic/hooks/userinterface"
-import AccountSelectionList from "~Account/components/AccountSelectionList"
-import DialogBody from "~Layout/components/DialogBody"
-import MergeIcon from "~Icons/components/Merge"
-import { HorizontalLayout } from "~Layout/components/Box"
-import ScrollableBalances from "~Generic/components/ScrollableBalances"
-import MainTitle from "~Generic/components/MainTitle"
-import TransactionSender from "~Transaction/components/TransactionSender"
 import { ActionButton, ConfirmDialog, DialogActionsBox } from "~Generic/components/DialogActions"
+import MainTitle from "~Generic/components/MainTitle"
+import ScrollableBalances from "~Generic/components/ScrollableBalances"
+import MergeIcon from "~Icons/components/Merge"
+import DialogBody from "~Layout/components/DialogBody"
+import { HorizontalLayout } from "~Layout/components/Box"
+import TransactionSender from "~Transaction/components/TransactionSender"
 
 interface DeletionConfirmationDialogProps {
   merging: boolean
@@ -205,9 +205,11 @@ function AccountDeletionDialog(props: AccountDeletionDialogProps) {
   return (
     <DialogBody
       background={<WarnIcon style={{ fontSize: 160 }} />}
+      noMaxWidth
       top={
         <>
           <MainTitle
+            hideBackButton
             title={<span>{t("account-settings.account-deletion.title")}</span>}
             titleColor="inherit"
             onBack={props.onClose}

--- a/src/AccountSettings/components/AccountSettings.tsx
+++ b/src/AccountSettings/components/AccountSettings.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import Dialog from "@material-ui/core/Dialog"
 import List from "@material-ui/core/List"
 import ListItemText from "@material-ui/core/ListItemText"
 import EyeIcon from "@material-ui/icons/RemoveRedEye"
@@ -9,16 +8,16 @@ import GroupIcon from "@material-ui/icons/Group"
 import KeyIcon from "@material-ui/icons/VpnKey"
 import { Account } from "~App/contexts/accounts"
 import { SettingsContext } from "~App/contexts/settings"
+import * as routes from "~App/routes"
 import { useLiveAccountData } from "~Generic/hooks/stellar-subscriptions"
 import { useIsMobile, useRouter } from "~Generic/hooks/userinterface"
 import { matchesRoute } from "~Generic/lib/routes"
-import * as routes from "~App/routes"
-import { FullscreenDialogTransition } from "~App/theme"
+import Carousel from "~Layout/components/Carousel"
+import ManageSignersDialog from "~ManageSigners/components/ManageSignersDialog"
 import AccountDeletionDialog from "./AccountDeletionDialog"
 import AccountSettingsItem from "./AccountSettingsItem"
 import ChangePasswordDialog from "./ChangePasswordDialog"
 import ExportKeyDialog from "./ExportKeyDialog"
-import ManageSignersDialog from "~ManageSigners/components/ManageSignersDialog"
 
 function SettingsDialogs(props: Props) {
   const router = useRouter()
@@ -38,42 +37,22 @@ function SettingsDialogs(props: Props) {
 
   return (
     <>
-      <Dialog
-        fullScreen
-        open={showChangePassword}
-        onClose={navigateTo.accountSettings}
-        TransitionComponent={FullscreenDialogTransition}
-      >
+      <div style={{ display: showChangePassword ? undefined : "none" }}>
         <ChangePasswordDialog account={props.account} onClose={navigateTo.accountSettings} />
-      </Dialog>
-      <Dialog
-        fullScreen
-        open={showDeleteAccount}
-        onClose={navigateTo.accountSettings}
-        TransitionComponent={FullscreenDialogTransition}
-      >
+      </div>
+      <div style={{ display: showDeleteAccount ? undefined : "none" }}>
         <AccountDeletionDialog
           account={props.account}
           onClose={navigateTo.accountSettings}
           onDeleted={navigateTo.allAccounts}
         />
-      </Dialog>
-      <Dialog
-        fullScreen
-        open={showExportKey}
-        onClose={navigateTo.accountSettings}
-        TransitionComponent={FullscreenDialogTransition}
-      >
+      </div>
+      <div style={{ display: showExportKey ? undefined : "none" }}>
         <ExportKeyDialog account={props.account} onClose={navigateTo.accountSettings} variant="export" />
-      </Dialog>
-      <Dialog
-        fullScreen
-        open={showManageSigners}
-        onClose={navigateTo.accountSettings}
-        TransitionComponent={FullscreenDialogTransition}
-      >
+      </div>
+      <div style={{ display: showManageSigners ? undefined : "none" }}>
         <ManageSignersDialog account={props.account} onClose={navigateTo.accountSettings} />
-      </Dialog>
+      </div>
     </>
   )
 }
@@ -99,6 +78,8 @@ function AccountSettings(props: Props) {
     [router.history, props.account]
   )
 
+  const showSettingsOverview = matchesRoute(router.location.pathname, routes.accountSettings(props.account.id), true)
+
   const listItemTextStyle: React.CSSProperties = React.useMemo(
     () => ({
       paddingRight: isSmallScreen ? 0 : undefined
@@ -107,7 +88,7 @@ function AccountSettings(props: Props) {
   )
 
   return (
-    <>
+    <Carousel current={showSettingsOverview ? 0 : 1}>
       <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
         <AccountSettingsItem
           caret="right"
@@ -169,7 +150,7 @@ function AccountSettings(props: Props) {
         </AccountSettingsItem>
       </List>
       <SettingsDialogs account={props.account} />
-    </>
+    </Carousel>
   )
 }
 

--- a/src/AccountSettings/components/AccountSettings.tsx
+++ b/src/AccountSettings/components/AccountSettings.tsx
@@ -37,20 +37,20 @@ function SettingsDialogs(props: Props) {
 
   return (
     <>
-      <div style={{ display: showChangePassword ? undefined : "none" }}>
+      <div style={{ display: showChangePassword ? undefined : "none", height: "100%" }}>
         <ChangePasswordDialog account={props.account} onClose={navigateTo.accountSettings} />
       </div>
-      <div style={{ display: showDeleteAccount ? undefined : "none" }}>
+      <div style={{ display: showDeleteAccount ? undefined : "none", height: "100%" }}>
         <AccountDeletionDialog
           account={props.account}
           onClose={navigateTo.accountSettings}
           onDeleted={navigateTo.allAccounts}
         />
       </div>
-      <div style={{ display: showExportKey ? undefined : "none" }}>
+      <div style={{ display: showExportKey ? undefined : "none", height: "100%" }}>
         <ExportKeyDialog account={props.account} onClose={navigateTo.accountSettings} variant="export" />
       </div>
-      <div style={{ display: showManageSigners ? undefined : "none" }}>
+      <div style={{ display: showManageSigners ? undefined : "none", height: "100%" }}>
         <ManageSignersDialog account={props.account} onClose={navigateTo.accountSettings} />
       </div>
     </>

--- a/src/AccountSettings/components/ChangePasswordDialog.tsx
+++ b/src/AccountSettings/components/ChangePasswordDialog.tsx
@@ -11,10 +11,10 @@ import { NotificationsContext } from "~App/contexts/notifications"
 import { useIsMobile } from "~Generic/hooks/userinterface"
 import { renderFormFieldError, isWrongPasswordError } from "~Generic/lib/errors"
 import { ActionButton, DialogActionsBox } from "~Generic/components/DialogActions"
-import { Box } from "~Layout/components/Box"
-import DialogBody from "~Layout/components/DialogBody"
 import MainTitle from "~Generic/components/MainTitle"
 import PasswordField from "~Generic/components/PasswordField"
+import { Box } from "~Layout/components/Box"
+import DialogBody from "~Layout/components/DialogBody"
 
 const adornmentLock = (
   <InputAdornment position="start">
@@ -181,8 +181,10 @@ function ChangePasswordDialog(props: Props) {
 
   return (
     <DialogBody
+      noMaxWidth
       top={
         <MainTitle
+          hideBackButton
           onBack={onClose}
           title={
             props.account.requiresPassword

--- a/src/AccountSettings/components/ChangePasswordDialog.tsx
+++ b/src/AccountSettings/components/ChangePasswordDialog.tsx
@@ -13,7 +13,7 @@ import { renderFormFieldError, isWrongPasswordError } from "~Generic/lib/errors"
 import { ActionButton, DialogActionsBox } from "~Generic/components/DialogActions"
 import MainTitle from "~Generic/components/MainTitle"
 import PasswordField from "~Generic/components/PasswordField"
-import { Box } from "~Layout/components/Box"
+import { Box, HorizontalLayout } from "~Layout/components/Box"
 import DialogBody from "~Layout/components/DialogBody"
 
 const adornmentLock = (
@@ -204,8 +204,14 @@ function ChangePasswordDialog(props: Props) {
         </DialogActions>
       }
     >
-      <Box alignSelf="center" margin="24px auto 0" maxWidth={400} width="100%">
-        <Box hidden={!props.account.requiresPassword} margin="0 0 8px">
+      <HorizontalLayout
+        alignSelf="center"
+        justifyContent="space-evenly"
+        margin="24px 0 0"
+        width="calc(100% + 16px)"
+        wrap="wrap"
+      >
+        <Box basis="400px" grow={0} hidden={!props.account.requiresPassword} margin="0 16px" shrink>
           <PasswordField
             autoFocus={props.account.requiresPassword && process.env.PLATFORM !== "ios"}
             error={Boolean(errors.prevPassword)}
@@ -221,7 +227,7 @@ function ChangePasswordDialog(props: Props) {
             InputProps={{ startAdornment: adornmentLockOpen }}
           />
         </Box>
-        <Box hidden={removingPassword}>
+        <Box basis="400px" grow={0} hidden={removingPassword} margin="0 16px" shrink>
           <PasswordField
             autoFocus={!props.account.requiresPassword && process.env.PLATFORM !== "ios"}
             error={Boolean(errors.nextPassword)}
@@ -250,7 +256,7 @@ function ChangePasswordDialog(props: Props) {
             InputProps={{ startAdornment: adornmentLock }}
           />
         </Box>
-      </Box>
+      </HorizontalLayout>
     </DialogBody>
   )
 }

--- a/src/AccountSettings/components/ExportKeyDialog.tsx
+++ b/src/AccountSettings/components/ExportKeyDialog.tsx
@@ -6,16 +6,16 @@ import LockIcon from "@material-ui/icons/LockOutlined"
 import LockOpenIcon from "@material-ui/icons/LockOpenOutlined"
 import LockFilledIcon from "@material-ui/icons/Lock"
 import WarnIcon from "@material-ui/icons/Warning"
+import KeyExportBox from "~Account/components/KeyExportBox"
 import { Account } from "~App/contexts/accounts"
 import { trackError } from "~App/contexts/notifications"
 import { useIsMobile } from "~Generic/hooks/userinterface"
+import MainTitle from "~Generic/components/MainTitle"
+import PasswordField from "~Generic/components/PasswordField"
 import { isWrongPasswordError, getErrorTranslation } from "~Generic/lib/errors"
 import { ActionButton, DialogActionsBox } from "~Generic/components/DialogActions"
 import { Box } from "~Layout/components/Box"
 import DialogBody from "~Layout/components/DialogBody"
-import KeyExportBox from "~Account/components/KeyExportBox"
-import MainTitle from "~Generic/components/MainTitle"
-import PasswordField from "~Generic/components/PasswordField"
 
 interface PromptToRevealProps {
   children: React.ReactNode
@@ -34,6 +34,7 @@ function PromptToReveal(props: PromptToRevealProps) {
   return (
     <DialogBody
       background={<WarnIcon style={{ fontSize: 220 }} />}
+      noMaxWidth
       top={props.title}
       actions={
         <DialogActionsBox desktopStyle={{ marginTop: 32 }} smallDialog>
@@ -88,6 +89,7 @@ function ShowSecretKey(props: ShowSecretKeyProps) {
   return (
     <DialogBody
       background={<LockFilledIcon style={{ fontSize: 220 }} />}
+      noMaxWidth
       top={props.title}
       actions={
         props.onConfirm ? (
@@ -159,13 +161,13 @@ function ExportKeyDialog(props: Props) {
     () =>
       props.variant === "initial-backup" ? null : (
         <MainTitle
-          hideBackButton={!props.onClose}
+          hideBackButton
           onBack={onBackButtonClick}
           style={{ marginBottom: 24 }}
           title={t("account-settings.export-key.title.default")}
         />
       ),
-    [props.onClose, props.variant, onBackButtonClick, t]
+    [props.variant, onBackButtonClick, t]
   )
 
   const backupInfoContent = React.useMemo(

--- a/src/Layout/components/DialogBody.tsx
+++ b/src/Layout/components/DialogBody.tsx
@@ -53,6 +53,7 @@ interface Props {
   children: React.ReactNode
   excessWidth?: number
   fitToShrink?: boolean
+  noMaxWidth?: boolean
   preventActionsPlaceholder?: boolean
   preventNotch?: boolean
   top?: React.ReactNode
@@ -99,7 +100,7 @@ function DialogBody(props: Props) {
         display="flex"
         height="100%"
         margin="0 auto"
-        maxWidth={900}
+        maxWidth={props.noMaxWidth ? undefined : 900}
         overflowX="hidden"
         padding={isSmallScreen ? "12px 24px" : "24px 32px"}
         style={{ flexDirection: "column" }}

--- a/src/ManageSigners/components/ManageSignersDialog.tsx
+++ b/src/ManageSigners/components/ManageSignersDialog.tsx
@@ -84,6 +84,7 @@ function ManageSignersDialog(props: Props) {
   const titleContent = React.useMemo(
     () => (
       <MainTitle
+        hideBackButton
         title={
           isSmallScreen
             ? t("account-settings.manage-signers.title.short")

--- a/src/ManageSigners/components/ManageSignersDialogContent.tsx
+++ b/src/ManageSigners/components/ManageSignersDialogContent.tsx
@@ -210,7 +210,7 @@ function ManageSignersDialogContent(props: Props) {
   )
 
   return (
-    <DialogBody top={props.title} actions={isSmallScreen ? actionsRef : undefined}>
+    <DialogBody noMaxWidth top={props.title} actions={isSmallScreen ? actionsRef : undefined}>
       <VerticalLayout
         justifyContent="space-between"
         margin="8px 0 0"


### PR DESCRIPTION
- [x] Use a carousel instead of fullscreen dialogs for showing the account settings.
- [x] Hide back buttons of title components of account settings
- [x] Add `noMaxWidth` prop to `<DialogBody>` which disables the `maxWidth={900}` restriction (to allow increasing the width)
- [x] Set `noMaxWidth=true` when using `<DialogBody>` in account settings

Closes #1009.