### PR TITLE
Show 'Server Error: ...' message for server errors

### DIFF
--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -57,6 +57,9 @@
         "op_self_not_allowed": "Account cannot trust assets issued by itself.",
         "op_underfunded": "Not enough funds to perform this operation."
       },
+      "prefix": {
+        "server-error": "Server Error"
+      },
       "tx-result-code": {
         "insufficient_fee": "Network demands higher fees than set in the transaction.",
         "internal_error": "An unknown error occured on the Stellar server.",

--- a/src/Generic/lib/errors.ts
+++ b/src/Generic/lib/errors.ts
@@ -102,8 +102,15 @@ export function getErrorTranslation(error: Error, t: TFunction): string {
   const key = `generic.error.${toKebabCase(error.name)}`
   const params = CustomError.isCustomError(error) ? pick(error, error.__extraProps || []) : undefined
 
+  let prefix = ""
+  if (params && params["status"] && String(params["status"]).startsWith("5")) {
+    // explicity state it's a server error
+    prefix = t("generic.error.submission-error.prefix.server-error")
+    prefix += ": "
+  }
+
   const fallback = error.message
-  return t([key, fallback], params)
+  return prefix + t([key, fallback], params)
 }
 
 export function renderFormFieldError(error: any, t: TFunction) {


### PR DESCRIPTION
Adds a "Server Error: " prefix to translated errors if they are of type `CustomError` and their params contain a `status` that starts with `5`.

Closes #487.