### PR TITLE
Fix wrong connection state message handling

### DIFF
--- a/src/Workers/lib/connection.ts
+++ b/src/Workers/lib/connection.ts
@@ -28,7 +28,7 @@ export function handleConnectionState(handlers: ConnectionStateHandlers) {
   const handleMessage = (event: MessageEvent) => {
     if (event.data && event.data === "app:pause") {
       onOffline()
-    } else if (event.data && event.data === "app:pause") {
+    } else if (event.data && event.data === "app:resume") {
       onOnline()
     }
   }


### PR DESCRIPTION
Fixes wrong event name used in `if` statement of connection state handler.

Closes #1180. 