### PR TITLE
Enforce standard fontsize on android

### DIFF
--- a/cordova/scripts/android/MainActivity.java
+++ b/cordova/scripts/android/MainActivity.java
@@ -24,6 +24,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.WindowManager;
+import android.webkit.WebView;
+import android.webkit.WebSettings;
 
 import org.apache.cordova.*;
 
@@ -56,5 +58,10 @@ public class MainActivity extends CordovaActivity
 
         // Set by <content src="index.html" /> in config.xml
         loadUrl(launchUrl);
+
+        // Force font size to be 100% (standard) instead of using user-defined font size
+        WebView webView = (WebView) appView.getEngine().getView();
+        WebSettings settings = webView.getSettings();
+        settings.setTextZoom(100);
     }
 }


### PR DESCRIPTION
This change will set the text zoom to `100%` (which is the default value) on app start thus making sure that UI elements are not displaced due to a high font size set by the user in system settings.

Closes #866. 