### PR TITLE
Add selector for memo type and fix stellar-expert fetch

### DIFF
--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -1,4 +1,8 @@
 {
+  "asset-selector": {
+    "placeholder": "Select an asset",
+    "select": "Select"
+  },
   "dialog-actions": {
     "close": {
       "label": "Close"

--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -78,6 +78,10 @@
       "cancel": "Cancel"
     }
   },
+  "memo-selector": {
+    "placeholder": "Select a memo",
+    "select": "Select"
+  },
   "submission-progress": {
     "pending": "Submitting to network ...",
     "success": {

--- a/i18n/locales/en/payment.json
+++ b/i18n/locales/en/payment.json
@@ -5,8 +5,7 @@
   "memo-metadata": {
     "label": {
       "default": "Memo",
-      "id": "Memo (ID)",
-      "text": "Memo (Text)"
+      "required": "Memo (Required)"
     },
     "placeholder": {
       "optional": "Description (optional)",

--- a/src/Assets/components/AddAssetDialog.tsx
+++ b/src/Assets/components/AddAssetDialog.tsx
@@ -242,7 +242,7 @@ const AddAssetDialog = React.memo(function AddAssetDialog(props: AddAssetDialogP
   const allAssets = useTickerAssets(props.account.testnet)
   const router = useRouter()
   const { t } = useTranslation()
-  const wellKnownAccounts = useWellKnownAccounts(props.account.testnet)
+  const wellKnownAccounts = useWellKnownAccounts()
   const [customTrustlineDialogOpen, setCustomTrustlineDialogOpen] = React.useState(false)
   const [searchFieldValue, setSearchFieldValue] = React.useState("")
   const [txCreationPending, setTxCreationPending] = React.useState(false)
@@ -283,15 +283,15 @@ const AddAssetDialog = React.memo(function AddAssetDialog(props: AddAssetDialogP
   }
 
   const wellknownAccountMatches = React.useCallback(
-    (accountID: string, search: string) => {
+    async (accountID: string, search: string) => {
       const lowerCasedSearch = search.toLowerCase()
-      const record = wellKnownAccounts.lookup(accountID)
+      const record = await wellKnownAccounts.lookup(accountID)
 
       if (!record) {
         return false
       }
       return (
-        record.domain.toLowerCase().includes(lowerCasedSearch) || record.name.toLowerCase().includes(lowerCasedSearch)
+        record.domain?.toLowerCase().includes(lowerCasedSearch) || record.name.toLowerCase().includes(lowerCasedSearch)
       )
     },
     [wellKnownAccounts]

--- a/src/Generic/components/AssetSelector.tsx
+++ b/src/Generic/components/AssetSelector.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import { Asset, Horizon } from "stellar-sdk"
 import ListItemIcon from "@material-ui/core/ListItemIcon"
 import ListItemText from "@material-ui/core/ListItemText"
@@ -90,6 +91,7 @@ interface AssetSelectorProps {
 function AssetSelector(props: AssetSelectorProps) {
   const { onChange } = props
   const classes = useAssetSelectorStyles()
+  const { t } = useTranslation()
 
   const assets = React.useMemo(
     () => [
@@ -129,7 +131,7 @@ function AssetSelector(props: AssetSelectorProps) {
       margin={props.margin}
       onChange={handleChange as any}
       name={props.name}
-      placeholder="Select an asset"
+      placeholder={t("generic.asset-selector.placeholder")}
       select
       style={{ flexShrink: 0, ...props.style }}
       value={props.value ? props.value.getCode() : ""}
@@ -151,12 +153,12 @@ function AssetSelector(props: AssetSelectorProps) {
         },
         displayEmpty: !props.value,
         disableUnderline: props.disableUnderline,
-        renderValue: () => (props.value ? props.value.getCode() : "Select")
+        renderValue: () => (props.value ? props.value.getCode() : t("generic.asset-selector.select"))
       }}
     >
       {props.value ? null : (
         <MenuItem disabled value="">
-          Select an asset
+          {t("generic.asset-selector.placeholder")}
         </MenuItem>
       )}
       {props.showXLM ? (

--- a/src/Generic/components/Fetchers.tsx
+++ b/src/Generic/components/Fetchers.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useAccountHomeDomainSafe } from "../hooks/stellar"
-import { useWellKnownAccounts } from "../hooks/stellar-ecosystem"
+import { AccountRecord, useWellKnownAccounts } from "../hooks/stellar-ecosystem"
 import { Address } from "./PublicKey"
 
 interface AccountNameProps {
@@ -9,9 +9,13 @@ interface AccountNameProps {
 }
 
 export const AccountName = React.memo(function AccountName(props: AccountNameProps) {
-  const wellknownAccounts = useWellKnownAccounts(props.testnet)
+  const wellknownAccounts = useWellKnownAccounts()
   const homeDomain = useAccountHomeDomainSafe(props.publicKey, props.testnet, true)
-  const record = wellknownAccounts.lookup(props.publicKey)
+  const [record, setRecord] = React.useState<AccountRecord | undefined>(undefined)
+
+  React.useEffect(() => {
+    wellknownAccounts.lookup(props.publicKey).then(setRecord)
+  }, [props.publicKey, wellknownAccounts])
 
   if (record && record.domain) {
     return <span style={{ userSelect: "text" }}>{record.domain}</span>

--- a/src/Generic/components/FormFields.tsx
+++ b/src/Generic/components/FormFields.tsx
@@ -87,6 +87,41 @@ export const PriceInput = React.memo(function PriceInput(props: PriceInputProps)
   )
 })
 
+type MemoInputProps = TextFieldProps & {
+  memoSelector: React.ReactNode
+  memoStyle?: React.CSSProperties
+  readOnly?: boolean
+}
+
+export const MemoInput = React.memo(function MemoInput(props: MemoInputProps) {
+  const { memoSelector, memoStyle, readOnly, ...textfieldProps } = props
+  const InputField = readOnly ? ReadOnlyTextfield : TextField
+  return (
+    <InputField
+      {...textfieldProps}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment
+            disableTypography
+            position="start"
+            style={{
+              pointerEvents: typeof memoSelector === "string" ? "none" : undefined,
+              ...memoStyle
+            }}
+          >
+            {memoSelector}
+          </InputAdornment>
+        ),
+        ...textfieldProps.InputProps
+      }}
+      style={{
+        pointerEvents: props.readOnly ? "none" : undefined,
+        ...textfieldProps.style
+      }}
+    />
+  )
+})
+
 const useReadOnlyTextfieldStyles = makeStyles({
   root: {
     "&:focus": {

--- a/src/Generic/components/MemoSelector.tsx
+++ b/src/Generic/components/MemoSelector.tsx
@@ -1,0 +1,138 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { MemoHash, MemoID, MemoNone, MemoReturn, MemoText, MemoType } from "stellar-sdk"
+import ListItemText from "@material-ui/core/ListItemText"
+import MenuItem from "@material-ui/core/MenuItem"
+import { makeStyles } from "@material-ui/core/styles"
+import TextField, { TextFieldProps } from "@material-ui/core/TextField"
+
+interface MemoItemProps {
+  disabled?: boolean
+  key: string
+  memoType: MemoType
+  value: string
+}
+
+const MemoItem = React.memo(
+  React.forwardRef(function MemoItem(props: MemoItemProps, ref: React.Ref<HTMLLIElement>) {
+    const { memoType, ...reducedProps } = props
+
+    return (
+      <MenuItem {...reducedProps} key={props.key} ref={ref} value={props.value}>
+        <ListItemText>{memoType}</ListItemText>
+      </MenuItem>
+    )
+  })
+)
+
+const useMemoSelectorStyles = makeStyles({
+  helperText: {
+    maxWidth: 100,
+    whiteSpace: "nowrap"
+  },
+  input: {
+    minWidth: 72
+  },
+  select: {
+    fontSize: 18,
+    fontWeight: 400
+  },
+  unselected: {
+    opacity: 0.5
+  }
+})
+
+interface MemoSelectorProps {
+  autoFocus?: TextFieldProps["autoFocus"]
+  children?: React.ReactNode
+  className?: string
+  disabledMemos?: MemoType[]
+  disableUnderline?: boolean
+  helperText?: TextFieldProps["helperText"]
+  inputError?: string
+  label?: TextFieldProps["label"]
+  margin?: TextFieldProps["margin"]
+  minWidth?: number | string
+  name?: string
+  onChange?: (memoType: MemoType) => void
+  style?: React.CSSProperties
+  value?: MemoType
+}
+
+function MemoSelector(props: MemoSelectorProps) {
+  const { onChange } = props
+  const classes = useMemoSelectorStyles()
+
+  const { t } = useTranslation()
+
+  const memoTypes = React.useMemo<MemoType[]>(() => [MemoNone, MemoText, MemoID, MemoHash, MemoReturn], [])
+
+  const handleChange = React.useCallback(
+    (event: React.ChangeEvent<{ name?: any; value: any }>, child: React.ComponentElement<MemoItemProps, any>) => {
+      const matchingMemo = memoTypes.find(memoType => memoType === child.props.memoType)
+
+      if (matchingMemo) {
+        if (onChange) {
+          onChange(matchingMemo)
+        }
+      } else {
+        // tslint:disable-next-line no-console
+        console.error(`Invariant violation: Trustline ${child.props.memoType} selected, but no matching memo found.`)
+      }
+    },
+    [memoTypes, onChange]
+  )
+
+  return (
+    <TextField
+      autoFocus={props.autoFocus}
+      className={props.className}
+      error={Boolean(props.inputError)}
+      helperText={props.helperText}
+      label={props.inputError ? props.inputError : props.label}
+      margin={props.margin}
+      onChange={handleChange as any}
+      name={props.name}
+      placeholder={t("generic.memo-selector.select")}
+      select
+      style={{ flexShrink: 0, ...props.style }}
+      value={props.value || ""}
+      FormHelperTextProps={{
+        className: classes.helperText
+      }}
+      InputProps={{
+        classes: {
+          root: classes.input
+        },
+        style: {
+          minWidth: props.minWidth
+        }
+      }}
+      SelectProps={{
+        classes: {
+          root: props.value ? undefined : classes.unselected,
+          select: classes.select
+        },
+        displayEmpty: !props.value,
+        disableUnderline: props.disableUnderline,
+        renderValue: () => props.value || t("generic.memo-selector.select")
+      }}
+    >
+      {props.value ? null : (
+        <MenuItem disabled value="">
+          {t("generic.memo-selector.placeholder")}
+        </MenuItem>
+      )}
+      {memoTypes.map(memoType => (
+        <MemoItem
+          memoType={memoType}
+          disabled={props.disabledMemos && props.disabledMemos.some(someMemo => someMemo === memoType)}
+          key={memoType}
+          value={memoType}
+        />
+      ))}
+    </TextField>
+  )
+}
+
+export default React.memo(MemoSelector)

--- a/src/Generic/components/MemoSelector.tsx
+++ b/src/Generic/components/MemoSelector.tsx
@@ -13,13 +13,17 @@ interface MemoItemProps {
   value: string
 }
 
+function capitalizeFirstLetter(word: string) {
+  return word.charAt(0).toUpperCase() + word.slice(1)
+}
+
 const MemoItem = React.memo(
   React.forwardRef(function MemoItem(props: MemoItemProps, ref: React.Ref<HTMLLIElement>) {
     const { memoType, ...reducedProps } = props
 
     return (
       <MenuItem {...reducedProps} key={props.key} ref={ref} value={props.value}>
-        <ListItemText>{memoType}</ListItemText>
+        <ListItemText>{capitalizeFirstLetter(memoType)}</ListItemText>
       </MenuItem>
     )
   })
@@ -115,7 +119,7 @@ function MemoSelector(props: MemoSelectorProps) {
         },
         displayEmpty: !props.value,
         disableUnderline: props.disableUnderline,
-        renderValue: () => props.value || t("generic.memo-selector.select")
+        renderValue: () => (props.value ? capitalizeFirstLetter(props.value) : t("generic.memo-selector.select"))
       }}
     >
       {props.value ? null : (

--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -18,15 +18,17 @@ import { isPublicKey, isStellarAddress } from "~Generic/lib/stellar-address"
 import { createPaymentOperation, createTransaction, multisigMinimumFee } from "~Generic/lib/transaction"
 import { ActionButton, DialogActionsBox } from "~Generic/components/DialogActions"
 import AssetSelector from "~Generic/components/AssetSelector"
-import { PriceInput, QRReader } from "~Generic/components/FormFields"
+import { MemoInput, PriceInput, QRReader } from "~Generic/components/FormFields"
 import { formatBalance } from "~Generic/lib/balances"
-import { HorizontalLayout } from "~Layout/components/Box"
+import MemoSelector from "~Generic/components/MemoSelector"
 import Portal from "~Generic/components/Portal"
+import { HorizontalLayout } from "~Layout/components/Box"
 
 export interface PaymentFormValues {
   amount: string
   asset: Asset
   destination: string
+  memoType: MemoType
   memoValue: string
 }
 
@@ -35,7 +37,7 @@ type ExtendedPaymentFormValues = PaymentFormValues & { memoType: MemoType }
 interface MemoMetadata {
   label: string
   placeholder: string
-  requiredType: MemoType | undefined
+  required: boolean
 }
 
 function createMemo(memoType: MemoType, memoValue: string) {
@@ -70,17 +72,17 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
   const wellknownAccounts = useWellKnownAccounts(props.testnet)
 
   const [matchingWellknownAccount, setMatchingWellknownAccount] = React.useState<AccountRecord | undefined>(undefined)
-  const [memoType, setMemoType] = React.useState<MemoType>("none")
   const [memoMetadata, setMemoMetadata] = React.useState<MemoMetadata>({
     label: t("payment.memo-metadata.label.default"),
     placeholder: t("payment.memo-metadata.placeholder.optional"),
-    requiredType: undefined
+    required: false
   })
   const form = useForm<PaymentFormValues>({
     defaultValues: {
       amount: "",
       asset: Asset.native(),
       destination: "",
+      memoType: "none",
       memoValue: ""
     }
   })
@@ -106,26 +108,25 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
 
     if (knownAccount && knownAccount.tags.indexOf("exchange") !== -1) {
       const acceptedMemoType = knownAccount.accepts && knownAccount.accepts.memo
-      const requiredType = acceptedMemoType === "MEMO_ID" ? "id" : "text"
-      setMemoType(requiredType)
+      const required = false
       setMemoMetadata({
         label:
           acceptedMemoType === "MEMO_ID" ? t("payment.memo-metadata.label.id") : t("payment.memo-metadata.label.text"),
         placeholder: t("payment.memo-metadata.placeholder.mandatory"),
-        requiredType
+        required
       })
     } else {
-      setMemoType(formValues.memoValue.length === 0 ? "none" : "text")
+      const required = false
       setMemoMetadata({
         label: t("payment.memo-metadata.label.default"),
         placeholder: t("payment.memo-metadata.placeholder.optional"),
-        requiredType: undefined
+        required
       })
     }
-  }, [formValues.destination, formValues.memoValue, matchingWellknownAccount, memoType, t, wellknownAccounts])
+  }, [formValues.destination, formValues.memoValue, matchingWellknownAccount, t, wellknownAccounts])
 
   const handleFormSubmission = () => {
-    props.onSubmit({ memoType, ...form.getValues() }, spendableBalance, matchingWellknownAccount)
+    props.onSubmit(form.getValues(), spendableBalance, matchingWellknownAccount)
   }
 
   const handleQRScan = React.useCallback(
@@ -141,7 +142,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
       const memoValue = searchParams.get("dt")
 
       if (memoValue) {
-        setMemoType("id")
+        setValue("memoType", "id")
         setValue("memoValue", memoValue)
       }
     },
@@ -232,9 +233,21 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
     [assetSelector, form, isSmallScreen, spendableBalance, t]
   )
 
+  const memoSelector = React.useMemo(
+    () => (
+      <Controller
+        as={<MemoSelector disableUnderline value={formValues.memoType} />}
+        control={form.control}
+        name="memoType"
+      />
+    ),
+    [form.control, formValues.memoType]
+  )
+
   const memoInput = React.useMemo(
     () => (
-      <TextField
+      <MemoInput
+        memoSelector={memoSelector}
         error={Boolean(form.errors.memoValue)}
         inputProps={{ maxLength: 28 }}
         label={form.errors.memoValue ? form.errors.memoValue.message : memoMetadata.label}
@@ -244,7 +257,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
           validate: {
             length: value => value.length <= 28 || t<string>("payment.validation.memo-too-long"),
             memoRequired: value =>
-              !memoMetadata.requiredType ||
+              !memoMetadata.required ||
               !matchingWellknownAccount ||
               value.length > 0 ||
               t<string>(
@@ -255,16 +268,16 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
                 }
               ),
             idPattern: value =>
-              memoType !== "id" || value.match(/^[0-9]+$/) || t<string>("payment.validation.integer-memo-required")
+              formValues.memoType !== "id" ||
+              value.match(/^[0-9]+$/) ||
+              t<string>("payment.validation.integer-memo-required")
           }
         })}
         onChange={event => {
           const { value } = event.target
-          if (!memoMetadata.requiredType) {
-            // only change memo type if no type is required
-            const newMemoType = value.length === 0 ? "none" : "text"
-            setMemoType(newMemoType)
-          }
+          const newMemoType =
+            value.length === 0 ? "none" : formValues.memoType === "none" ? "text" : formValues.memoType
+          setValue("memoType", newMemoType)
           setValue("memoValue", value)
         }}
         placeholder={memoMetadata.placeholder}
@@ -278,11 +291,12 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
     ),
     [
       form,
-      memoType,
+      formValues.memoType,
       matchingWellknownAccount,
+      memoSelector,
       memoMetadata.label,
       memoMetadata.placeholder,
-      memoMetadata.requiredType,
+      memoMetadata.required,
       setValue,
       t
     ]

--- a/src/Workers/net-worker/stellar-ecosystem.ts
+++ b/src/Workers/net-worker/stellar-ecosystem.ts
@@ -3,10 +3,8 @@ import { AccountRecord } from "~Generic/lib/stellar-expert"
 import { AssetRecord } from "~Generic/lib/stellar-ticker"
 import { CustomError } from "~Generic/lib/errors"
 
-export async function fetchWellknownAccounts(testnet: boolean): Promise<AccountRecord[]> {
-  const requestURL = testnet
-    ? "https://api.stellar.expert/api/explorer/testnet/directory"
-    : "https://api.stellar.expert/api/explorer/public/directory"
+export async function fetchWellknownAccount(accountID: string): Promise<AccountRecord | null> {
+  const requestURL = "https://api.stellar.expert/api/explorer/directory" + `?address[]=${accountID}`
 
   const response = await fetch(requestURL)
 
@@ -19,7 +17,8 @@ export async function fetchWellknownAccounts(testnet: boolean): Promise<AccountR
 
   const json = await response.json()
   const knownAccounts = json._embedded.records as AccountRecord[]
-  return knownAccounts
+  const account = knownAccounts.length > 0 ? knownAccounts[0] : null
+  return account
 }
 
 function byAccountCountSorter(a: AssetRecord, b: AssetRecord) {


### PR DESCRIPTION
- [x] Add `<MemoSelector>` component
- [x] Add `<MemoInput>` component which acts similar as the `<PriceInput>` component. It's basically a TextField that has a memo-selector as a start adornment 
- [x] Show the `<MemoInput>` field in the payment form
- [x]  Rewrite fetching of stellar-expert known accounts


Instead of fetching all known-accounts in batches and storing them in the cache, I replaced `fetchWellKnownAccounts()` with `fetchWellKnownAccount()` which fetches an individual account address from stellar-expert and stores the result in the cache. 
Since the `lookup()` function call may include a fetch it now returns a promise.
The [stellar-expert directory API](https://stellar.expert/openapi.html#tag/Directory-API) does not differentiate between testnet and pubnet anymore. That's why the cache-key is now called `"all"` instead of `"testnet"` or `"pubnet"`. 

Closes #1210. 