### PR TITLE
Add retry button to submission error view

### DIFF
--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -2,6 +2,9 @@
   "dialog-actions": {
     "close": {
       "label": "Close"
+    },
+    "retry": {
+      "label": "Retry"
     }
   },
   "error": {

--- a/src/Transaction/components/SubmissionProgress.tsx
+++ b/src/Transaction/components/SubmissionProgress.tsx
@@ -9,6 +9,7 @@ import RetryIcon from "@material-ui/icons/Replay"
 import SuccessIcon from "~Icons/components/Success"
 import { Box, VerticalLayout } from "~Layout/components/Box"
 import { explainSubmissionErrorResponse } from "~Generic/lib/horizonErrors"
+import { getErrorTranslation } from "~Generic/lib/errors"
 
 function Container(props: { children: React.ReactNode }) {
   return (
@@ -67,7 +68,11 @@ function SubmissionProgress(props: SubmissionProgressProps) {
       catch={error => (
         <Container>
           <ErrorIcon size={100} />
-          <Heading>{explainSubmissionErrorResponse(error.response, t).message || JSON.stringify(error)}</Heading>
+          <Heading>
+            {error.response
+              ? explainSubmissionErrorResponse(error.response, t).message || JSON.stringify(error)
+              : getErrorTranslation(error, t)}
+          </Heading>
           <DialogActionsBox>
             {props.onRetry && (
               <ActionButton icon={<RetryIcon />} onClick={props.onRetry} type="primary">

--- a/src/Transaction/components/SubmissionProgress.tsx
+++ b/src/Transaction/components/SubmissionProgress.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from "react-i18next"
 import Async from "react-promise"
 import CircularProgress from "@material-ui/core/CircularProgress"
 import Typography from "@material-ui/core/Typography"
-import { CloseButton, DialogActionsBox } from "~Generic/components/DialogActions"
+import { ActionButton, CloseButton, DialogActionsBox } from "~Generic/components/DialogActions"
 import ErrorIcon from "~Icons/components/Error"
+import RetryIcon from "@material-ui/icons/Replay"
 import SuccessIcon from "~Icons/components/Success"
 import { Box, VerticalLayout } from "~Layout/components/Box"
 import { explainSubmissionErrorResponse } from "~Generic/lib/horizonErrors"
@@ -41,6 +42,7 @@ const successMessages: { [type: number]: string } = {
 
 interface SubmissionProgressProps {
   onClose?: () => void
+  onRetry?: () => void
   promise: Promise<any>
   type: SubmissionType
 }
@@ -67,6 +69,11 @@ function SubmissionProgress(props: SubmissionProgressProps) {
           <ErrorIcon size={100} />
           <Heading>{explainSubmissionErrorResponse(error.response, t).message || JSON.stringify(error)}</Heading>
           <DialogActionsBox>
+            {props.onRetry && (
+              <ActionButton icon={<RetryIcon />} onClick={props.onRetry} type="primary">
+                {t("generic.dialog-actions.retry.label")}
+              </ActionButton>
+            )}
             <CloseButton onClick={props.onClose} />
           </DialogActionsBox>
         </Container>

--- a/src/Transaction/stories/SubmissionProgress.tsx
+++ b/src/Transaction/stories/SubmissionProgress.tsx
@@ -14,3 +14,10 @@ storiesOf("SubmissionProgress", module)
   .add("failed", () => (
     <SubmissionProgress type={SubmissionType.default} promise={Promise.reject(new Error("Test error"))} />
   ))
+  .add("failed with retry", () => (
+    <SubmissionProgress
+      type={SubmissionType.default}
+      promise={Promise.reject(new Error("Test error"))}
+      onRetry={() => undefined}
+    />
+  ))


### PR DESCRIPTION
- [x] Show a 'Retry' button next to the 'Close' button of the submission progress if the transaction submission fails
- [x] Show human-readable translated error message on submission timeout error

The issue of submission timeouts was not related to horizon but to the timeout specified for the promise queue [here](https://github.com/satoshipay/solar/blob/589241b2adfdae7d4fb2a8086de4420751e2c683/src/Workers/net-worker/stellar-network.ts#L101). That's why the transaction often went through although the "An unknown error occured" message was shown.
Instead of increasing this timeout I changed the error message shown in the submission progress so that the error translation is used if `error.response` is undefined (i.e. the error is not a submission error). 
This means that a "Request timed out" message (i18n translation for `timeout-error`) is shown once the timeout of 10 seconds is reached on transaction submission. If the user clicks on the newly added "Retry" button he is likely to see a "Successful" message pretty fast since the transaction was already accepted by the network.

Closes #1208. 