### PR TITLE
Fix small issue with Italian translations

### DIFF
--- a/i18n/locales/it/account-settings.json
+++ b/i18n/locales/it/account-settings.json
@@ -113,8 +113,8 @@
       "new-signer": {
         "label": "Chiave Pubblica o indirizzo Stellar",
         "placeholder": {
-          "long": "GABC… o indirizzo",
-          "short": "GABCDEFGHIJK… or alice*example.org"
+          "long": "GABCDEFGHIJK… o alice*example.org",
+          "short": "GABC… o indirizzo"
         }
       },
       "validation": {


### PR DESCRIPTION
Swaps the long and short placeholder of `new-signer` in `account-settings.json`.

Follow-up of #1157. 