### PR TITLE
Quick-fix for missing balance issue

### DIFF
--- a/src/App/contexts/stellar.tsx
+++ b/src/App/contexts/stellar.tsx
@@ -18,11 +18,8 @@ const initialHorizonSelection = (async () => {
   const { netWorker } = await workers
 
   return Promise.all([
-    netWorker.checkHorizonOrFailover("https://stellar-horizon.satoshipay.io/", "https://horizon.stellar.org"),
-    netWorker.checkHorizonOrFailover(
-      "https://stellar-horizon-testnet.satoshipay.io/",
-      "https://horizon-testnet.stellar.org"
-    )
+    netWorker.checkHorizonOrFailover("https://horizon.stellar.org", "https://horizon.stellar.org"),
+    netWorker.checkHorizonOrFailover("https://horizon-testnet.stellar.org", "https://horizon-testnet.stellar.org")
   ])
 })()
 


### PR DESCRIPTION
The original issue was a wrong `Location` parameter in the redirection response.
<img width="550" alt="Screenshot 2021-05-06 at 11 34 03" src="https://user-images.githubusercontent.com/6690623/117288234-920d2200-ae6b-11eb-8461-4675242fee51.png">

Although we fixed this, the balance is still missing if the user does not re-install the application due to the long expiry time of the cached response.

The easiest way to circumvent this issue, for now, is to just use the SDF horizon.

