### PR TITLE
Show badges for account import on wider screens

### DIFF
--- a/src/Account/components/AccountTitle.tsx
+++ b/src/Account/components/AccountTitle.tsx
@@ -310,7 +310,7 @@ function AccountTitle(props: AccountTitleProps) {
   return (
     <MainTitle
       actions={props.actions}
-      badges={props.editable && !isSmallScreen ? null : props.badges}
+      badges={props.editable && isSmallScreen ? null : props.badges}
       onBack={props.onNavigateBack}
       style={{ marginTop: -12, marginLeft: 0 }}
       title={


### PR DESCRIPTION
At the moment, the badges for 'testnet' and 'password security' are only shown during account import for devices with small screens. It probably makes more sense to do it the other way round.
