### PR TITLE
Fix wrong type declaration of networker

### DIFF
--- a/src/Workers/worker-controller.ts
+++ b/src/Workers/worker-controller.ts
@@ -15,7 +15,7 @@ function spawnNetWorker() {
     }
   })
 
-  return spawn<NetWorker>(netWorker)
+  return spawn<NetWorkerInterface>(netWorker)
 }
 
 async function spawnWorkers() {


### PR DESCRIPTION
Fixes the wrong type declaration of the spawned networker. Before this, all usages of the networker were marked as an error because the networker has type `any` due to the wrong type declaration. 