### PR TITLE
Fix AppImage issues on linux

### DIFF
--- a/electron-build.yml
+++ b/electron-build.yml
@@ -37,4 +37,5 @@ linux:
   artifactName: Solar-Wallet-${version}.${ext}
   category: Utility
 
+afterPack: ./scripts/electron-builder-afterpack.js
 afterSign: ./scripts/electron-builder-aftersign.js

--- a/scripts/electron-builder-afterpack.js
+++ b/scripts/electron-builder-afterpack.js
@@ -1,0 +1,31 @@
+const fs = require("fs")
+const path = require("path")
+
+const appDir = path.join(__dirname, "../electron/dist/linux-unpacked/")
+
+// Change permissions of the `chrome-sandbox` binary to 4755 to fix issues on some linux distributions
+module.exports = async function(context) {
+  const platform = context.packager.platform.name
+  // Only change permissions of `chrome-sandbox` on linux
+  if (platform !== "linux") {
+    return
+  }
+
+  console.log("Running linux afterpack hook...")
+  updateSandboxHelperPermissions(appDir)
+}
+
+async function sandboxHelperPath(appDir) {
+  const helperPath = path.join(appDir, "chrome-sandbox")
+  if (fs.existsSync(helperPath)) {
+    return helperPath
+  }
+}
+
+async function updateSandboxHelperPermissions(appDir) {
+  const helperPath = await sandboxHelperPath(appDir)
+  if (typeof helperPath !== "undefined") {
+    console.log("Changing permissions of " + helperPath + " to 4755...")
+    return fs.chmodSync(helperPath, 0o4755)
+  }
+}


### PR DESCRIPTION
Adds an "afterPack" script for  `electron-builder` that changes the permissions of the `chrome-sandbox` to `4755` to fix issues on some Linux distributions. This way users should not need to add the `--no-sandbox` attribute when running the `.appimage`.

I could not test it properly because I am not using a Debian based distribution.

Closes #1209. 