### PR TITLE
Allow importing pubnet and testnet account with same key

### DIFF
--- a/src/Account/components/TransactionList.tsx
+++ b/src/Account/components/TransactionList.tsx
@@ -101,16 +101,18 @@ function OfferDescription(props: {
   )
 }
 
-function RemotePublicKeys(props: { publicKeys: string[]; short?: boolean }) {
+function RemotePublicKeys(props: { publicKeys: string[]; short?: boolean; testnet: boolean }) {
   const { t } = useTranslation()
   if (props.publicKeys.length === 0) {
     return <>-</>
   } else if (props.publicKeys.length === 1) {
-    return <PublicKey publicKey={props.publicKeys[0]} variant={props.short ? "short" : "full"} />
+    return (
+      <PublicKey publicKey={props.publicKeys[0]} testnet={props.testnet} variant={props.short ? "short" : "full"} />
+    )
   } else {
     return (
       <>
-        <PublicKey publicKey={props.publicKeys[0]} variant="short" />{" "}
+        <PublicKey publicKey={props.publicKeys[0]} testnet={props.testnet} variant="short" />{" "}
         <i>
           + {props.publicKeys.length - 1} {t("account.transactions.transaction-list.item.remote-public-keys.more")}
         </i>
@@ -169,6 +171,8 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
     [] as string[]
   )
 
+  const testnet = props.transaction.networkPassphrase === Networks.TESTNET
+
   const secondary = React.useMemo(
     () => (
       <span style={{ display: "block", overflow: "hidden", textOverflow: "ellipsis" }}>
@@ -193,7 +197,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
         primary={
           <span>
             {t("account.transactions.transaction-list.item.from")}&nbsp;
-            <RemotePublicKeys publicKeys={remotePublicKeys} short />
+            <RemotePublicKeys publicKeys={remotePublicKeys} short testnet={testnet} />
           </span>
         }
         primaryTypographyProps={{ style: props.style }}
@@ -210,11 +214,11 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
         primary={
           <span>
             {t("account.transactions.transaction-list.item.to")}&nbsp;
-            <RemotePublicKeys publicKeys={remotePublicKeys} short />
+            <RemotePublicKeys publicKeys={remotePublicKeys} short testnet={testnet} />
             {props.alwaysShowSource ? (
               <span>
                 &nbsp;{t("account.transactions.transaction-list.item.from")}&nbsp;
-                <PublicKey publicKey={props.accountPublicKey} variant="short" />{" "}
+                <PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />{" "}
               </span>
             ) : null}
           </span>
@@ -239,7 +243,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
             {props.alwaysShowSource ? (
               <>
                 {" "}
-                (<PublicKey publicKey={props.accountPublicKey} variant="short" />)
+                (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
               </>
             ) : null}
           </span>
@@ -258,7 +262,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
             {props.alwaysShowSource ? (
               <>
                 {" "}
-                (<PublicKey publicKey={props.accountPublicKey} variant="short" />)
+                (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
               </>
             ) : null}
           </span>
@@ -285,7 +289,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
               {props.alwaysShowSource ? (
                 <>
                   {" "}
-                  (<PublicKey publicKey={props.accountPublicKey} variant="short" />)
+                  (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
                 </>
               ) : null}
             </span>
@@ -305,7 +309,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
               {props.alwaysShowSource ? (
                 <>
                   {" "}
-                  (<PublicKey publicKey={props.accountPublicKey} variant="short" />)
+                  (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
                 </>
               ) : null}
             </span>
@@ -325,7 +329,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
               {props.alwaysShowSource ? (
                 <>
                   {" "}
-                  (<PublicKey publicKey={props.accountPublicKey} variant="short" />)
+                  (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
                 </>
               ) : null}
             </span>

--- a/src/AccountCreation/hooks/useAccountCreation.ts
+++ b/src/AccountCreation/hooks/useAccountCreation.ts
@@ -5,9 +5,9 @@ import { Keypair } from "stellar-sdk"
 import { Account, AccountsContext } from "~App/contexts/accounts"
 import { AccountCreation, AccountCreationErrors } from "../types/types"
 
-function isAccountAlreadyImported(privateKey: string, accounts: Account[]) {
+function isAccountAlreadyImported(privateKey: string, accounts: Account[], testnet: boolean) {
   const publicKey = Keypair.fromSecret(privateKey).publicKey()
-  return accounts.some(account => account.publicKey === publicKey)
+  return accounts.some(account => account.publicKey === publicKey && account.testnet === testnet)
 }
 
 function getNewAccountName(t: TFunction, accounts: Account[], testnet: boolean) {
@@ -35,7 +35,10 @@ function validateAccountCreation(t: TFunction, accounts: Account[], accountCreat
 
   if (accountCreation.import && !(accountCreation.secretKey || "").match(/^S[A-Z0-9]{55}$/)) {
     errors.secretKey = t("create-account.validation.invalid-key")
-  } else if (accountCreation.import && isAccountAlreadyImported(accountCreation.secretKey!, accounts)) {
+  } else if (
+    accountCreation.import &&
+    isAccountAlreadyImported(accountCreation.secretKey!, accounts, accountCreation.testnet)
+  ) {
     errors.secretKey = t("create-account.validation.same-account")
   }
 

--- a/src/Generic/components/Fetchers.tsx
+++ b/src/Generic/components/Fetchers.tsx
@@ -18,6 +18,6 @@ export const AccountName = React.memo(function AccountName(props: AccountNamePro
   } else if (homeDomain) {
     return <span style={{ userSelect: "text" }}>{homeDomain}</span>
   } else {
-    return <Address address={props.publicKey} variant="short" />
+    return <Address address={props.publicKey} testnet={props.testnet} variant="short" />
   }
 })

--- a/src/Generic/components/PublicKey.tsx
+++ b/src/Generic/components/PublicKey.tsx
@@ -41,6 +41,7 @@ interface PublicKeyProps {
   publicKey: string
   variant?: Variant
   style?: React.CSSProperties
+  testnet: boolean
 }
 
 // tslint:disable-next-line no-shadowed-variable
@@ -49,7 +50,9 @@ export const PublicKey = React.memo(function PublicKey(props: PublicKeyProps) {
   const digits = getDigitCounts(props.variant)
   const { accounts } = React.useContext(AccountsContext)
 
-  const matchingLocalAccount = accounts.find(account => account.publicKey === props.publicKey)
+  const matchingLocalAccount = accounts.find(
+    account => account.publicKey === props.publicKey && account.testnet === props.testnet
+  )
 
   const style: React.CSSProperties = {
     display: "inline",
@@ -87,6 +90,7 @@ interface AddressProps {
   address: string
   variant?: Variant
   style?: React.CSSProperties
+  testnet: boolean
 }
 
 // tslint:disable-next-line no-shadowed-variable
@@ -108,11 +112,19 @@ export const Address = React.memo(function Address(props: AddressProps) {
 
       return (
         <span style={style}>
-          {formattedStellarAddress} ({<PublicKey publicKey={props.address} variant="shorter" />})
+          {formattedStellarAddress} ({<PublicKey publicKey={props.address} testnet={props.testnet} variant="shorter" />}
+          )
         </span>
       )
     } else {
-      return <PublicKey publicKey={props.address} style={{ fontWeight: "inherit" }} variant={props.variant} />
+      return (
+        <PublicKey
+          publicKey={props.address}
+          style={{ fontWeight: "inherit" }}
+          testnet={props.testnet}
+          variant={props.variant}
+        />
+      )
     }
   } else {
     return props.variant === "short" ? (

--- a/src/ManageSigners/components/ManageSignersDialog.tsx
+++ b/src/ManageSigners/components/ManageSignersDialog.tsx
@@ -119,6 +119,7 @@ function ManageSignersDialog(props: Props) {
       onCancel={props.onClose}
       onSubmit={submitTransaction}
       setIsEditingNewSigner={setIsEditingNewSigner}
+      testnet={props.account.testnet}
       title={titleContent}
     />
   )

--- a/src/ManageSigners/components/ManageSignersDialogContent.tsx
+++ b/src/ManageSigners/components/ManageSignersDialogContent.tsx
@@ -96,6 +96,7 @@ interface Props {
   onCancel: () => void
   onSubmit: (values: SignerUpdate) => void
   style?: React.CSSProperties
+  testnet: boolean
   title: React.ReactNode
 }
 
@@ -225,6 +226,7 @@ function ManageSignersDialogContent(props: Props) {
           localPublicKey={accountData.id}
           signers={updatedSigners}
           showKeyWeights={!allDefaultKeyweights}
+          testnet={props.testnet}
         />
       </VerticalLayout>
       {actionsContent}

--- a/src/ManageSigners/components/SignersEditor.tsx
+++ b/src/ManageSigners/components/SignersEditor.tsx
@@ -56,6 +56,7 @@ interface SignersEditorProps {
   addSigner: (signer: Horizon.AccountSigner) => void
   removeSigner: (signer: Horizon.AccountSigner) => void
   showKeyWeights?: boolean
+  testnet: boolean
 }
 
 function SignersEditor(props: SignersEditorProps) {
@@ -114,7 +115,7 @@ function SignersEditor(props: SignersEditorProps) {
             <PersonIcon style={{ fontSize: "2rem" }} />
           </ListItemIcon>
           <ListItemText
-            primary={<Address address={signer.key} variant="full" />}
+            primary={<Address address={signer.key} testnet={props.testnet} variant="full" />}
             secondary={
               <>
                 {props.showKeyWeights ? (

--- a/src/TransactionReview/components/Operations.tsx
+++ b/src/TransactionReview/components/Operations.tsx
@@ -2,7 +2,7 @@ import BigNumber from "big.js"
 import { TFunction } from "i18next"
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Asset, Operation, Transaction } from "stellar-sdk"
+import { Asset, Operation, Transaction, Networks } from "stellar-sdk"
 import { SingleBalance } from "~Account/components/AccountBalances"
 import { useLiveAccountOffers } from "~Generic/hooks/stellar-subscriptions"
 import { useAccountHomeDomainSafe } from "~Generic/hooks/stellar"
@@ -114,6 +114,7 @@ interface OperationProps<Op extends Operation> {
   operation: Op
   hideHeading?: boolean
   style?: React.CSSProperties
+  testnet: boolean
 }
 
 function PaymentOperation(props: OperationProps<Operation.Payment>) {
@@ -127,12 +128,12 @@ function PaymentOperation(props: OperationProps<Operation.Payment>) {
       />
       <SummaryDetailsField
         label={t("operations.payment.summary.destination")}
-        value={<CopyableAddress address={destination} variant="short" />}
+        value={<CopyableAddress address={destination} testnet={props.testnet} variant="short" />}
       />
       {source ? (
         <SummaryDetailsField
           label={t("operations.payment.summary.source")}
-          value={<CopyableAddress address={source} variant="short" />}
+          value={<CopyableAddress address={source} testnet={props.testnet} variant="short" />}
         />
       ) : null}
     </SummaryItem>
@@ -146,7 +147,7 @@ function CreateAccountOperation(props: OperationProps<Operation.CreateAccount>) 
     <SummaryItem heading={props.hideHeading ? undefined : t("operations.create-account.title")}>
       <SummaryDetailsField
         label={t("operations.create-account.summary.account")}
-        value={<CopyableAddress address={destination} variant="short" />}
+        value={<CopyableAddress address={destination} testnet={props.testnet} variant="short" />}
       />
       <SummaryDetailsField
         label={t("operations.create-account.summary.funding-amount")}
@@ -155,7 +156,7 @@ function CreateAccountOperation(props: OperationProps<Operation.CreateAccount>) 
       {source ? (
         <SummaryDetailsField
           label={t("operations.create-account.summary.funding-account")}
-          value={<CopyableAddress address={source} variant="short" />}
+          value={<CopyableAddress address={source} testnet={props.testnet} variant="short" />}
         />
       ) : null}
     </SummaryItem>
@@ -172,7 +173,13 @@ function ChangeTrustOperation(props: OperationProps<Operation.ChangeTrust> & { t
         <SummaryDetailsField label={t("operations.change-trust.summary.asset")} value={props.operation.line.code} />
         <SummaryDetailsField
           label={t("operations.change-trust.summary.issued-by")}
-          value={<CopyableAddress address={homeDomain || props.operation.line.issuer} variant="short" />}
+          value={
+            <CopyableAddress
+              address={homeDomain || props.operation.line.issuer}
+              testnet={props.testnet}
+              variant="short"
+            />
+          }
         />
       </SummaryItem>
     )
@@ -182,7 +189,13 @@ function ChangeTrustOperation(props: OperationProps<Operation.ChangeTrust> & { t
         <SummaryDetailsField label="Asset" value={props.operation.line.code} />
         <SummaryDetailsField
           label={t("operations.change-trust.summary.issued-by")}
-          value={<CopyableAddress address={homeDomain || props.operation.line.issuer} variant="short" />}
+          value={
+            <CopyableAddress
+              address={homeDomain || props.operation.line.issuer}
+              testnet={props.testnet}
+              variant="short"
+            />
+          }
         />
         {BigNumber(props.operation.limit).gt(900000000000) ? null : (
           <SummaryDetailsField
@@ -377,6 +390,8 @@ interface SetOptionsOperationProps {
 
 function SetOptionsOperation(props: SetOptionsOperationProps) {
   const { t } = useTranslation()
+  const testnet = props.transaction.networkPassphrase === Networks.TESTNET
+
   if (
     props.operation.signer &&
     "ed25519PublicKey" in props.operation.signer &&
@@ -388,7 +403,7 @@ function SetOptionsOperation(props: SetOptionsOperationProps) {
         <SummaryItem heading={props.hideHeading ? undefined : t("operations.set-options.add-signer.title")}>
           <SummaryDetailsField
             label={t("operations.set-options.add-signer.summary.new-signer")}
-            value={<CopyableAddress address={signerPublicKey} variant="short" />}
+            value={<CopyableAddress address={signerPublicKey} testnet={testnet} variant="short" />}
           />
           <SummaryDetailsField
             label={t("operations.set-options.add-signer.summary.key-weight")}
@@ -396,7 +411,13 @@ function SetOptionsOperation(props: SetOptionsOperationProps) {
           />
           <SummaryDetailsField
             label={t("operations.set-options.add-signer.summary.account")}
-            value={<CopyableAddress address={props.operation.source || props.transaction.source} variant="short" />}
+            value={
+              <CopyableAddress
+                address={props.operation.source || props.transaction.source}
+                testnet={testnet}
+                variant="short"
+              />
+            }
           />
         </SummaryItem>
       )
@@ -405,11 +426,17 @@ function SetOptionsOperation(props: SetOptionsOperationProps) {
         <SummaryItem heading={props.hideHeading ? undefined : t("operations.set-options.remove-signer.title")}>
           <SummaryDetailsField
             label={t("operations.set-options.remove-signer.summary.signer")}
-            value={<CopyableAddress address={signerPublicKey} variant="short" />}
+            value={<CopyableAddress address={signerPublicKey} testnet={testnet} variant="short" />}
           />
           <SummaryDetailsField
             label={t("operations.set-options.remove-signer.summary.account")}
-            value={<CopyableAddress address={props.operation.source || props.transaction.source} variant="short" />}
+            value={
+              <CopyableAddress
+                address={props.operation.source || props.transaction.source}
+                testnet={testnet}
+                variant="short"
+              />
+            }
           />
         </SummaryItem>
       )
@@ -456,7 +483,7 @@ function SetOptionsOperation(props: SetOptionsOperationProps) {
         <SummaryDetailsField
           fullWidth
           label={t("operations.set-options.set-inflation-destination.summary.new-destination")}
-          value={<CopyableAddress address={props.operation.inflationDest} variant="short" />}
+          value={<CopyableAddress address={props.operation.inflationDest} testnet={testnet} variant="short" />}
         />
       </SummaryItem>
     )
@@ -481,12 +508,12 @@ function AccountMergeOperation(props: OperationProps<Operation.AccountMerge>) {
       {source ? (
         <SummaryDetailsField
           label={t("operations.account-merge.summary.account")}
-          value={<CopyableAddress address={source} variant="short" />}
+          value={<CopyableAddress address={source} testnet={props.testnet} variant="short" />}
         />
       ) : null}
       <SummaryDetailsField
         label={t("operations.account-merge.summary.merge-into")}
-        value={<CopyableAddress address={destination} variant="short" />}
+        value={<CopyableAddress address={destination} testnet={props.testnet} variant="short" />}
       />
     </SummaryItem>
   )
@@ -526,9 +553,23 @@ function OperationListItem(props: Props) {
       />
     )
   } else if (props.operation.type === "createAccount") {
-    return <CreateAccountOperation hideHeading={hideHeading} operation={props.operation} style={props.style} />
+    return (
+      <CreateAccountOperation
+        hideHeading={hideHeading}
+        operation={props.operation}
+        style={props.style}
+        testnet={props.testnet}
+      />
+    )
   } else if (props.operation.type === "payment") {
-    return <PaymentOperation hideHeading={hideHeading} operation={props.operation} style={props.style} />
+    return (
+      <PaymentOperation
+        hideHeading={hideHeading}
+        operation={props.operation}
+        style={props.style}
+        testnet={props.testnet}
+      />
+    )
   } else if (props.operation.type === "manageData") {
     return (
       <ManageDataOperation
@@ -559,7 +600,14 @@ function OperationListItem(props: Props) {
       />
     )
   } else if (props.operation.type === "accountMerge") {
-    return <AccountMergeOperation hideHeading={hideHeading} operation={props.operation} style={props.style} />
+    return (
+      <AccountMergeOperation
+        hideHeading={hideHeading}
+        operation={props.operation}
+        style={props.style}
+        testnet={props.testnet}
+      />
+    )
   } else {
     return <GenericOperation operation={props.operation} style={props.style} />
   }

--- a/src/TransactionReview/components/Transaction.tsx
+++ b/src/TransactionReview/components/Transaction.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Horizon, Memo, Transaction } from "stellar-sdk"
+import { Horizon, Memo, Transaction, Networks } from "stellar-sdk"
 import ListItem from "@material-ui/core/ListItem"
 import ListItemIcon from "@material-ui/core/ListItemIcon"
 import ListItemText from "@material-ui/core/ListItemText"
@@ -78,6 +78,7 @@ const Signer = React.memo(function Signer(props: {
   transaction: Transaction
 }) {
   const isSmallScreen = useIsMobile()
+  const testnet = props.transaction.networkPassphrase === Networks.TESTNET
 
   return (
     <div style={{ display: "flex", alignItems: "center", ...props.style }}>
@@ -86,6 +87,7 @@ const Signer = React.memo(function Signer(props: {
         <Address
           address={props.signer.key}
           style={{ display: "inline-block", fontWeight: "normal", minWidth: 480 }}
+          testnet={testnet}
           variant={isSmallScreen ? "short" : "full"}
         />
       </div>

--- a/src/TransactionReview/components/TransactionSummary.tsx
+++ b/src/TransactionReview/components/TransactionSummary.tsx
@@ -135,7 +135,7 @@ function DefaultTransactionSummary(props: DefaultTransactionSummaryProps) {
               <SummaryDetailsField
                 fullWidth
                 label={t("account.transaction-review.summary.item.account.label")}
-                value={<CopyableAddress address={props.transaction.source} variant="short" />}
+                value={<CopyableAddress address={props.transaction.source} testnet={props.testnet} variant="short" />}
               />
             </SummaryItem>
           ) : null}
@@ -144,7 +144,7 @@ function DefaultTransactionSummary(props: DefaultTransactionSummaryProps) {
               <SummaryDetailsField
                 fullWidth
                 label={t("account.transaction-review.summary.item.tx-hash.label")}
-                value={<ClickableAddress address={transactionHash} variant="shorter" />}
+                value={<ClickableAddress address={transactionHash} testnet={props.testnet} variant="shorter" />}
               />
             </SummaryItem>
           ) : null}
@@ -195,7 +195,7 @@ function WebAuthTransactionSummary(props: WebAuthTransactionSummaryProps) {
         />
         <SummaryDetailsField
           label={t("account.transaction-review.summary.item.authenticating-account.label")}
-          value={<CopyableAddress address={manageDataOperation.source || ""} variant="short" />}
+          value={<CopyableAddress address={manageDataOperation.source || ""} testnet={props.testnet} variant="short" />}
         />
       </SummaryItem>
       {maxTime ? (


### PR DESCRIPTION
- [x] Modify the `validateAccountCreation` check to look for accounts with the same `publicKey` on same network
- [x] Add `testnet` to props of `<PublicKey>` and `<Address>`
- [x] Pass `testnet` prop to `<PublicKey>` and `<Address>` components

Closes #1140.