### PR TITLE
Fix app crashing when searching for XLM in Add-Asset dialog

### DIFF
--- a/src/Assets/components/AddAssetDialog.tsx
+++ b/src/Assets/components/AddAssetDialog.tsx
@@ -146,7 +146,13 @@ function createSearchResultRow(
           {item.type === "issuer" ? (
             <ListItem key={item.issuer} className={classes.issuerItem}>
               <ListItemText
-                primary={<AccountName publicKey={item.issuer} testnet={account.testnet} />}
+                primary={
+                  item.issuer === "native" ? (
+                    "stellar.org"
+                  ) : (
+                    <AccountName publicKey={item.issuer} testnet={account.testnet} />
+                  )
+                }
                 secondary={
                   assetsByIssuer[item.issuer].length === 1
                     ? t("account.add-asset.item.issuer.secondary.one-asset")


### PR DESCRIPTION
Fixes a bug where the application crashes when entering "XLM" in the search bar of the add asset dialog.
If the item to be displayed is the native asset then `item.issuer` is "native" instead of a public key thus the `<AccountName>` component will try to fetch "native" which is invalid.