### PR TITLE
Make open orders collapsible and add load more button

### DIFF
--- a/src/Account/components/OfferList.tsx
+++ b/src/Account/components/OfferList.tsx
@@ -2,13 +2,19 @@ import BigNumber from "big.js"
 import React from "react"
 import { Trans } from "react-i18next"
 import { Operation, Server, ServerApi, Transaction } from "stellar-sdk"
+import ExpansionPanel from "@material-ui/core/ExpansionPanel"
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails"
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary"
 import ListItem from "@material-ui/core/ListItem"
 import ListItemIcon from "@material-ui/core/ListItemIcon"
 import ListItemText from "@material-ui/core/ListItemText"
 import ListSubheader from "@material-ui/core/ListSubheader"
+import makeStyles from "@material-ui/core/styles/makeStyles"
 import ArrowRightIcon from "@material-ui/icons/ArrowRightAlt"
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import BarChartIcon from "@material-ui/icons/BarChart"
 import { Account } from "~App/contexts/accounts"
+import { breakpoints } from "~App/theme"
 import { trackError } from "~App/contexts/notifications"
 import { useHorizon } from "~Generic/hooks/stellar"
 import { useLiveAccountData, useLiveAccountOffers } from "~Generic/hooks/stellar-subscriptions"
@@ -150,10 +156,45 @@ interface Props {
   title: React.ReactNode
 }
 
+const useStyles = makeStyles({
+  expansionPanel: {
+    background: "transparent",
+
+    "&:before": {
+      background: "transparent"
+    }
+  },
+  expansionPanelSummary: {
+    justifyContent: "flex-start",
+    minHeight: "48px !important",
+    padding: 0
+  },
+  expansionPanelSummaryContent: {
+    flexGrow: 0,
+    marginTop: "0 !important",
+    marginBottom: "0 !important"
+  },
+  expansionPanelDetails: {
+    display: "block",
+    padding: 0
+  },
+  listItem: {
+    padding: "8px 24px",
+
+    [breakpoints.down(600)]: {
+      paddingLeft: 24,
+      paddingRight: 24
+    }
+  }
+})
+
 function OfferList(props: Props & { sendTransaction: (tx: Transaction) => Promise<void> }) {
   const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
+  const classes = useStyles()
   const offers = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
   const horizon = useHorizon(props.account.testnet)
+
+  const [expanded, setExpanded] = React.useState(true)
 
   const onCancel = async (offer: ServerApi.OfferRecord) => {
     try {
@@ -169,17 +210,35 @@ function OfferList(props: Props & { sendTransaction: (tx: Transaction) => Promis
   } else {
     return (
       <List style={{ background: "transparent" }}>
-        <ListSubheader disableSticky style={{ background: "transparent" }}>
-          {props.title}
-        </ListSubheader>
-        {offers.map(offer => (
-          <OfferListItem
-            key={offer.id}
-            accountPublicKey={props.account.publicKey}
-            offer={offer}
-            onCancel={() => onCancel(offer)}
-          />
-        ))}
+        <ExpansionPanel
+          className={classes.expansionPanel}
+          elevation={0}
+          expanded={expanded}
+          onChange={() => setExpanded(!expanded)}
+        >
+          <ExpansionPanelSummary
+            classes={{ root: classes.expansionPanelSummary, content: classes.expansionPanelSummaryContent }}
+            expandIcon={<ExpandMoreIcon />}
+          >
+            <ListSubheader
+              className={classes.listItem}
+              disableSticky
+              style={{ background: "transparent", paddingRight: 0 }}
+            >
+              {props.title}
+            </ListSubheader>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails className={classes.expansionPanelDetails}>
+            {offers.map(offer => (
+              <OfferListItem
+                key={offer.id}
+                accountPublicKey={props.account.publicKey}
+                offer={offer}
+                onCancel={() => onCancel(offer)}
+              />
+            ))}
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
       </List>
     )
   }

--- a/src/Assets/components/BalanceDetailsDialog.tsx
+++ b/src/Assets/components/BalanceDetailsDialog.tsx
@@ -129,7 +129,7 @@ interface BalanceDetailsProps {
 
 function BalanceDetailsDialog(props: BalanceDetailsProps) {
   const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
-  const openOrders = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
+  const { offers: openOrders } = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
   const isSmallScreen = useIsMobile()
   const router = useRouter()
   const { t } = useTranslation()

--- a/src/Assets/components/SpendableBalanceBreakdown.tsx
+++ b/src/Assets/components/SpendableBalanceBreakdown.tsx
@@ -136,7 +136,7 @@ interface Props {
 }
 
 function SpendableBalanceBreakdown(props: Props) {
-  const openOrders = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
+  const { offers: openOrders } = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
   const { t } = useTranslation()
 
   const nativeBalance = props.accountData.balances.find(balance => balance.asset_type === "native")

--- a/src/Generic/hooks/_caches.ts
+++ b/src/Generic/hooks/_caches.ts
@@ -103,6 +103,11 @@ export interface TransactionHistory {
   transactions: Horizon.TransactionResponse[]
 }
 
+export interface OfferHistory {
+  olderOffersAvailable: boolean
+  offers: ServerApi.OfferRecord[]
+}
+
 function areTransactionsNewer(prev: TransactionHistory, next: TransactionHistory) {
   const prevMaxTimestamp =
     (prev
@@ -120,17 +125,33 @@ function areTransactionsNewer(prev: TransactionHistory, next: TransactionHistory
   return !prev || nextMaxTimestamp > prevMaxTimestamp
 }
 
+function areOffersNewer(prev: OfferHistory, next: OfferHistory) {
+  const prevMaxTimestamp =
+    (prev
+      ? max(
+          prev.offers.map(tx => tx.last_modified_time),
+          "0"
+        )
+      : undefined) || ""
+  const nextMaxTimestamp =
+    max(
+      next.offers.map(tx => tx.last_modified_time),
+      "0"
+    ) || ""
+
+  return !prev || nextMaxTimestamp > prevMaxTimestamp
+}
+
 export const accountDataCache = createCache<readonly [string, string], AccountData, AccountData>(createAccountCacheKey)
 
 export const accountHomeDomainCache = createCache<readonly [string, string], [string] | [], AccountData["home_domain"]>(
   createAccountCacheKey
 )
 
-export const accountOpenOrdersCache = createCache<
-  readonly [string, string],
-  ServerApi.OfferRecord[],
-  ServerApi.OfferRecord[]
->(createAccountCacheKey)
+export const accountOpenOrdersCache = createCache<readonly [string, string], OfferHistory, ServerApi.OfferRecord[]>(
+  createAccountCacheKey,
+  areOffersNewer
+)
 
 export const accountTransactionsCache = createCache<
   readonly [string, string],

--- a/src/Payment/components/PaymentDialog.tsx
+++ b/src/Payment/components/PaymentDialog.tsx
@@ -85,7 +85,7 @@ function PaymentDialog(props: Props) {
 
 function ConnectedPaymentDialog(props: Pick<Props, "account" | "onClose">) {
   const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
-  const openOrders = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
+  const { offers: openOrders } = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
 
   const closeAfterTimeout = () => {
     // Close automatically a second after successful submission

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -105,7 +105,7 @@ function TradingForm(props: Props) {
 
   const horizon = useHorizon(props.account.testnet)
   const tradePair = useLiveOrderbook(primaryAsset || Asset.native(), secondaryAsset, props.account.testnet)
-  const openOrders = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
+  const { offers: openOrders } = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
 
   const assets = React.useMemo(() => props.trustlines.map(balancelineToAsset), [props.trustlines])
 

--- a/src/TransactionReview/components/Operations.tsx
+++ b/src/TransactionReview/components/Operations.tsx
@@ -265,7 +265,7 @@ function ManageOfferOperation(props: ManageOfferOperationProps) {
       ? BigNumber(props.operation.buyAmount).mul(props.operation.price)
       : BigNumber(props.operation.amount)
 
-  const offers = useLiveAccountOffers(props.accountData.id, props.testnet)
+  const { offers } = useLiveAccountOffers(props.accountData.id, props.testnet)
 
   if (offerId === "0") {
     // Offer creation

--- a/src/Workers/net-worker/stellar-network.ts
+++ b/src/Workers/net-worker/stellar-network.ts
@@ -471,7 +471,7 @@ function subscribeToOpenOrdersUncached(horizonURL: string, accountID: string) {
   const fetchUpdate = async () => {
     // Don't use latest cursor as we want to fetch all open orders
     // (otherwise we could not handle order deletions)
-    const page = await fetchAccountOpenOrders(horizonURL, accountID)
+    const page = await fetchAccountOpenOrders(horizonURL, accountID, { order: "desc" })
     return page._embedded.records
   }
 


### PR DESCRIPTION
- [x] Add arrow next to the "Open Orders" title to show/hide open orders
- [x] Add "Load More" button below the list of open orders
- [x] Change order/sequence of open orders to descending to align it with how the recent transactions are displayed (+ this makes it more intuitive when loading more orders)

Closes #564. 
Might also close #1093 assuming that the underlying issue is that some orders were not shown because there are more than 10.