### PR TITLE
Fix invalid price error in trading form

### DIFF
--- a/src/Trading/components/TradingPrice.tsx
+++ b/src/Trading/components/TradingPrice.tsx
@@ -1,4 +1,3 @@
-import BigNumber from "big.js"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { Asset } from "stellar-sdk"
@@ -14,7 +13,6 @@ interface TradingPriceProps {
   onBlur?: () => void
   onChange?: (event: React.ChangeEvent) => void
   onSetPriceDenotedIn: (denotedIn: "primary" | "secondary") => void
-  price: BigNumber
   priceDenotedIn: "primary" | "secondary"
   primaryAsset: Asset | undefined
   secondaryAsset: Asset | undefined


### PR DESCRIPTION
Fixes a bug where the user cannot submit a trade order because the "Invalid price" error message is always shown if the user has not manually changed the price.

I removed the validation from the `<Controller>` component because the value that is passed here is not enough to check if a price is invalid. The reason for this is that the price input field does either contain the `manualPrice` (input by the user) or the `defaultPrice` that was calculated in the `useCalculation` hook. The `validation` function however receives only the `manualPrice` (that is 0 until the user edited the field manually) which is basically the root issue of the bug. I tried passing a validation function that uses the calculation results of the `useCalculation` hook but this does not work because the component is not rerendered and the function not up-to-date. That's why I put the validation into the `submitForm()` function.