### PR TITLE
Fix app crashing due to unavailable transfer servers

### DIFF
--- a/src/Generic/hooks/transfer-server.ts
+++ b/src/Generic/hooks/transfer-server.ts
@@ -58,14 +58,15 @@ export function useTransferInfos(
     domain => {
       return (transferInfosCache.get(domain) ||
         transferInfosCache.suspend(domain, async () => {
-          try {
-            const transferServer = await initTransferServer(domain, testnet)
-            if (!transferServer) return []
+          const transferServer = await initTransferServer(domain, testnet)
+          if (!transferServer) return []
 
+          try {
             const transferInfo = await fetchTransferInfos(transferServer)
             return (transferInfo ? [transferInfo] : []) as [TransferServerInfo] | []
           } catch (error) {
-            // catch network error if no transfer server is available for domain
+            // tslint:disable-next-line no-console
+            console.error(`Failed to fetch transfer infos for transfer server ${transferServer.domain}:`, error)
             return []
           }
         }))[0]

--- a/src/Generic/hooks/transfer-server.ts
+++ b/src/Generic/hooks/transfer-server.ts
@@ -58,11 +58,16 @@ export function useTransferInfos(
     domain => {
       return (transferInfosCache.get(domain) ||
         transferInfosCache.suspend(domain, async () => {
-          const transferServer = await initTransferServer(domain, testnet)
-          if (!transferServer) return []
+          try {
+            const transferServer = await initTransferServer(domain, testnet)
+            if (!transferServer) return []
 
-          const transferInfo = await fetchTransferInfos(transferServer)
-          return (transferInfo ? [transferInfo] : []) as [TransferServerInfo] | []
+            const transferInfo = await fetchTransferInfos(transferServer)
+            return (transferInfo ? [transferInfo] : []) as [TransferServerInfo] | []
+          } catch (error) {
+            // catch network error if no transfer server is available for domain
+            return []
+          }
         }))[0]
     },
     { ignoreSingleErrors: true }

--- a/src/Generic/hooks/transfer-server.ts
+++ b/src/Generic/hooks/transfer-server.ts
@@ -58,15 +58,15 @@ export function useTransferInfos(
     domain => {
       return (transferInfosCache.get(domain) ||
         transferInfosCache.suspend(domain, async () => {
-          const transferServer = await initTransferServer(domain, testnet)
-          if (!transferServer) return []
-
           try {
+            const transferServer = await initTransferServer(domain, testnet)
+            if (!transferServer) return []
+
             const transferInfo = await fetchTransferInfos(transferServer)
             return (transferInfo ? [transferInfo] : []) as [TransferServerInfo] | []
           } catch (error) {
             // tslint:disable-next-line no-console
-            console.error(`Failed to fetch transfer infos for transfer server ${transferServer.domain}:`, error)
+            console.error(`Failed to fetch transfer infos for transfer server ${domain}:`, error)
             return []
           }
         }))[0]


### PR DESCRIPTION
Fixes a bug where the application crashes due to network errors that occur when trying to deposit/withdraw with an account that trusts assets that do not have a transfer server.

<img width="548" alt="Screenshot 2021-02-01 at 11 56 30" src="https://user-images.githubusercontent.com/6690623/106449866-ba5c3d80-6484-11eb-83b8-e634023e6ec2.png">

Catches the "no transfer server available" errors and returns an empty array. 
