### PR TITLE
Disable and show loading indicator for submit button

### DIFF
--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -84,6 +84,7 @@ function TradingForm(props: Props) {
 
   const [expanded, setExpanded] = React.useState(false)
   const [priceMode, setPriceMode] = React.useState<"primary" | "secondary">("secondary")
+  const [pending, setPending] = React.useState(false)
 
   const form = useForm<TradingFormValues>({
     defaultValues: {
@@ -142,6 +143,8 @@ function TradingForm(props: Props) {
 
   const submitForm = React.useCallback(async () => {
     try {
+      setPending(true)
+
       if (!primaryAsset) {
         throw CustomError(
           "InvariantViolationError",
@@ -185,6 +188,8 @@ function TradingForm(props: Props) {
       sendTransaction(tx)
     } catch (error) {
       trackError(error)
+    } finally {
+      setPending(false)
     }
   }, [
     effectivePrice,
@@ -391,7 +396,13 @@ function TradingForm(props: Props) {
         ) : null}
         <Portal target={props.dialogActionsRef?.element}>
           <DialogActionsBox desktopStyle={{ marginTop: 32 }}>
-            <ActionButton icon={<GavelIcon />} onClick={form.handleSubmit(submitForm)} type="primary">
+            <ActionButton
+              disabled={pending}
+              loading={pending}
+              icon={<GavelIcon />}
+              onClick={form.handleSubmit(submitForm)}
+              type="primary"
+            >
               {t("trading.action.submit")}
             </ActionButton>
           </DialogActionsBox>


### PR DESCRIPTION
Closes #1221. 

@andywer I noticed that the submit buttons do not share the same behavior. For example, the "Send" button when creating a payment has a loading indicator but is not disabled (and I think if it's clicked again while loading, then the request will be sent again, which should not be possible).
Should I add a follow-up ticket about making all submit buttons behave similarly, i.e. showing a loading indicator + being disabled?