### PR TITLE
Fix Spanish language not configured properly and missing multi-sig translations

### DIFF
--- a/i18n/locales/es/account-settings.json
+++ b/i18n/locales/es/account-settings.json
@@ -93,15 +93,40 @@
   },
   "manage-signers": {
     "action": {
-      "add-co-signer": {
-        "long": "Añadir co-firmante",
-        "short": "Firmante"
-      },
-      "cancel": "Cancelar",
+      "add-signer": "Añadir firmante",
       "apply": {
         "long": "Aplicar el cambio",
         "short": "Aplicar"
-      }
+      },
+      "cancel": "Cancelar",
+      "proceed": "TODO"
+    },
+    "preset-description": {
+      "m-out-of-n": "TODO",
+      "m-out-of-n_plural": "TODO",
+      "one-out-of-n": "TODO",
+      "single-signature": "TODO"
+    },
+    "preset-description-extra": {
+      "m-out-of-n": "TODO",
+      "one-out-of-n": "TODO"
+    },
+    "preset-selector": {
+      "options": {
+        "m-out-of-n": {
+          "primary": "TODO",
+          "secondary": "TODO"
+        },
+        "one-out-of-n": {
+          "primary": "TODO",
+          "secondary": "TODO"
+        },
+        "single-signature": {
+          "primary": "TODO",
+          "secondary": "TODO"
+        }
+      },
+      "title": "TODO"
     },
     "signers-editor": {
       "list": {
@@ -117,22 +142,14 @@
           "short": "GABCDEFGHIJK… o alice*example.org"
         }
       },
+      "threshold": {
+        "primary": "TODO",
+        "secondary": "TODO"
+      },
       "validation": {
         "existing-signer": "No puede agregar firmante existente.",
         "integer-required": "Debe ser un número entero.",
         "invalid-stellar-address": "Se espera un clave pública o dirección Stellar"
-      }
-    },
-    "textfield": {
-      "weight-threshold": {
-        "explanation": {
-          "required-signatures": "Toda transacción necesita ser firmada por {{amount}} firmantes"
-        },
-        "required-weight": "Toda transacción debe ser firmada por firmantes con un peso de claves combinado de {{amount}}",
-        "label": {
-          "required-signatures": "Se requieren firmas",
-          "required-weight": "Se requiere peso de claves"
-        }
       }
     },
     "title": {

--- a/i18n/locales/es/account-settings.json
+++ b/i18n/locales/es/account-settings.json
@@ -99,34 +99,34 @@
         "short": "Aplicar"
       },
       "cancel": "Cancelar",
-      "proceed": "TODO"
+      "proceed": "Continuar"
     },
     "preset-description": {
-      "m-out-of-n": "TODO",
-      "m-out-of-n_plural": "TODO",
-      "one-out-of-n": "TODO",
-      "single-signature": "TODO"
+      "m-out-of-n": "Agregar o quitar firmantes de la cuenta. Cualquier firma autorizará las transacciones. ",
+      "m-out-of-n_plural": "Agregar o quitar firmantes de la cuenta. {{ count }} firmas autorizarán las transacciones",
+      "one-out-of-n": "Agregar o quitar firmantes de la cuenta. Cualquier firmante puede autorizar transacciones.",
+      "single-signature": "Escoge la clave que será la firma única de la cuenta."
     },
     "preset-description-extra": {
-      "m-out-of-n": "TODO",
-      "one-out-of-n": "TODO"
+      "m-out-of-n": "Ve a 'Agregar cuenta' > 'Unirse a la cuenta' en Solar para crear una nueva clave de co-firmante.",
+      "one-out-of-n": "Ve a 'Agregar cuenta' > 'Unirse a la cuenta' en Solar para crear una nueva clave de co-firmante."
     },
     "preset-selector": {
       "options": {
         "m-out-of-n": {
-          "primary": "TODO",
-          "secondary": "TODO"
+          "primary": "Firma colectiva",
+          "secondary": "Múltiples firmantes tienen que firmar una transacción."
         },
         "one-out-of-n": {
-          "primary": "TODO",
-          "secondary": "TODO"
+          "primary": "Claves de respaldo",
+          "secondary": "Cada firmante puede firmar transacciones por él mismo."
         },
         "single-signature": {
-          "primary": "TODO",
-          "secondary": "TODO"
+          "primary": "Firma única",
+          "secondary": "No hay co-firmantes. Solo un par de claves."
         }
       },
-      "title": "TODO"
+      "title": "Elige como quieres que funcione tu cuenta"
     },
     "signers-editor": {
       "list": {
@@ -143,8 +143,8 @@
         }
       },
       "threshold": {
-        "primary": "TODO",
-        "secondary": "TODO"
+        "primary": "Firmas requeridas",
+        "secondary": "Número de firmas requeridas para autorizar transacciones"
       },
       "validation": {
         "existing-signer": "No puede agregar firmante existente.",

--- a/i18n/locales/es/create-account.json
+++ b/i18n/locales/es/create-account.json
@@ -3,7 +3,8 @@
     "cancel": "Cancelar",
     "confirm": "Confirmar",
     "create": "Crear una cuenta",
-    "import": "Importar cuenta"
+    "import": "Importar cuenta",
+    "join-shared": "TODO"
   },
   "action-selection": {
     "create": {
@@ -13,6 +14,10 @@
     "import": {
       "description": "Restaurar cuenta desde copia de seguridad",
       "label": "Importar cuenta"
+    },
+    "join-shared": {
+      "description": "TODO",
+      "label": "TODO"
     }
   },
   "base-name": {
@@ -36,6 +41,13 @@
       "label": "Clave secreta",
       "title": "Importar existente"
     },
+    "multisig-account": {
+      "explanation-long": "TODO",
+      "explanation-short": "TODO",
+      "helper-text": "TODO",
+      "placeholder": "GABCDEFGH…",
+      "label": "TODO"
+    },
     "password": {
       "label": "Contraseña",
       "placeholder": "Ingresa una contraseña"
@@ -46,6 +58,14 @@
     }
   },
   "options": {
+    "cosigner": {
+      "label": "TODO",
+      "description": "TODO"
+    },
+    "cosigner-import": {
+      "label": "TODO",
+      "description": "TODO"
+    },
     "import": {
       "label": "Importar clave secreta",
       "description": "Restaurar cuenta desde copia de seguridad"

--- a/i18n/locales/es/create-account.json
+++ b/i18n/locales/es/create-account.json
@@ -4,7 +4,7 @@
     "confirm": "Confirmar",
     "create": "Crear una cuenta",
     "import": "Importar cuenta",
-    "join-shared": "TODO"
+    "join-shared": "Agregar cuenta compartida"
   },
   "action-selection": {
     "create": {
@@ -16,8 +16,8 @@
       "label": "Importar cuenta"
     },
     "join-shared": {
-      "description": "TODO",
-      "label": "TODO"
+      "description": "Co-firmar una cuenta compartida",
+      "label": "Unirse a la cuenta"
     }
   },
   "base-name": {
@@ -42,11 +42,11 @@
       "title": "Importar existente"
     },
     "multisig-account": {
-      "explanation-long": "TODO",
-      "explanation-short": "TODO",
-      "helper-text": "TODO",
+      "explanation-long": "Asegúrate de que la cuenta a agregar tenga al menos 2 XLM, así puedes ser agregado como co-firmante.",
+      "explanation-short": "Asegúrate de que la cuenta tiene fondos.",
+      "helper-text": "La dirección de la cuenta Multisig (clave pública)",
       "placeholder": "GABCDEFGH…",
-      "label": "TODO"
+      "label": "Cuenta Multisig (firmas múltiples)"
     },
     "password": {
       "label": "Contraseña",
@@ -59,12 +59,12 @@
   },
   "options": {
     "cosigner": {
-      "label": "TODO",
-      "description": "TODO"
+      "label": "Unirse a cuenta compartida",
+      "description": "Co-firmar una cuenta Multisig (de múltiples firmas)"
     },
     "cosigner-import": {
-      "label": "TODO",
-      "description": "TODO"
+      "label": "Co-firma una cuenta compartida",
+      "description": "La clave es firmante de otra cuenta"
     },
     "import": {
       "label": "Importar clave secreta",

--- a/src/App/i18n.ts
+++ b/src/App/i18n.ts
@@ -3,6 +3,7 @@ import LanguageDetector from "i18next-browser-languagedetector"
 import { initReactI18next } from "react-i18next"
 
 import translationEN from "../../i18n/en"
+import translationES from "../../i18n/es"
 import translationIT from "../../i18n/it"
 
 i18n
@@ -17,6 +18,9 @@ i18n
     resources: {
       en: {
         translation: translationEN
+      },
+      es: {
+        translation: translationES
       },
       it: {
         translation: translationIT


### PR DESCRIPTION
The Spanish translations were not added to the i18n `resources` so they were not loaded when switching the language in the app settings.

I noticed that there are no Spanish translations for the new multi-sig strings, @gonzamontiel could you maybe add those as well? I already added placeholders to the JSON files so that you don't have to spend time figuring out which are missing. 