### PR TITLE
Unify code for closing dialogs after transaction submission

### DIFF
--- a/src/AccountSettings/components/AccountDeletionDialog.tsx
+++ b/src/AccountSettings/components/AccountDeletionDialog.tsx
@@ -92,7 +92,7 @@ interface AccountDeletionDialogProps {
   account: Account
   horizon: Server
   onClose: () => void
-  onDeleted: () => void
+  onDelete: () => void
   sendTransaction: (transaction: Transaction) => void
 }
 
@@ -100,7 +100,7 @@ function AccountDeletionDialog(props: AccountDeletionDialogProps) {
   const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
   const horizon = props.horizon
 
-  const { accounts, deleteAccount } = React.useContext(AccountsContext)
+  const { accounts } = React.useContext(AccountsContext)
   const [mergeAccountEnabled, setMergeAccountEnabled] = React.useState(false)
   const [confirmationPending, setConfirmationPending] = React.useState(false)
   const [selectedMergeAccount, setSelectedMergeAccount] = React.useState<Account | null>(null)
@@ -117,12 +117,6 @@ function AccountDeletionDialog(props: AccountDeletionDialogProps) {
     setWarning(prev => (prev ? { ...prev, open: false } : undefined))
   }, [setWarning])
 
-  const onDelete = () => {
-    deleteAccount(props.account.id)
-    props.onClose()
-    props.onDeleted()
-  }
-
   const onMerge = async () => {
     if (selectedMergeAccount) {
       const transaction = await createTransaction(
@@ -136,7 +130,6 @@ function AccountDeletionDialog(props: AccountDeletionDialogProps) {
       )
 
       await props.sendTransaction(transaction)
-      setTimeout(onDelete, 1000)
     }
   }
 
@@ -145,7 +138,7 @@ function AccountDeletionDialog(props: AccountDeletionDialogProps) {
     if (mergeAccountEnabled) {
       onMerge()
     } else {
-      onDelete()
+      props.onDelete()
     }
   }
 
@@ -275,9 +268,17 @@ interface AccountDeletionContainerProps {
 }
 
 function AccountDeletionContainer(props: AccountDeletionContainerProps) {
+  const { deleteAccount } = React.useContext(AccountsContext)
+
+  const onDelete = () => {
+    deleteAccount(props.account.id)
+    props.onClose()
+    props.onDeleted()
+  }
+
   return (
-    <TransactionSender account={props.account}>
-      {txContext => <AccountDeletionDialog {...props} {...txContext} />}
+    <TransactionSender account={props.account} onSubmissionCompleted={onDelete}>
+      {txContext => <AccountDeletionDialog {...props} {...txContext} onDelete={onDelete} />}
     </TransactionSender>
   )
 }

--- a/src/Assets/components/AddAssetDialog.tsx
+++ b/src/Assets/components/AddAssetDialog.tsx
@@ -375,12 +375,8 @@ const AddAssetDialog = React.memo(function AddAssetDialog(props: AddAssetDialogP
 })
 
 function ConnectedAddAssetDialog(props: Omit<AddAssetDialogProps, "horizon" | "sendTransaction">) {
-  const closeAfterTimeout = () => {
-    // Close automatically a second after successful submission
-    setTimeout(() => props.onClose(), 1000)
-  }
   return (
-    <TransactionSender account={props.account} onSubmissionCompleted={closeAfterTimeout}>
+    <TransactionSender account={props.account} onSubmissionCompleted={props.onClose}>
       {({ horizon, sendTransaction }) => (
         <AddAssetDialog {...props} horizon={horizon} sendTransaction={sendTransaction} />
       )}

--- a/src/Assets/components/RemoveTrustline.tsx
+++ b/src/Assets/components/RemoveTrustline.tsx
@@ -84,12 +84,8 @@ const RemoveTrustlineDialog = React.memo(function RemoveTrustlineDialog(props: P
 })
 
 function ConnectedRemoveTrustlineDialog(props: Omit<Props, "balances" | "horizon" | "sendTransaction">) {
-  const closeAfterTimeout = () => {
-    // Close automatically a second after successful submission
-    setTimeout(() => props.onClose(), 1000)
-  }
   return (
-    <TransactionSender account={props.account} onSubmissionCompleted={closeAfterTimeout}>
+    <TransactionSender account={props.account} onSubmissionCompleted={props.onClose}>
       {({ horizon, sendTransaction }) => (
         <RemoveTrustlineDialog
           {...props}

--- a/src/Payment/components/PaymentDialog.tsx
+++ b/src/Payment/components/PaymentDialog.tsx
@@ -87,12 +87,8 @@ function ConnectedPaymentDialog(props: Pick<Props, "account" | "onClose">) {
   const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
   const { offers: openOrders } = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
 
-  const closeAfterTimeout = () => {
-    // Close automatically a second after successful submission
-    setTimeout(() => props.onClose(), 1000)
-  }
   return (
-    <TransactionSender account={props.account} onSubmissionCompleted={closeAfterTimeout}>
+    <TransactionSender account={props.account} onSubmissionCompleted={props.onClose}>
       {({ horizon, sendTransaction }) => (
         <PaymentDialog
           {...props}

--- a/src/Trading/components/TradingDialog.tsx
+++ b/src/Trading/components/TradingDialog.tsx
@@ -149,10 +149,7 @@ function TradingDialog(props: TradingDialogProps) {
 
 function TradingDialogContainer(props: Pick<TradingDialogProps, "account" | "onClose">) {
   const router = useRouter()
-  const navigateToAccount = () =>
-    setTimeout(() => {
-      router.history.push(routes.account(props.account.id))
-    }, 1000)
+  const navigateToAccount = () => router.history.push(routes.account(props.account.id))
 
   return (
     <TransactionSender account={props.account} onSubmissionCompleted={navigateToAccount}>

--- a/src/Transaction/components/TransactionSender.tsx
+++ b/src/Transaction/components/TransactionSender.tsx
@@ -79,6 +79,7 @@ interface RenderFunctionProps {
 
 interface Props {
   account: Account
+  completionCallbackDelay?: number
   forceClose?: boolean
   horizon: Server
   settings: SettingsContextType
@@ -175,7 +176,13 @@ class TransactionSender extends React.Component<Props, State> {
 
   submitTransaction = async (transaction: Transaction, formValues: { password: string | null }) => {
     let signedTx: Transaction
-    const { account, horizon, onSubmissionCompleted = () => undefined, onSubmissionFailure } = this.props
+    const {
+      account,
+      completionCallbackDelay = 1000,
+      horizon,
+      onSubmissionCompleted = () => undefined,
+      onSubmissionFailure
+    } = this.props
 
     try {
       signedTx = await signTransaction(transaction, this.props.account, formValues.password)
@@ -201,7 +208,10 @@ class TransactionSender extends React.Component<Props, State> {
       setTimeout(() => {
         this.clearSubmissionPromise()
       }, 1000)
-      onSubmissionCompleted(signedTx)
+
+      setTimeout(() => {
+        onSubmissionCompleted(signedTx)
+      }, completionCallbackDelay)
     } catch (error) {
       if (onSubmissionFailure) {
         onSubmissionFailure(error, transaction)


### PR DESCRIPTION
- [x] Add additional `completionCallbackDelay` prop to `<TransactionSender>` which controls the delay between registering the successful tx submission and triggering the `onSubmissionCompleted` callback. 
- [x] Remove custom timeouts for closing in components using the `<TransactionSender>`

Closes #274. 