### PR TITLE
Fix android view not resizing with keyboard

### DIFF
--- a/cordova/config/config.template
+++ b/cordova/config/config.template
@@ -117,6 +117,7 @@
     <preference name="HideKeyboardFormAccessoryBar" value="false" />
     <preference name="KeyboardResize" value="true" />
     <preference name="KeyboardResizeMode" value="native" />
+    <preference name="resizeOnFullScreen" value="true" />
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="SplashScreenDelay" value="$SPLASH_SCREEN_DELAY" />
     <preference name="SwiftVersion" value="5.0" />

--- a/cordova/scripts/android/CDVIonicKeyboard.java
+++ b/cordova/scripts/android/CDVIonicKeyboard.java
@@ -1,0 +1,163 @@
+// Fix from https://github.com/ionic-team/cordova-plugin-ionic-keyboard/pull/145
+package io.ionic.keyboard;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PluginResult;
+import org.apache.cordova.PluginResult.Status;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.Rect;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.view.ViewTreeObserver;
+import android.view.ViewTreeObserver.OnGlobalLayoutListener;
+import android.view.Window;
+import android.view.inputmethod.InputMethodManager;
+
+// import additionally required classes for calculating screen height
+import android.view.Display;
+import android.graphics.Point;
+import android.os.Build;
+import android.widget.FrameLayout;
+
+public class CDVIonicKeyboard extends CordovaPlugin {
+    private OnGlobalLayoutListener list;
+    private View rootView;
+    private View mChildOfContent;
+    private int usableHeightPrevious;
+    private FrameLayout.LayoutParams frameLayoutParams;
+
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+    }
+
+    public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
+        if ("hide".equals(action)) {
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                    //http://stackoverflow.com/a/7696791/1091751
+                    InputMethodManager inputManager = (InputMethodManager) cordova.getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+                    View v = cordova.getActivity().getCurrentFocus();
+
+                    if (v == null) {
+                        callbackContext.error("No current focus");
+                    } else {
+                        inputManager.hideSoftInputFromWindow(v.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+                        callbackContext.success(); // Thread-safe.
+                    }
+                }
+            });
+            return true;
+        }
+        if ("show".equals(action)) {
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                    ((InputMethodManager) cordova.getActivity().getSystemService(Context.INPUT_METHOD_SERVICE)).toggleSoftInput(0, InputMethodManager.HIDE_IMPLICIT_ONLY);
+                    callbackContext.success(); // Thread-safe.
+                }
+            });
+            return true;
+        }
+        if ("init".equals(action)) {
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                	//calculate density-independent pixels (dp)
+                    //http://developer.android.com/guide/practices/screens_support.html
+                    DisplayMetrics dm = new DisplayMetrics();
+                    cordova.getActivity().getWindowManager().getDefaultDisplay().getMetrics(dm);
+                    final float density = dm.density;
+
+                    //http://stackoverflow.com/a/4737265/1091751 detect if keyboard is showing
+                    FrameLayout content = (FrameLayout) cordova.getActivity().findViewById(android.R.id.content);
+                    rootView = content.getRootView();
+                    
+                    list = new OnGlobalLayoutListener() {
+                        int previousHeightDiff = 0;
+                        @Override
+                        public void onGlobalLayout() {
+                            boolean resize = preferences.getBoolean("resizeOnFullScreen", false);
+                            if (resize) {
+                                possiblyResizeChildOfContent();
+                            }
+                            Rect r = new Rect();
+                            //r will be populated with the coordinates of your view that area still visible.
+                            rootView.getWindowVisibleDisplayFrame(r);
+
+                            PluginResult result;
+
+                            // cache properties for later use
+                            int rootViewHeight = rootView.getRootView().getHeight();
+                            int resultBottom = r.bottom;
+
+                            // calculate screen height differently for android versions >= 21: Lollipop 5.x, Marshmallow 6.x
+                            //http://stackoverflow.com/a/29257533/3642890 beware of nexus 5
+                            int screenHeight;
+
+                            if (Build.VERSION.SDK_INT >= 21) {
+                                Display display = cordova.getActivity().getWindowManager().getDefaultDisplay();
+                                Point size = new Point();
+                                display.getSize(size);
+                                screenHeight = size.y;
+                            } else {
+                                screenHeight = rootViewHeight;
+                            }
+
+                            int heightDiff = screenHeight - resultBottom;
+
+                            int pixelHeightDiff = (int)(heightDiff / density);
+                            if (pixelHeightDiff > 100 && pixelHeightDiff != previousHeightDiff) { // if more than 100 pixels, its probably a keyboard...
+                                String msg = "S" + Integer.toString(pixelHeightDiff);
+                                result = new PluginResult(PluginResult.Status.OK, msg);
+                                result.setKeepCallback(true);
+                                callbackContext.sendPluginResult(result);
+                            }
+                            else if ( pixelHeightDiff != previousHeightDiff && ( previousHeightDiff - pixelHeightDiff ) > 100 ){
+                            	String msg = "H";
+                                result = new PluginResult(PluginResult.Status.OK, msg);
+                                result.setKeepCallback(true);
+                                callbackContext.sendPluginResult(result);
+                            }
+                            previousHeightDiff = pixelHeightDiff;
+                        }
+
+                        private void possiblyResizeChildOfContent() {
+                            int usableHeightNow = computeUsableHeight();
+                            if (usableHeightNow != usableHeightPrevious) {
+                                frameLayoutParams.height = usableHeightNow;
+                                mChildOfContent.requestLayout();
+                                usableHeightPrevious = usableHeightNow;
+                            }
+                        }
+
+                        private int computeUsableHeight() {
+                            Rect r = new Rect();
+                            mChildOfContent.getWindowVisibleDisplayFrame(r);
+                            return r.bottom;
+                        }
+                    };
+
+                    mChildOfContent = content.getChildAt(0);
+                    rootView.getViewTreeObserver().addOnGlobalLayoutListener(list);
+                    frameLayoutParams = (FrameLayout.LayoutParams) mChildOfContent.getLayoutParams();
+                    PluginResult dataResult = new PluginResult(PluginResult.Status.OK);
+                    dataResult.setKeepCallback(true);
+                    callbackContext.sendPluginResult(dataResult);
+                }
+            });
+            return true;
+        }
+        return false;  // Returning false results in a "MethodNotFound" error.
+    }
+
+    @Override
+    public void onDestroy() {
+        rootView.getViewTreeObserver().removeOnGlobalLayoutListener(list);
+    }
+
+}

--- a/cordova/scripts/android/CDVIonicKeyboard.java
+++ b/cordova/scripts/android/CDVIonicKeyboard.java
@@ -1,4 +1,5 @@
-// Fix from https://github.com/ionic-team/cordova-plugin-ionic-keyboard/pull/145
+// Code copied from https://github.com/ionic-team/cordova-plugin-ionic-keyboard/pull/145 (because it is not yet merged)
+// to fix an issue with the keyboard covering input fields (see https://github.com/satoshipay/solar/pull/1144)
 package io.ionic.keyboard;
 
 import org.apache.cordova.CallbackContext;

--- a/cordova/scripts/android/useFullScreenActivity.sh
+++ b/cordova/scripts/android/useFullScreenActivity.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 ROOT_DIR=$1
 cp $ROOT_DIR/scripts/android/MainActivity.java $ROOT_DIR/platforms/android/app/src/main/java/io/solarwallet/MainActivity.java
+cp $ROOT_DIR/scripts/android/CDVIonicKeyboard.java $ROOT_DIR/platforms/android/app/src/main/java/io/ionic/keyboard/CDVIonicKeyboard.java


### PR DESCRIPTION
Fixes an issue where focused input fields were covered by the keyboard if they are in the middle/bottom end of the screen and it's not possible to scroll down to make it visible again.
- [x] Set `resizeOnFullScreen` to `true` to make scrolling below the input fields possible
- [x] Add [this](https://github.com/ionic-team/cordova-plugin-ionic-keyboard/pull/145) fix for navigation overflow and the black bar issue (mentioned in #1000)
Since it's not yet merged into `master` and there are only changes in one file I decided to just hard-copy it to circumvent creating a new fork.

Closes #1000. 