### PR TITLE
Fix 'Place order' button shown without selected action

### DIFF
--- a/src/Trading/components/TradingDialog.tsx
+++ b/src/Trading/components/TradingDialog.tsx
@@ -91,7 +91,7 @@ function TradingDialog(props: TradingDialogProps) {
           <TradingForm
             account={props.account}
             accountData={accountData}
-            dialogActionsRef={dialogActionsRef}
+            dialogActionsRef={primaryAction ? dialogActionsRef : null}
             initialPrimaryAsset={preselectedAsset}
             primaryAction={primaryAction || "buy"}
             sendTransaction={props.sendTransaction}

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -67,7 +67,7 @@ interface Props {
   account: Account
   accountData: AccountData
   className?: string
-  dialogActionsRef: RefStateObject
+  dialogActionsRef: RefStateObject | null
   initialPrimaryAsset?: Asset
   primaryAction: "buy" | "sell"
   sendTransaction: (transaction: Transaction) => void
@@ -389,7 +389,7 @@ function TradingForm(props: Props) {
             )}
           </Box>
         ) : null}
-        <Portal target={props.dialogActionsRef.element}>
+        <Portal target={props.dialogActionsRef?.element}>
           <DialogActionsBox desktopStyle={{ marginTop: 32 }}>
             <ActionButton icon={<GavelIcon />} onClick={form.handleSubmit(submitForm)} type="primary">
               {t("trading.action.submit")}


### PR DESCRIPTION
Fixes a bug where the 'Place order' button is already visible when choosing the primary action (i.e. buying or selling an asset). 