### PR TITLE
Fix no spinner on confirm or retry button

### DIFF
--- a/src/Transaction/components/SubmissionProgress.tsx
+++ b/src/Transaction/components/SubmissionProgress.tsx
@@ -51,16 +51,17 @@ interface SubmissionProgressProps {
 }
 
 function SubmissionProgress(props: SubmissionProgressProps) {
+  const { onRetry } = props
   const { t } = useTranslation()
 
   const [loading, setLoading] = React.useState(false)
 
-  const onRetry = React.useCallback(() => {
-    if (props.onRetry) {
+  const retry = React.useCallback(() => {
+    if (onRetry) {
       setLoading(true)
-      props.onRetry().finally(() => setLoading(false))
+      onRetry().finally(() => setLoading(false))
     }
-  }, [props.onRetry, setLoading])
+  }, [onRetry, setLoading])
 
   return (
     <Async
@@ -87,7 +88,7 @@ function SubmissionProgress(props: SubmissionProgressProps) {
           </Heading>
           <DialogActionsBox>
             {props.onRetry && (
-              <ActionButton icon={<RetryIcon />} loading={loading} onClick={onRetry} type="primary">
+              <ActionButton icon={<RetryIcon />} loading={loading} onClick={retry} type="primary">
                 {t("generic.dialog-actions.retry.label")}
               </ActionButton>
             )}

--- a/src/Transaction/components/SubmissionProgress.tsx
+++ b/src/Transaction/components/SubmissionProgress.tsx
@@ -45,13 +45,23 @@ const successMessages: { [type: number]: string } = {
 
 interface SubmissionProgressProps {
   onClose?: () => void
-  onRetry?: () => void
+  onRetry?: () => Promise<void>
   promise: Promise<any>
   type: SubmissionType
 }
 
 function SubmissionProgress(props: SubmissionProgressProps) {
   const { t } = useTranslation()
+
+  const [loading, setLoading] = React.useState(false)
+
+  const onRetry = () => {
+    if (props.onRetry) {
+      setLoading(true)
+      props.onRetry().finally(() => setLoading(false))
+    }
+  }
+
   return (
     <Async
       promise={props.promise}
@@ -77,7 +87,7 @@ function SubmissionProgress(props: SubmissionProgressProps) {
           </Heading>
           <DialogActionsBox>
             {props.onRetry && (
-              <ActionButton icon={<RetryIcon />} onClick={props.onRetry} type="primary">
+              <ActionButton icon={<RetryIcon />} loading={loading} onClick={onRetry} type="primary">
                 {t("generic.dialog-actions.retry.label")}
               </ActionButton>
             )}

--- a/src/Transaction/components/SubmissionProgress.tsx
+++ b/src/Transaction/components/SubmissionProgress.tsx
@@ -55,12 +55,12 @@ function SubmissionProgress(props: SubmissionProgressProps) {
 
   const [loading, setLoading] = React.useState(false)
 
-  const onRetry = () => {
+  const onRetry = React.useCallback(() => {
     if (props.onRetry) {
       setLoading(true)
       props.onRetry().finally(() => setLoading(false))
     }
-  }
+  }, [props.onRetry, setLoading])
 
   return (
     <Async

--- a/src/Transaction/components/TransactionSender.tsx
+++ b/src/Transaction/components/TransactionSender.tsx
@@ -200,7 +200,7 @@ class TransactionSender extends React.Component<Props, State> {
     try {
       signedTx = await signTransaction(transaction, this.props.account, formValues.password)
       this.setState({ passwordError: null, signedTransaction: signedTx, unsignedTransaction: unsignedTx })
-      this.submitSignedTransaction(signedTx, unsignedTx)
+      return this.submitSignedTransaction(signedTx, unsignedTx)
     } catch (error) {
       if (isWrongPasswordError(error)) {
         this.setState({ passwordError: error })

--- a/src/Transaction/components/TransactionSender.tsx
+++ b/src/Transaction/components/TransactionSender.tsx
@@ -28,7 +28,7 @@ type Timer = any
 
 function ConditionalSubmissionProgress(props: {
   onClose: () => void
-  onRetry: () => void
+  onRetry: () => Promise<void>
   promise: Promise<any> | null
   type: SubmissionType
 }) {
@@ -348,9 +348,9 @@ class TransactionSender extends React.Component<Props, State> {
     }
   }
 
-  retrySubmission = () => {
+  retrySubmission = async () => {
     if (this.state.signedTransaction && this.state.unsignedTransaction) {
-      this.submitSignedTransaction(this.state.signedTransaction, this.state.unsignedTransaction)
+      return this.submitSignedTransaction(this.state.signedTransaction, this.state.unsignedTransaction)
     }
   }
 


### PR DESCRIPTION
Adds a loading indicator to the retry button.

Adding the 'return' to TransactionSender l. 203 might also fix the sometimes very short spinner on the confirm button because in the ReviewForm the [`onConfirm()` is awaited](https://github.com/satoshipay/solar/blob/2fe70a80664756140a6b149b55dfd30651c6c70a/src/TransactionReview/components/ReviewForm.tsx#L105) and since [`onConfirm()` is basically just submitTransaction()](https://github.com/satoshipay/solar/blob/2fe70a80664756140a6b149b55dfd30651c6c70a/src/TransactionReview/components/TransactionReviewDialog.tsx#L94) adding the return statement here should make `onConfirm` also await the submission of the signed transaction. 
But I was not able to test it because it seems like the spinner is working as expected if the horizon response times are reasonably short. 

Closes #1245. 