### PR TITLE
Improve keystore initialization error message

### DIFF
--- a/src/App/cordova/app.cordova.ts
+++ b/src/App/cordova/app.cordova.ts
@@ -170,9 +170,11 @@ function initializeStorage(contentWindow: Window) {
 
       return [secureStorage, keyStore] as const
     } catch (error) {
-      // Assume that it is a 'device not secure' error
+      const message = error && error.message ? error.message : "Unknown error."
       alert(
-        "This application requires you to set a PIN or unlock pattern for your device.\n\nPlease retry after setting it up."
+        "Could not initialize keystore: " +
+          message +
+          " If this error persists try wiping your application data in the system settings."
       )
       return navigator.app.exitApp()
     }


### PR DESCRIPTION
Shows a more detailed message when encountering an error during keystore initialisation on mobile. Encountering an error (on android) is unlikely though because we patched the secure lock screen requirement in our fork of the `secure-storage` plugin and since we limited the application to API level 21 and above we should not run into the "Device not supported" error (which is thrown for devices below API 21).

Closes #997.