### PR TITLE
Fix ambiguous error on request timeout

### DIFF
--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -33,6 +33,7 @@
     "stellar-address-request-failed-error": "Stellar address resolution of {{address}} failed.",
     "submission-failed-error": "Submitting transaction to {{endpoint}} failed with status {{status}}: {{message}}",
     "testnet-endpoint-not-available-error": "{{service}} does not provide a testnet endpoint.",
+    "timeout-error": "Request timed out",
     "unexpected-action-error": "Unexpected action: {{action}}",
     "unexpected-state-error": "Encountered unexpected state: {{state}}",
     "unexpected-response-type-error": "Unexpected response type: {{type}} / ${dataType}",

--- a/src/Generic/components/ErrorBoundaries.tsx
+++ b/src/Generic/components/ErrorBoundaries.tsx
@@ -3,7 +3,7 @@ import Typography from "@material-ui/core/Typography"
 import { fade, useTheme } from "@material-ui/core/styles"
 import ErrorIcon from "@material-ui/icons/Error"
 import React from "react"
-import { Translation } from "react-i18next"
+import { Translation, useTranslation } from "react-i18next"
 import { Box, HorizontalLayout, VerticalLayout } from "~Layout/components/Box"
 import { getErrorTranslation } from "../lib/errors"
 
@@ -56,6 +56,8 @@ interface InlineErrorBoundaryProps {
 
 export const InlineErrorBoundary = ErrorBoundary<InlineErrorBoundaryProps>(function InlineErrorBoundary(props) {
   const theme = useTheme()
+  const { t } = useTranslation()
+
   return (
     <HorizontalLayout
       alignItems="center"
@@ -69,7 +71,7 @@ export const InlineErrorBoundary = ErrorBoundary<InlineErrorBoundaryProps>(funct
       }}
     >
       <ErrorIcon />
-      <span style={{ marginLeft: 8 }}>{props.error.message}</span>
+      <span style={{ marginLeft: 8 }}>{getErrorTranslation(props.error, t)}</span>
     </HorizontalLayout>
   )
 })

--- a/src/Workers/net-worker/stellar-network.ts
+++ b/src/Workers/net-worker/stellar-network.ts
@@ -98,7 +98,8 @@ function getFetchQueue(horizonURL: string): PromiseQueue {
       concurrency: 4,
       interval: 1000,
       intervalCap: 4,
-      timeout: 10000
+      timeout: 10000,
+      throwOnTimeout: true
     })
     fetchQueuesByHorizon.set(horizonURL, fetchQueue)
   }


### PR DESCRIPTION
- [x] Set `throwOnTimeout` option to `true` for the fetch queue because otherwise the promise will resolve `undefined` after the timeout is reached. 
- [x] Make `InlineErrorBoundary` translate the error like the `NotificationsContainer` and `MainErrorBoundary` do
- [x] Add a translation for `TimeoutError`

Setting `throwOnTimeout` will make `p-queue` throw a `new TimeoutError()` on timeout without any message provided. So the translation will make sure that we have an error message is shown.

<img width="765" alt="Screenshot 2020-11-04 at 11 51 30" src="https://user-images.githubusercontent.com/6690623/98102704-32ba5f00-1e94-11eb-9c44-fe6caf91a369.png">
