### PR TITLE
Fix wrong spendable balance for accounts with too many open orders

### DIFF
--- a/src/Assets/components/AssetDetailsDialog.tsx
+++ b/src/Assets/components/AssetDetailsDialog.tsx
@@ -22,6 +22,7 @@ import MainTitle from "~Generic/components/MainTitle"
 import AssetDetailsActions from "./AssetDetailsActions"
 import AssetLogo from "./AssetLogo"
 import SpendableBalanceBreakdown from "./SpendableBalanceBreakdown"
+import { useLiveAccountData } from "~Generic/hooks/stellar-subscriptions"
 
 const capitalize = (text: string) => text[0].toUpperCase() + text.substr(1)
 
@@ -61,7 +62,7 @@ interface LumenDetailProps {
 }
 
 const LumenDetails = React.memo(function LumenDetails(props: LumenDetailProps) {
-  const accountData = useAccountData(props.account.publicKey, props.account.testnet)
+  const accountData = useLiveAccountData(props.account.publicKey, props.account.testnet)
   const classes = useDetailContentStyles()
   const { t } = useTranslation()
 

--- a/src/Assets/components/BalanceDetailsDialog.tsx
+++ b/src/Assets/components/BalanceDetailsDialog.tsx
@@ -79,7 +79,6 @@ interface NativeBalanceItemsProps {
   hmargin: string | number
   hpadding: string | number
   onOpenAssetDetails: (asset: Asset) => void
-  openOffers: ServerApi.OfferRecord[]
 }
 
 const NativeBalanceItems = React.memo(function NativeBalanceItems(props: NativeBalanceItemsProps) {
@@ -103,10 +102,7 @@ const NativeBalanceItems = React.memo(function NativeBalanceItems(props: NativeB
           ...props.balance,
           balance: BigNumber(props.balance.balance).eq(0)
             ? "0"
-            : getSpendableBalance(
-                getAccountMinimumBalance(props.accountData, props.openOffers.length),
-                props.balance
-              ).toString()
+            : getSpendableBalance(getAccountMinimumBalance(props.accountData), props.balance).toString()
         }}
         hideLogo
         onClick={() => props.onOpenAssetDetails(Asset.native())}
@@ -204,7 +200,6 @@ function BalanceDetailsDialog(props: BalanceDetailsProps) {
             hmargin={itemHMargin}
             hpadding={itemHPadding}
             onOpenAssetDetails={openAssetDetails}
-            openOffers={openOrders}
           />
         ) : null}
       </List>

--- a/src/Assets/components/SpendableBalanceBreakdown.tsx
+++ b/src/Assets/components/SpendableBalanceBreakdown.tsx
@@ -6,7 +6,6 @@ import ListItem from "@material-ui/core/ListItem"
 import ListItemText from "@material-ui/core/ListItemText"
 import { makeStyles } from "@material-ui/core/styles"
 import { Account } from "~App/contexts/accounts"
-import { useLiveAccountOffers } from "~Generic/hooks/stellar-subscriptions"
 import { AccountData } from "~Generic/lib/account"
 import { breakpoints } from "~App/theme"
 import { SingleBalance } from "~Account/components/AccountBalances"
@@ -136,17 +135,21 @@ interface Props {
 }
 
 function SpendableBalanceBreakdown(props: Props) {
-  const { offers: openOrders } = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
   const { t } = useTranslation()
 
   const nativeBalance = props.accountData.balances.find(balance => balance.asset_type === "native")
   const trustedAssetBalances = props.accountData.balances.filter(balance => balance.asset_type !== "native")
 
   const dataReserve = props.baseReserve * Object.keys(props.accountData.data_attr).length
-  const openOrdersReserve = props.baseReserve * openOrders.length
   const signersReserve = props.baseReserve * props.accountData.signers.length
   const trustlinesReserve = props.baseReserve * trustedAssetBalances.length
   const sellingLiabilities = nativeBalance ? BigNumber(nativeBalance.selling_liabilities) : BigNumber(0)
+
+  // calculate open orders reserve based on subentry count to circumvent fetching all orders
+  const openOrdersReserve = BigNumber(props.accountData.subentry_count * props.baseReserve)
+    .minus(props.baseReserve * (props.accountData.signers.length - 1))
+    .minus(dataReserve)
+    .minus(trustlinesReserve)
 
   const rawBalance = nativeBalance ? BigNumber(nativeBalance.balance) : BigNumber(0)
   const spendableBalance = rawBalance
@@ -195,7 +198,7 @@ function SpendableBalanceBreakdown(props: Props) {
       />
       <BreakdownItem
         amount={openOrdersReserve.toFixed(1)}
-        hide={openOrdersReserve === 0}
+        hide={openOrdersReserve.cmp(0) === 0}
         indent
         primary={t("account.balance-details.spendable-balances.open-orders-reserve.primary")}
         secondary={t("account.balance-details.spendable-balances.open-orders-reserve.secondary")}

--- a/src/Generic/lib/stellar.ts
+++ b/src/Generic/lib/stellar.ts
@@ -69,17 +69,9 @@ export async function friendbotTopup(horizonURL: string, publicKey: string) {
   return response.json()
 }
 
-export function getAccountMinimumBalance(
-  accountData: Pick<AccountData, "balances" | "data_attr" | "signers">,
-  openOfferCount: number = 0
-) {
-  const trustlineCount = accountData.balances.filter(balance => balance.asset_type !== "native").length
-
-  return BigNumber(1)
-    .add(accountData.signers.length)
-    .add(Object.keys(accountData.data_attr).length)
-    .add(openOfferCount)
-    .add(trustlineCount)
+export function getAccountMinimumBalance(accountData: Pick<AccountData, "subentry_count">) {
+  return BigNumber(2) // 2 accounts for base reserve and signer reserve from own account
+    .add(accountData.subentry_count)
     .mul(BASE_RESERVE)
 }
 

--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -89,7 +89,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
   const { setValue } = form
 
   const spendableBalance = getSpendableBalance(
-    getAccountMinimumBalance(props.accountData, props.openOrdersCount),
+    getAccountMinimumBalance(props.accountData),
     findMatchingBalanceLine(props.accountData.balances, formValues.asset)
   )
 

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -21,7 +21,7 @@ import { ReadOnlyTextfield } from "~Generic/components/FormFields"
 import { ActionButton, DialogActionsBox } from "~Generic/components/DialogActions"
 import Portal from "~Generic/components/Portal"
 import { useHorizon } from "~Generic/hooks/stellar"
-import { useLiveOrderbook, useLiveAccountOffers } from "~Generic/hooks/stellar-subscriptions"
+import { useLiveOrderbook } from "~Generic/hooks/stellar-subscriptions"
 import { useIsMobile, RefStateObject } from "~Generic/hooks/userinterface"
 import { AccountData } from "~Generic/lib/account"
 import { CustomError } from "~Generic/lib/errors"
@@ -106,13 +106,11 @@ function TradingForm(props: Props) {
 
   const horizon = useHorizon(props.account.testnet)
   const tradePair = useLiveOrderbook(primaryAsset || Asset.native(), secondaryAsset, props.account.testnet)
-  const { offers: openOrders } = useLiveAccountOffers(props.account.publicKey, props.account.testnet)
 
   const assets = React.useMemo(() => props.trustlines.map(balancelineToAsset), [props.trustlines])
 
   const calculation = useCalculation({
     accountData: props.accountData,
-    openOrdersCount: openOrders.length,
     priceMode,
     primaryAction: props.primaryAction,
     tradePair,
@@ -154,7 +152,7 @@ function TradingForm(props: Props) {
       }
 
       const spendableXLMBalance = getSpendableBalance(
-        getAccountMinimumBalance(props.accountData, openOrders.length),
+        getAccountMinimumBalance(props.accountData),
         findMatchingBalanceLine(props.accountData.balances, Asset.native())
       )
       if (spendableXLMBalance.minus(0.5).cmp(0) <= 0) {
@@ -194,7 +192,6 @@ function TradingForm(props: Props) {
   }, [
     effectivePrice,
     horizon,
-    openOrders.length,
     primaryAsset,
     props.account,
     props.accountData,

--- a/src/Trading/hooks/form.ts
+++ b/src/Trading/hooks/form.ts
@@ -34,7 +34,6 @@ export interface TradingFormValues {
 
 interface CalculationParameters {
   accountData: AccountData
-  openOrdersCount: number
   priceMode: "primary" | "secondary"
   primaryAction: "buy" | "sell"
   tradePair: FixedOrderbookRecord
@@ -56,7 +55,7 @@ interface CalculationResults {
 }
 
 export function useCalculation(parameters: CalculationParameters): CalculationResults {
-  const { accountData, openOrdersCount, priceMode, primaryAction, tradePair } = parameters
+  const { accountData, priceMode, primaryAction, tradePair } = parameters
   const { manualPrice, primaryAmountString, primaryAsset, secondaryAsset } = parameters.values
 
   const price =
@@ -89,7 +88,7 @@ export function useCalculation(parameters: CalculationParameters): CalculationRe
   const inversePrice = effectivePrice.eq(0) ? BigNumber(0) : BigNumber(1).div(effectivePrice)
   const defaultPrice = bigNumberToInputValue(priceMode === "secondary" ? effectivePrice : inversePrice)
 
-  const minAccountBalance = getAccountMinimumBalance(accountData, openOrdersCount)
+  const minAccountBalance = getAccountMinimumBalance(accountData)
 
   const spendablePrimaryBalance = primaryBalance
     ? primaryAction === "sell"


### PR DESCRIPTION
Changes the way the minimum account balance is calculated. Instead of using the number of open offers for calculating the base reserve, the `subentry_count` is used. 

Closes #1223. 