### PR TITLE
Improve items of language selector

### DIFF
--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -1,1 +1,6 @@
 export const availableLanguages = ["en", "it"] as const
+
+export const languageAbbreviationMap: { [type: string]: string } = {
+  ["en"]: "English",
+  ["it"]: "Italiano"
+}

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -1,6 +1,6 @@
-export const availableLanguages = ["en", "it"] as const
-
-export const languageAbbreviationMap: { [type: string]: string } = {
+export const languageNames: { [type: string]: string } = {
   ["en"]: "English",
   ["it"]: "Italiano"
 }
+
+export const availableLanguages = Object.keys(languageNames)

--- a/src/AppSettings/components/AppSettings.tsx
+++ b/src/AppSettings/components/AppSettings.tsx
@@ -46,8 +46,8 @@ function AppSettings() {
   ])
 
   const switchLanguage = React.useCallback(
-    (lang: string | undefined) => {
-      i18n.changeLanguage(getEffectiveLanguage(lang || navigator.language.substr(0, 2), "en"))
+    (lang: string) => {
+      i18n.changeLanguage(getEffectiveLanguage(lang, "en"))
       settings.setLanguage(lang)
     },
     [i18n, settings]
@@ -57,7 +57,7 @@ function AppSettings() {
     <Carousel current={showSettingsOverview ? 0 : 1}>
       <List style={{ padding: isSmallScreen ? 0 : "24px 16px" }}>
         {availableLanguages.length > 1 ? (
-          <LanguageSetting onSelect={switchLanguage} value={getEffectiveLanguage(settings.language, undefined)} />
+          <LanguageSetting onSelect={switchLanguage} value={getEffectiveLanguage(settings.language, "en")} />
         ) : null}
         {settings.biometricAvailability.available ? (
           <BiometricLockSetting

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -12,7 +12,7 @@ import LanguageIcon from "@material-ui/icons/Language"
 import MessageIcon from "@material-ui/icons/Message"
 import TestnetIcon from "@material-ui/icons/MoneyOff"
 import TrustIcon from "@material-ui/icons/VerifiedUser"
-import { availableLanguages } from "../../../i18n/index"
+import { availableLanguages, languageAbbreviationMap } from "../../../i18n/index"
 import AppSettingsItem from "./AppSettingsItem"
 
 interface SettingsToggleProps {
@@ -104,7 +104,7 @@ export const HideMemoSetting = React.memo(function HideMemoSetting(props: Settin
 })
 
 interface LanguageSettingProps {
-  onSelect: (language: string | undefined) => void
+  onSelect: (language: string) => void
   value: string | null | undefined
 }
 
@@ -113,9 +113,11 @@ export const LanguageSetting = React.memo(function LanguageSetting(props: Langua
   const classes = useSettingsStyles(props)
   const { t } = useTranslation()
 
+  const browserLanguage = navigator.language.substr(0, 2)
+
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<{ value: unknown }>) => {
-      onSelect(event.target.value !== "auto" ? (event.target.value as string) : undefined)
+      onSelect(event.target.value as string)
     },
     [onSelect]
   )
@@ -123,11 +125,10 @@ export const LanguageSetting = React.memo(function LanguageSetting(props: Langua
   return (
     <AppSettingsItem
       actions={
-        <Select onChange={handleChange} value={props.value || "auto"}>
-          <MenuItem value="auto">{t("app-settings.settings.language.auto-detect.label")}</MenuItem>
+        <Select onChange={handleChange} value={props.value}>
           {[...availableLanguages].sort().map(lang => (
             <MenuItem key={lang} value={lang}>
-              {lang}
+              {languageAbbreviationMap[lang]} {lang === browserLanguage && "(Auto)"}
             </MenuItem>
           ))}
         </Select>

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -125,7 +125,12 @@ export const LanguageSetting = React.memo(function LanguageSetting(props: Langua
   return (
     <AppSettingsItem
       actions={
-        <Select onChange={handleChange} value={props.value} style={{ marginLeft: 8 }}>
+        <Select
+          onChange={handleChange}
+          style={{ marginLeft: 8 }}
+          value={props.value}
+          SelectDisplayProps={{ style: { paddingLeft: 8 } }}
+        >
           {[...availableLanguages].sort().map(lang => (
             <MenuItem key={lang} value={lang}>
               {languageNames[lang]} {lang === browserLanguage && "(Auto)"}

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -12,7 +12,7 @@ import LanguageIcon from "@material-ui/icons/Language"
 import MessageIcon from "@material-ui/icons/Message"
 import TestnetIcon from "@material-ui/icons/MoneyOff"
 import TrustIcon from "@material-ui/icons/VerifiedUser"
-import { availableLanguages, languageAbbreviationMap } from "../../../i18n/index"
+import { availableLanguages, languageNames } from "../../../i18n/index"
 import AppSettingsItem from "./AppSettingsItem"
 
 interface SettingsToggleProps {
@@ -128,7 +128,7 @@ export const LanguageSetting = React.memo(function LanguageSetting(props: Langua
         <Select onChange={handleChange} value={props.value}>
           {[...availableLanguages].sort().map(lang => (
             <MenuItem key={lang} value={lang}>
-              {languageAbbreviationMap[lang]} {lang === browserLanguage && "(Auto)"}
+              {languageNames[lang]} {lang === browserLanguage && "(Auto)"}
             </MenuItem>
           ))}
         </Select>

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -125,7 +125,7 @@ export const LanguageSetting = React.memo(function LanguageSetting(props: Langua
   return (
     <AppSettingsItem
       actions={
-        <Select onChange={handleChange} value={props.value}>
+        <Select onChange={handleChange} value={props.value} style={{ marginLeft: 8 }}>
           {[...availableLanguages].sort().map(lang => (
             <MenuItem key={lang} value={lang}>
               {languageNames[lang]} {lang === browserLanguage && "(Auto)"}


### PR DESCRIPTION
Changes the language selector so that it shows the full language name instead of its abbreviation. 
The language item that is equal to the browser language will show "(Auto)" at the end of its label.


Closes #1176. 