### PR TITLE
Fix error when adding asset to testnet account

### DIFF
--- a/src/Generic/lib/stellar-ticker.ts
+++ b/src/Generic/lib/stellar-ticker.ts
@@ -15,7 +15,7 @@ export interface AssetRecord {
   type: string
 }
 
-const assetsCache = createPersistentCache<AssetRecord[]>("known-accounts", { expiresIn: 60 * 60_000 })
+const assetsCache = createPersistentCache<AssetRecord[]>("known-assets", { expiresIn: 60 * 60_000 })
 
 export async function fetchAllAssets(testnet: boolean): Promise<AssetRecord[]> {
   const cacheKey = testnet ? "testnet" : "mainnet"


### PR DESCRIPTION
Fixes a bug where a `Cannot read property 'toLowerCase' of undefined` error is thrown when trying to add new assets to a testnet account.
The underlying problem is that the assets cache is not properly set up as it's sharing the same namespace as the well-known accounts cache.

