### PR TITLE
Fix PasswordField storybook error

### DIFF
--- a/src/Generic/components/PasswordField.tsx
+++ b/src/Generic/components/PasswordField.tsx
@@ -1,11 +1,11 @@
 import React from "react"
 import IconButton from "@material-ui/core/IconButton"
 import InputAdornment from "@material-ui/core/InputAdornment"
-import TextField, { TextFieldProps } from "@material-ui/core/TextField"
+import TextField, { StandardTextFieldProps } from "@material-ui/core/TextField"
 import Visibility from "@material-ui/icons/Visibility"
 import VisibilityOff from "@material-ui/icons/VisibilityOff"
 
-function PasswordField(props: Omit<TextFieldProps, "type">) {
+function PasswordField(props: Omit<StandardTextFieldProps, "type">) {
   const [showPassword, setShowPassword] = React.useState(false)
 
   const handleClickShowPassword = React.useCallback(() => {


### PR DESCRIPTION
Fixes the following error thrown by storybook:
```
ERROR in solar/src/Generic/components/PasswordField.tsx(16,6)
      TS2769: No overload matches this call.
  Overload 1 of 2, '(props: TextFieldProps, context?: any): ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)> | Component<...> | null', gave the following error.
    Type '{ InputProps: { endAdornment: Element; } | { endAdornment: Element; disableUnderline?: boolean | undefined; ref?: ((instance: unknown) => void) | RefObject<unknown> | null | undefined; ... 275 more ...; classes?: Partial<...> | undefined; } | { ...; } | { ...; }; ... 281 more ...; SelectProps?: Partial<...> | undefi...' is not assignable to type '(IntrinsicAttributes & StandardTextFieldProps) | (IntrinsicAttributes & FilledTextFieldProps) | (IntrinsicAttributes & OutlinedTextFieldProps)'.
      Type '{ InputProps: { endAdornment: Element; } | { endAdornment: Element; disableUnderline?: boolean | undefined; ref?: ((instance: unknown) => void) | RefObject<unknown> | null | undefined; ... 275 more ...; classes?: Partial<...> | undefined; } | { ...; } | { ...; }; ... 281 more ...; SelectProps?: Partial<...> | undefi...' is not assignable to type 'OutlinedTextFieldProps'.
        Types of property 'variant' are incompatible.
          Type '"filled" | "outlined" | "standard" | undefined' is not assignable to type '"outlined"'.
            Type 'undefined' is not assignable to type '"outlined"'.
  Overload 2 of 2, '(props: PropsWithChildren<TextFieldProps>, context?: any): ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)> | Component<...> | null', gave the following error.
    Type '{ InputProps: { endAdornment: Element; } | { endAdornment: Element; disableUnderline?: boolean | undefined; ref?: ((instance: unknown) => void) | RefObject<unknown> | null | undefined; ... 275 more ...; classes?: Partial<...> | undefined; } | { ...; } | { ...; }; ... 281 more ...; SelectProps?: Partial<...> | undefi...' is not assignable to type '(IntrinsicAttributes & StandardTextFieldProps & { children?: ReactNode; }) | (IntrinsicAttributes & FilledTextFieldProps & { ...; }) | (IntrinsicAttributes & ... 1 more ... & { ...; })'.
      Type '{ InputProps: { endAdornment: Element; } | { endAdornment: Element; disableUnderline?: boolean | undefined; ref?: ((instance: unknown) => void) | RefObject<unknown> | null | undefined; ... 275 more ...; classes?: Partial<...> | undefined; } | { ...; } | { ...; }; ... 281 more ...; SelectProps?: Partial<...> | undefi...' is not assignable to type 'OutlinedTextFieldProps'.
        Types of property 'variant' are incompatible.
          Type '"filled" | "outlined" | "standard" | undefined' is not assignable to type '"outlined"'.
            Type 'undefined' is not assignable to type '"outlined"'.
```