### PR TITLE
Prevent withdrawal with not enough tokens

### DIFF
--- a/i18n/locales/en/transfer-service.json
+++ b/i18n/locales/en/transfer-service.json
@@ -219,7 +219,7 @@
         "label": "Amount",
         "max-amount": "Max. {{amount}} {{assetCode}}",
         "min-amount": "Min. {{amount}} {{assetCode}}",
-        "not-enough-funds": "You do not own the required amount of tokens."
+        "not-enough-funds": "You do not have enough funds."
       },
       "fee": {
         "helper-text": "As charged by {{domain}}",

--- a/i18n/locales/en/transfer-service.json
+++ b/i18n/locales/en/transfer-service.json
@@ -218,7 +218,8 @@
       "min-max-amount": {
         "label": "Amount",
         "max-amount": "Max. {{amount}} {{assetCode}}",
-        "min-amount": "Min. {{amount}} {{assetCode}}"
+        "min-amount": "Min. {{amount}} {{assetCode}}",
+        "not-enough-funds": "You do not own the required amount of tokens."
       },
       "fee": {
         "helper-text": "As charged by {{domain}}",


### PR DESCRIPTION
Shows an error message and disables the "Proceed" button if the account does not have the minimum amount of tokens.

<img width="860" alt="Screenshot 2020-12-09 at 16 08 57" src="https://user-images.githubusercontent.com/6690623/101650979-d8855e80-3a3c-11eb-80e4-5670af1a62a2.png">


Closes #1186. 