### PR TITLE
Fix app crashing with empty account name

### DIFF
--- a/src/Account/components/AccountHeaderCard.tsx
+++ b/src/Account/components/AccountHeaderCard.tsx
@@ -67,6 +67,10 @@ function AccountHeaderCard(props: Props) {
       ? ({ account: props.account as Account } as const)
       : ({ accountCreation: props.account as AccountCreation } as const)
 
+  // It should never happen that "Unnamed account" is used
+  // It is only added for the rare case that the user has renamed their account to "" which is prevented by now
+  const name = meta.account?.name || meta.accountCreation?.name || "Unnamed Account"
+
   const showingSettings = matchesRoute(router.location.pathname, routes.accountSettings("*"))
 
   const actions = React.useMemo(
@@ -150,7 +154,7 @@ function AccountHeaderCard(props: Props) {
             editable={props.editableAccountName}
             error={props.error}
             permanentlyEditing={props.editableAccountName && !meta.account}
-            name={meta.account?.name || meta.accountCreation!.name}
+            name={name}
             onNavigateBack={props.onClose}
             onRename={props.onRename}
           />

--- a/src/Account/components/AccountHeaderCard.tsx
+++ b/src/Account/components/AccountHeaderCard.tsx
@@ -44,6 +44,7 @@ interface Props {
   account: Account | AccountCreation
   children?: React.ReactNode
   editableAccountName?: boolean
+  error?: string
   onAccountSettings?: () => void
   onAccountTransactions?: () => void
   onClose: () => void
@@ -147,6 +148,7 @@ function AccountHeaderCard(props: Props) {
             actions={actions}
             badges={meta.account || props.editableAccountName ? badges : null}
             editable={props.editableAccountName}
+            error={props.error}
             permanentlyEditing={props.editableAccountName && !meta.account}
             name={meta.account?.name || meta.accountCreation!.name}
             onNavigateBack={props.onClose}

--- a/src/Account/components/AccountTitle.tsx
+++ b/src/Account/components/AccountTitle.tsx
@@ -226,32 +226,32 @@ function AccountTitle(props: AccountTitleProps) {
     [onRename, props.permanentlyEditing]
   )
 
-  const handleKeyDown = React.useCallback(
-    (event: React.KeyboardEvent) => {
-      if (event.key === "Enter") {
-        onRename(name)
-        setMode("readonly")
-        clearTextSelection()
-      } else if (event.key === "Escape") {
-        onRename(props.name)
-        setMode("readonly")
-        clearTextSelection()
-      }
-    },
-    [props.name, onRename, name]
-  )
-
-  const applyRenaming = React.useCallback(() => {
-    onRename(name)
-    setMode("readonly")
-    clearTextSelection()
-  }, [onRename, name])
-
   const cancelRenaming = React.useCallback(() => {
     setName(props.name)
     setMode("readonly")
     clearTextSelection()
   }, [props.name])
+
+  const applyRenaming = React.useCallback(() => {
+    if (!name) {
+      cancelRenaming()
+    } else {
+      onRename(name)
+      setMode("readonly")
+      clearTextSelection()
+    }
+  }, [cancelRenaming, onRename, name])
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Enter") {
+        applyRenaming()
+      } else if (event.key === "Escape") {
+        cancelRenaming()
+      }
+    },
+    [applyRenaming, cancelRenaming]
+  )
 
   const focusInput = React.useCallback(() => {
     // Doesn't work on iOS, even leads to weird broken behavior

--- a/src/Account/components/AccountTitle.tsx
+++ b/src/Account/components/AccountTitle.tsx
@@ -125,6 +125,7 @@ const useTitleTextfieldStyles = makeStyles({
 
 interface TitleTextFieldProps {
   actions?: React.ReactNode
+  error?: string
   inputRef?: React.Ref<HTMLInputElement>
   onChange: TextFieldProps["onChange"]
   onClick?: () => void
@@ -142,6 +143,7 @@ function TitleTextField(props: TitleTextFieldProps) {
   const length = props.value.length || props.placeholder?.length || 0
   return (
     <TextField
+      error={Boolean(props.error)}
       inputProps={{
         className: classes.input,
         onClick: props.onClick,
@@ -186,6 +188,7 @@ interface AccountTitleProps {
   actions: React.ReactNode
   badges: React.ReactNode
   editable?: boolean
+  error?: string
   name: string
   onNavigateBack: () => void
   onRename: (newName: string) => void
@@ -315,6 +318,7 @@ function AccountTitle(props: AccountTitleProps) {
           actions={
             props.permanentlyEditing ? permanentEditActions : mode === "readonly" ? readonlyActions : editActions
           }
+          error={props.error}
           inputRef={inputRef}
           onChange={handleNameEditing}
           onClick={props.editable ? switchToEditMode : undefined}

--- a/src/Account/components/AccountView.tsx
+++ b/src/Account/components/AccountView.tsx
@@ -241,6 +241,7 @@ const AccountPageContent = React.memo(function AccountPageContent(props: Account
         editableAccountName={
           showAccountSettings || (showAccountCreation && !showAccountCreationOptions && !accountToBackup)
         }
+        error={accountCreationErrors.name}
         onAccountSettings={navigateTo.accountSettings}
         onAccountTransactions={navigateTo.transactions}
         onClose={handleBackNavigation}
@@ -270,6 +271,7 @@ const AccountPageContent = React.memo(function AccountPageContent(props: Account
     ),
     [
       accountCreation,
+      accountCreationErrors.name,
       accountToBackup,
       creationTitle,
       handleBackNavigation,

--- a/src/AccountCreation/hooks/useAccountCreation.ts
+++ b/src/AccountCreation/hooks/useAccountCreation.ts
@@ -36,6 +36,10 @@ function getNewAccountName(t: TFunction, accounts: Account[], testnet: boolean) 
 function validateAccountCreation(t: TFunction, accounts: Account[], accountCreation: AccountCreation) {
   const errors: AccountCreationErrors = {}
 
+  if (!accountCreation.name) {
+    errors.name = t("create-account.validation.no-account-name")
+  }
+
   if (accountCreation.requiresPassword && !accountCreation.password) {
     errors.password = t("create-account.validation.no-password")
   } else if (accountCreation.requiresPassword && accountCreation.repeatedPassword !== accountCreation.password) {

--- a/src/AccountCreation/types/types.ts
+++ b/src/AccountCreation/types/types.ts
@@ -10,6 +10,7 @@ export interface AccountCreation {
 }
 
 export interface AccountCreationErrors {
+  name?: string
   password?: string
   secretKey?: string
 }


### PR DESCRIPTION
Fixes a bug where the user is able to enter an empty account name which causes the app to crash because it is always assumed that an account has a name.

- [x] Restore the old account name when the user is trying to change an existing account name to ""
- [x] Show an error when creating an account without a name (only changes the color of the account name textfield, no error message is shown because of space issues; adding a helper text below the textfield would cause a scrollbar to appear)
- [x] Show "Unnamed Account" if the account has no name
This only exists to help users who already renamed their account to "" get access to their accounts and should never be shown in the future since renaming to "" is now prevented.

Closes #1192.