### PR TITLE
Fix loading indicator issue when adding new asset

### DIFF
--- a/src/Assets/components/AddAssetDialog.tsx
+++ b/src/Assets/components/AddAssetDialog.tsx
@@ -142,33 +142,35 @@ function createSearchResultRow(
 
     return (
       <div style={props.style}>
-        {item.type === "issuer" ? (
-          <ListItem key={item.issuer} className={classes.issuerItem}>
-            <ListItemText
-              primary={<AccountName publicKey={item.issuer} testnet={account.testnet} />}
-              secondary={
-                assetsByIssuer[item.issuer].length === 1
-                  ? t("account.add-asset.item.issuer.secondary.one-asset")
-                  : t("account.add-asset.item.issuer.secondary.more-than-one-asset", {
-                      amount: assetsByIssuer[item.issuer].length
-                    })
-              }
-              secondaryTypographyProps={{
-                style: { overflow: "hidden", textOverflow: "ellipsis" }
-              }}
+        <React.Suspense fallback={<ViewLoading />}>
+          {item.type === "issuer" ? (
+            <ListItem key={item.issuer} className={classes.issuerItem}>
+              <ListItemText
+                primary={<AccountName publicKey={item.issuer} testnet={account.testnet} />}
+                secondary={
+                  assetsByIssuer[item.issuer].length === 1
+                    ? t("account.add-asset.item.issuer.secondary.one-asset")
+                    : t("account.add-asset.item.issuer.secondary.more-than-one-asset", {
+                        amount: assetsByIssuer[item.issuer].length
+                      })
+                }
+                secondaryTypographyProps={{
+                  style: { overflow: "hidden", textOverflow: "ellipsis" }
+                }}
+              />
+            </ListItem>
+          ) : null}
+          {item.type === "asset" ? (
+            <BalanceDetailsListItem
+              balance={assetToBalance(assetRecordToAsset(item.record))}
+              className={classes.assetItem}
+              hideBalance
+              onClick={() => openAssetDetails(assetRecordToAsset(item.record))}
+              style={{ paddingLeft: 32 }}
+              testnet={account.testnet}
             />
-          </ListItem>
-        ) : null}
-        {item.type === "asset" ? (
-          <BalanceDetailsListItem
-            balance={assetToBalance(assetRecordToAsset(item.record))}
-            className={classes.assetItem}
-            hideBalance
-            onClick={() => openAssetDetails(assetRecordToAsset(item.record))}
-            style={{ paddingLeft: 32 }}
-            testnet={account.testnet}
-          />
-        ) : null}
+          ) : null}
+        </React.Suspense>
       </div>
     )
   }


### PR DESCRIPTION
Fixes the issue with the loading indicator by wrapping the item returned in `SearchResultRow` with a `React.Suspense`.

@andywer seems like your suggested fix actually does work but I did not manually reload the page (hot reloading obviously was not enough in this case).

Closes #1175. 