### PR TITLE
Add visibility toggle to password fields

### DIFF
--- a/src/AccountCreation/components/PasswordSetting.tsx
+++ b/src/AccountCreation/components/PasswordSetting.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next"
 import Collapse from "@material-ui/core/Collapse"
 import ListItemText from "@material-ui/core/ListItemText"
 import Switch from "@material-ui/core/Switch"
-import TextField from "@material-ui/core/TextField"
 import AccountSettingsItem from "~AccountSettings/components/AccountSettingsItem"
+import PasswordField from "~Generic/components/PasswordField"
 
 interface PasswordSettingProps {
   error?: string
@@ -39,17 +39,16 @@ function PasswordSetting(props: PasswordSettingProps) {
       <Collapse in={props.requiresPassword}>
         <AccountSettingsItem icon={null} subItem>
           <ListItemText style={{ marginLeft: 12, marginRight: 56, marginTop: -8 }}>
-            <TextField
+            <PasswordField
               error={Boolean(props.error)}
               fullWidth
               label={t("create-account.inputs.password.label")}
               margin="normal"
               onChange={event => props.onEnterPassword(event.target.value)}
               placeholder={t("create-account.inputs.password.placeholder")}
-              type="password"
               value={props.password}
             />
-            <TextField
+            <PasswordField
               error={Boolean(props.error)}
               fullWidth
               helperText={props.error}
@@ -57,7 +56,6 @@ function PasswordSetting(props: PasswordSettingProps) {
               margin="normal"
               onChange={event => props.onRepeatPassword(event.target.value)}
               placeholder={t("create-account.inputs.password-repeat.placeholder")}
-              type="password"
               value={props.repeatedPassword}
             />
           </ListItemText>

--- a/src/AccountSettings/components/ChangePasswordDialog.tsx
+++ b/src/AccountSettings/components/ChangePasswordDialog.tsx
@@ -4,7 +4,6 @@ import DialogActions from "@material-ui/core/DialogActions"
 import FormControlLabel from "@material-ui/core/FormControlLabel"
 import InputAdornment from "@material-ui/core/InputAdornment"
 import Switch from "@material-ui/core/Switch"
-import TextField from "@material-ui/core/TextField"
 import LockIcon from "@material-ui/icons/LockOutlined"
 import LockOpenIcon from "@material-ui/icons/LockOpenOutlined"
 import { Account, AccountsContext } from "~App/contexts/accounts"
@@ -15,6 +14,7 @@ import { ActionButton, DialogActionsBox } from "~Generic/components/DialogAction
 import { Box } from "~Layout/components/Box"
 import DialogBody from "~Layout/components/DialogBody"
 import MainTitle from "~Generic/components/MainTitle"
+import PasswordField from "~Generic/components/PasswordField"
 
 const adornmentLock = (
   <InputAdornment position="start">
@@ -204,7 +204,7 @@ function ChangePasswordDialog(props: Props) {
     >
       <Box alignSelf="center" margin="24px auto 0" maxWidth={400} width="100%">
         <Box hidden={!props.account.requiresPassword} margin="0 0 8px">
-          <TextField
+          <PasswordField
             autoFocus={props.account.requiresPassword && process.env.PLATFORM !== "ios"}
             error={Boolean(errors.prevPassword)}
             label={
@@ -216,12 +216,11 @@ function ChangePasswordDialog(props: Props) {
             margin="normal"
             value={formValues.prevPassword}
             onChange={event => setFormValue("prevPassword", event.target.value)}
-            type="password"
             InputProps={{ startAdornment: adornmentLockOpen }}
           />
         </Box>
         <Box hidden={removingPassword}>
-          <TextField
+          <PasswordField
             autoFocus={!props.account.requiresPassword && process.env.PLATFORM !== "ios"}
             error={Boolean(errors.nextPassword)}
             label={
@@ -233,10 +232,9 @@ function ChangePasswordDialog(props: Props) {
             margin="normal"
             value={formValues.nextPassword}
             onChange={event => setFormValue("nextPassword", event.target.value)}
-            type="password"
             InputProps={{ startAdornment: adornmentLock }}
           />
-          <TextField
+          <PasswordField
             error={Boolean(errors.nextPasswordRepeat)}
             label={
               errors.nextPasswordRepeat
@@ -247,7 +245,6 @@ function ChangePasswordDialog(props: Props) {
             margin="normal"
             value={formValues.nextPasswordRepeat}
             onChange={event => setFormValue("nextPasswordRepeat", event.target.value)}
-            type="password"
             InputProps={{ startAdornment: adornmentLock }}
           />
         </Box>

--- a/src/AccountSettings/components/ExportKeyDialog.tsx
+++ b/src/AccountSettings/components/ExportKeyDialog.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import InputAdornment from "@material-ui/core/InputAdornment"
-import TextField from "@material-ui/core/TextField"
 import Typography from "@material-ui/core/Typography"
 import LockIcon from "@material-ui/icons/LockOutlined"
 import LockOpenIcon from "@material-ui/icons/LockOpenOutlined"
@@ -16,6 +15,7 @@ import { Box } from "~Layout/components/Box"
 import DialogBody from "~Layout/components/DialogBody"
 import KeyExportBox from "~Account/components/KeyExportBox"
 import MainTitle from "~Generic/components/MainTitle"
+import PasswordField from "~Generic/components/PasswordField"
 
 interface PromptToRevealProps {
   children: React.ReactNode
@@ -48,7 +48,7 @@ function PromptToReveal(props: PromptToRevealProps) {
       {props.children}
       <form noValidate onSubmit={props.onReveal}>
         {props.requiresPassword ? (
-          <TextField
+          <PasswordField
             autoFocus={process.env.PLATFORM !== "ios"}
             fullWidth
             error={props.passwordError !== null}
@@ -58,7 +58,6 @@ function PromptToReveal(props: PromptToRevealProps) {
                 : t("account-settings.export-key.textfield.password.label")
             }
             margin="dense"
-            type="password"
             value={props.password}
             onChange={props.updatePassword}
             style={{ marginTop: 8 }}

--- a/src/Generic/components/PasswordField.tsx
+++ b/src/Generic/components/PasswordField.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import IconButton from "@material-ui/core/IconButton"
+import InputAdornment from "@material-ui/core/InputAdornment"
+import TextField, { TextFieldProps } from "@material-ui/core/TextField"
+import Visibility from "@material-ui/icons/Visibility"
+import VisibilityOff from "@material-ui/icons/VisibilityOff"
+
+function PasswordField(props: Omit<TextFieldProps, "type">) {
+  const [showPassword, setShowPassword] = React.useState(false)
+
+  const handleClickShowPassword = React.useCallback(() => {
+    setShowPassword(!showPassword)
+  }, [showPassword])
+
+  return (
+    <TextField
+      {...props}
+      InputProps={{
+        ...props.InputProps,
+        endAdornment: (
+          <InputAdornment position="end">
+            <IconButton onClick={handleClickShowPassword}>
+              {showPassword ? <Visibility /> : <VisibilityOff />}
+            </IconButton>
+          </InputAdornment>
+        )
+      }}
+      type={showPassword ? "text" : "password"}
+    />
+  )
+}
+
+export default PasswordField

--- a/src/TransactionReview/components/ReviewForm.tsx
+++ b/src/TransactionReview/components/ReviewForm.tsx
@@ -3,7 +3,6 @@ import nanoid from "nanoid"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { Transaction } from "stellar-sdk"
-import TextField from "@material-ui/core/TextField"
 import CheckIcon from "@material-ui/icons/Check"
 import CloseIcon from "@material-ui/icons/Close"
 import OpenInNewIcon from "@material-ui/icons/OpenInNew"
@@ -18,6 +17,7 @@ import { VerticalLayout } from "~Layout/components/Box"
 import Portal from "~Generic/components/Portal"
 import DismissalConfirmationDialog from "./DismissalConfirmationDialog"
 import TransactionSummary from "./TransactionSummary"
+import PasswordField from "~Generic/components/PasswordField"
 
 type FormErrors = { [formField in keyof FormValues]: Error | null }
 
@@ -139,7 +139,7 @@ function TxConfirmationForm(props: Props) {
           transaction={props.transaction}
         />
         {props.account.requiresPassword && !props.disabled ? (
-          <TextField
+          <PasswordField
             autoFocus={process.env.PLATFORM !== "ios"}
             error={Boolean(passwordError)}
             label={
@@ -147,7 +147,6 @@ function TxConfirmationForm(props: Props) {
                 ? renderFormFieldError(passwordError, t)
                 : t("account.transaction-review.textfield.password.label")
             }
-            type="password"
             fullWidth
             margin="dense"
             value={formValues.password || ""}


### PR DESCRIPTION
Adds a new `<PasswordField>` component which provides a button to toggle the visibility of the password. 
Replaces all `<TextField>`s used for passwords with the new component.

Closes #1102.