### PR TITLE
Change style of network toggle button

### DIFF
--- a/i18n/locales/en/app.json
+++ b/i18n/locales/en/app.json
@@ -12,14 +12,7 @@
   },
   "all-accounts": {
     "switch": {
-      "to-mainnet": {
-        "short": "Mainnet",
-        "long": "Switch To Mainnet"
-      },
-      "to-testnet": {
-        "short": "Testnet",
-        "long": "Switch To Testnet"
-      }
+      "label": "Testnet"
     },
     "update": {
       "notification": {

--- a/src/App/components/AccountListView.tsx
+++ b/src/App/components/AccountListView.tsx
@@ -4,6 +4,7 @@ import Button from "@material-ui/core/Button"
 import IconButton from "@material-ui/core/IconButton"
 import makeStyles from "@material-ui/core/styles/makeStyles"
 import SettingsIcon from "@material-ui/icons/Settings"
+import SwapIcon from "@material-ui/icons/SwapHoriz"
 import Tooltip from "@material-ui/core/Tooltip"
 import useMediaQuery from "@material-ui/core/useMediaQuery"
 import UpdateIcon from "@material-ui/icons/SystemUpdateAlt"
@@ -83,7 +84,13 @@ function AllAccountsPage() {
   )
 
   const networkSwitchButton = (
-    <Button color="inherit" variant="outlined" onClick={toggleNetwork} style={{ borderColor: "white" }}>
+    <Button
+      color="inherit"
+      variant="outlined"
+      onClick={toggleNetwork}
+      startIcon={isSmallScreen ? <SwapIcon /> : undefined}
+      style={{ borderColor: "white", borderRadius: "40px" }}
+    >
       {networkSwitch === "testnet" ? switchToMainnetLabel : switchToTestnetLabel}
     </Button>
   )

--- a/src/App/components/AccountListView.tsx
+++ b/src/App/components/AccountListView.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import Button from "@material-ui/core/Button"
+import FormControlLabel from "@material-ui/core/FormControlLabel"
 import IconButton from "@material-ui/core/IconButton"
 import makeStyles from "@material-ui/core/styles/makeStyles"
 import SettingsIcon from "@material-ui/icons/Settings"
-import SwapIcon from "@material-ui/icons/SwapHoriz"
+import Switch from "@material-ui/core/Switch"
 import Tooltip from "@material-ui/core/Tooltip"
 import useMediaQuery from "@material-ui/core/useMediaQuery"
 import UpdateIcon from "@material-ui/icons/SystemUpdateAlt"
@@ -12,7 +12,7 @@ import DialogBody from "~Layout/components/DialogBody"
 import { Box, VerticalLayout } from "~Layout/components/Box"
 import { Section } from "~Layout/components/Page"
 import MainTitle from "~Generic/components/MainTitle"
-import { useIsMobile, useRouter } from "~Generic/hooks/userinterface"
+import { useRouter } from "~Generic/hooks/userinterface"
 import getUpdater from "~Platform/updater"
 import AppNotificationPermission from "~Toasts/components/AppNotificationPermission"
 import { AccountsContext } from "../contexts/accounts"
@@ -44,15 +44,7 @@ function AllAccountsPage() {
   const { t } = useTranslation()
 
   const styles = useStyles()
-  const isSmallScreen = useIsMobile()
   const isWidthMax450 = useMediaQuery("(max-width:450px)")
-
-  const switchToMainnetLabel = isSmallScreen
-    ? t("app.all-accounts.switch.to-mainnet.short")
-    : t("app.all-accounts.switch.to-mainnet.long")
-  const switchToTestnetLabel = isSmallScreen
-    ? t("app.all-accounts.switch.to-testnet.short")
-    : t("app.all-accounts.switch.to-testnet.long")
 
   const updater = getUpdater()
 
@@ -84,15 +76,11 @@ function AllAccountsPage() {
   )
 
   const networkSwitchButton = (
-    <Button
-      color="inherit"
-      variant="outlined"
-      onClick={toggleNetwork}
-      startIcon={isSmallScreen ? <SwapIcon /> : undefined}
-      style={{ borderColor: "white", borderRadius: "40px" }}
-    >
-      {networkSwitch === "testnet" ? switchToMainnetLabel : switchToTestnetLabel}
-    </Button>
+    <FormControlLabel
+      control={<Switch checked={networkSwitch === "testnet"} color="secondary" onChange={toggleNetwork} />}
+      label={t("app.all-accounts.switch.label")}
+      style={{ marginRight: 0 }}
+    />
   )
 
   const headerContent = React.useMemo(

--- a/src/App/theme.ts
+++ b/src/App/theme.ts
@@ -4,6 +4,7 @@ import Fade from "@material-ui/core/Fade"
 import ArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
 import amber from "@material-ui/core/colors/amber"
 import lightBlue from "@material-ui/core/colors/lightBlue"
+import grey from "@material-ui/core/colors/grey"
 import { SlideLeftTransition, SlideUpTransition } from "../Generic/components/Transitions"
 
 // TODO: The dark and light derivation of the brand color have not been design-reviewed!
@@ -276,6 +277,17 @@ const theme = createMuiTheme({
     MuiPaper: {
       rounded: {
         borderRadius: 8
+      }
+    },
+    MuiSwitch: {
+      colorSecondary: {
+        color: grey[50],
+        "&$checked": {
+          color: grey[50]
+        },
+        "&$checked + $track": {
+          backgroundColor: grey[50]
+        }
       }
     },
     MuiTab: {


### PR DESCRIPTION
Changes the style of the network toggle button in the account list view to make it more obvious that it's a button and not a label indicating the current network.

- [x] Set a `border-radius` to make it look like a pill button
- [x] Add a `startIcon` on small screens
The icon is only shown on small screens because on larger screens the text `Switch to ...` makes it obvious that you are switching to that network.

<img width="390" alt="Screenshot 2020-10-05 at 18 10 12" src="https://user-images.githubusercontent.com/6690623/95104381-09dc6800-0736-11eb-854a-ba536fba9175.png">
<img width="405" alt="Screenshot 2020-10-05 at 18 03 15" src="https://user-images.githubusercontent.com/6690623/95104031-a6523a80-0735-11eb-974b-2d9d6a82b1fd.png">

No `startIcon` on large screens:
<img width="849" alt="Screenshot 2020-10-05 at 18 03 39" src="https://user-images.githubusercontent.com/6690623/95104052-abaf8500-0735-11eb-90c5-ce2feb0ac8cd.png">

Closes #1148.
