### PR TITLE
Fix open orders badge in asset management

### DIFF
--- a/src/Assets/components/BalanceDetailsDialog.tsx
+++ b/src/Assets/components/BalanceDetailsDialog.tsx
@@ -38,6 +38,7 @@ interface TrustedAssetsProps {
   hpadding: string | number
   onOpenAssetDetails: (asset: Asset) => void
   openOffers: ServerApi.OfferRecord[]
+  olderOffersAvailable?: boolean
 }
 
 const TrustedAssets = React.memo(function TrustedAssets(props: TrustedAssetsProps) {
@@ -50,10 +51,11 @@ const TrustedAssets = React.memo(function TrustedAssets(props: TrustedAssetsProp
             (offer.buying.asset_code === asset.code && offer.buying.asset_issuer === asset.issuer) ||
             (offer.selling.asset_code === asset.code && offer.selling.asset_issuer === asset.issuer)
         )
+        const badgeCount = props.olderOffersAvailable && openOffers.length >= 10 ? "10+" : openOffers.length
         return (
           <BalanceDetailsListItem
             key={stringifyAsset(asset)}
-            badgeCount={openOffers.length}
+            badgeCount={badgeCount}
             balance={balance!}
             onClick={() => props.onOpenAssetDetails(asset)}
             style={{
@@ -129,7 +131,10 @@ interface BalanceDetailsProps {
 
 function BalanceDetailsDialog(props: BalanceDetailsProps) {
   const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
-  const { offers: openOrders } = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
+  const { offers: openOrders, olderOffersAvailable } = useLiveAccountOffers(
+    props.account.publicKey,
+    props.account.testnet
+  )
   const isSmallScreen = useIsMobile()
   const router = useRouter()
   const { t } = useTranslation()
@@ -186,6 +191,7 @@ function BalanceDetailsDialog(props: BalanceDetailsProps) {
           hpadding={itemHPadding}
           onOpenAssetDetails={openAssetDetails}
           openOffers={openOrders}
+          olderOffersAvailable={olderOffersAvailable}
         />
       </List>
       <Divider style={{ margin: "16px 0" }} />

--- a/src/Assets/components/BalanceDetailsListItem.tsx
+++ b/src/Assets/components/BalanceDetailsListItem.tsx
@@ -83,7 +83,7 @@ const useBalanceItemStyles = makeStyles({
 })
 
 interface BalanceListItemProps {
-  badgeCount?: number
+  badgeCount?: number | string
   balance: Horizon.BalanceLine
   className?: string
   hideBalance?: boolean


### PR DESCRIPTION
Adds the proposed quick-fix to show "10+" in the badge of assets which have more than 10 open offers.

It might happen that in the edge case that the user has 10 open orders with a specific assets and there are more orders available but not yet fetched that "10+" will be shown although the user has exactly 10 orders with that asset.
This is due to the way `oldersOffersAvailable` is set (i.e. `olderOffersAvailable: fetchedOffers.length === limit`) and the fact that we don't know if the offers that are not yet fetched contain offers with that specific asset.
But fixing this edge case would be not worth the effort I'd say.

Closes #1174.