### PR TITLE
Fix displaced layout of account settings on iOS/Android

### DIFF
--- a/src/Account/components/AccountView.tsx
+++ b/src/Account/components/AccountView.tsx
@@ -295,6 +295,7 @@ const AccountPageContent = React.memo(function AccountPageContent(props: Account
           backgroundColor: "#fcfcfc",
           flexGrow: 1,
           flexShrink: 1,
+          height: "100%",
           padding: isSmallScreen ? 0 : "0 24px",
           overflowY: "auto"
         }}

--- a/src/AccountSettings/components/AccountDeletionDialog.tsx
+++ b/src/AccountSettings/components/AccountDeletionDialog.tsx
@@ -209,7 +209,7 @@ function AccountDeletionDialog(props: AccountDeletionDialogProps) {
     <DialogBody
       background={<WarnIcon style={{ fontSize: 160 }} />}
       noMaxWidth
-      preventNotch
+      preventNotchSpacing
       top={
         <MainTitle
           hideBackButton

--- a/src/AccountSettings/components/AccountDeletionDialog.tsx
+++ b/src/AccountSettings/components/AccountDeletionDialog.tsx
@@ -209,6 +209,7 @@ function AccountDeletionDialog(props: AccountDeletionDialogProps) {
     <DialogBody
       background={<WarnIcon style={{ fontSize: 160 }} />}
       noMaxWidth
+      preventNotch
       top={
         <MainTitle
           hideBackButton

--- a/src/AccountSettings/components/ChangePasswordDialog.tsx
+++ b/src/AccountSettings/components/ChangePasswordDialog.tsx
@@ -182,7 +182,7 @@ function ChangePasswordDialog(props: Props) {
   return (
     <DialogBody
       noMaxWidth
-      preventNotch
+      preventNotchSpacing
       top={
         <MainTitle
           hideBackButton

--- a/src/AccountSettings/components/ChangePasswordDialog.tsx
+++ b/src/AccountSettings/components/ChangePasswordDialog.tsx
@@ -182,6 +182,7 @@ function ChangePasswordDialog(props: Props) {
   return (
     <DialogBody
       noMaxWidth
+      preventNotch
       top={
         <MainTitle
           hideBackButton

--- a/src/AccountSettings/components/ExportKeyDialog.tsx
+++ b/src/AccountSettings/components/ExportKeyDialog.tsx
@@ -35,7 +35,7 @@ function PromptToReveal(props: PromptToRevealProps) {
     <DialogBody
       background={<WarnIcon style={{ fontSize: 220 }} />}
       noMaxWidth
-      preventNotch
+      preventNotchSpacing
       top={props.title}
       actions={
         <DialogActionsBox desktopStyle={{ marginTop: 32 }} smallDialog>
@@ -91,7 +91,7 @@ function ShowSecretKey(props: ShowSecretKeyProps) {
     <DialogBody
       background={<LockFilledIcon style={{ fontSize: 220 }} />}
       noMaxWidth
-      preventNotch
+      preventNotchSpacing
       top={props.title}
       actions={
         props.onConfirm ? (

--- a/src/AccountSettings/components/ExportKeyDialog.tsx
+++ b/src/AccountSettings/components/ExportKeyDialog.tsx
@@ -35,6 +35,7 @@ function PromptToReveal(props: PromptToRevealProps) {
     <DialogBody
       background={<WarnIcon style={{ fontSize: 220 }} />}
       noMaxWidth
+      preventNotch
       top={props.title}
       actions={
         <DialogActionsBox desktopStyle={{ marginTop: 32 }} smallDialog>
@@ -90,6 +91,7 @@ function ShowSecretKey(props: ShowSecretKeyProps) {
     <DialogBody
       background={<LockFilledIcon style={{ fontSize: 220 }} />}
       noMaxWidth
+      preventNotch
       top={props.title}
       actions={
         props.onConfirm ? (

--- a/src/Layout/components/DialogBody.tsx
+++ b/src/Layout/components/DialogBody.tsx
@@ -55,7 +55,7 @@ interface Props {
   fitToShrink?: boolean
   noMaxWidth?: boolean
   preventActionsPlaceholder?: boolean
-  preventNotch?: boolean
+  preventNotchSpacing?: boolean
   top?: React.ReactNode
 }
 
@@ -104,7 +104,7 @@ function DialogBody(props: Props) {
         overflowX="hidden"
         padding={isSmallScreen ? "12px 24px" : "24px 32px"}
         style={{ flexDirection: "column" }}
-        top={!props.preventNotch}
+        top={!props.preventNotchSpacing}
         width="100%"
       >
         <React.Suspense fallback={<CircularProgress style={{ alignSelf: "center", justifySelf: "center" }} />}>

--- a/src/LumenPurchase/components/LegalConfirmation.tsx
+++ b/src/LumenPurchase/components/LegalConfirmation.tsx
@@ -60,7 +60,7 @@ function LegalConfirmation(props: Props) {
       open={props.open}
       TransitionComponent={CompactDialogTransition}
     >
-      <DialogBody actions={dialogActionsRef} preventActionsPlaceholder preventNotch>
+      <DialogBody actions={dialogActionsRef} preventActionsPlaceholder preventNotchSpacing>
         <Typography color="textSecondary">{props.message}</Typography>
       </DialogBody>
       <Portal target={isSmallScreen ? document.body : dialogActionsRef.element}>{actions}</Portal>

--- a/src/ManageSigners/components/ManageSignersDialogContent.tsx
+++ b/src/ManageSigners/components/ManageSignersDialogContent.tsx
@@ -211,7 +211,7 @@ function ManageSignersDialogContent(props: Props) {
   )
 
   return (
-    <DialogBody noMaxWidth top={props.title} actions={isSmallScreen ? actionsRef : undefined}>
+    <DialogBody noMaxWidth top={props.title} preventNotch actions={isSmallScreen ? actionsRef : undefined}>
       <VerticalLayout
         justifyContent="space-between"
         margin="8px 0 0"

--- a/src/ManageSigners/components/ManageSignersDialogContent.tsx
+++ b/src/ManageSigners/components/ManageSignersDialogContent.tsx
@@ -211,7 +211,7 @@ function ManageSignersDialogContent(props: Props) {
   )
 
   return (
-    <DialogBody noMaxWidth top={props.title} preventNotch actions={isSmallScreen ? actionsRef : undefined}>
+    <DialogBody noMaxWidth top={props.title} preventNotchSpacing actions={isSmallScreen ? actionsRef : undefined}>
       <VerticalLayout
         justifyContent="space-between"
         margin="8px 0 0"


### PR DESCRIPTION
- [x] Fix actions in inline dialogs (Account Settings) not properly placed at the bottom of  the screen on iOS
- [x] Fix inline dialogs having too much spacing at the top on iOS and Android
This was due to the fact that the `<DialogBody>` components by default add additional spacing at the top on mobile to prevent the dialogs overlapping with notch spaces

**Before:**
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-21 at 18 38 36](https://user-images.githubusercontent.com/6690623/93857137-6a8d8e80-fcba-11ea-95fd-338c93247c00.png)
**After:**
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-22 at 10 06 43](https://user-images.githubusercontent.com/6690623/93857729-57c78980-fcbb-11ea-9d35-5386a9a23292.png)

