### PR TITLE
Increase priority of transaction submissions

### DIFF
--- a/src/Generic/lib/transaction.ts
+++ b/src/Generic/lib/transaction.ts
@@ -101,7 +101,7 @@ export async function createTransaction(operations: Array<xdr.Operation<any>>, o
   const timeout = selectTransactionTimeout(options.accountData)
 
   const [accountMetadata, timebounds] = await Promise.all([
-    applyTimeout(netWorker.fetchAccountData(horizonURL, walletAccount.accountID), 10000, () =>
+    applyTimeout(netWorker.fetchAccountData(horizonURL, walletAccount.accountID, 10), 10000, () =>
       fail(`Fetching source account data timed out`)
     ),
     applyTimeout(netWorker.fetchTimebounds(horizonURL, timeout), 10000, () =>

--- a/src/Workers/net-worker/stellar-network.ts
+++ b/src/Workers/net-worker/stellar-network.ts
@@ -691,11 +691,12 @@ export interface PaginationOptions {
 
 export async function fetchAccountData(
   horizonURL: string,
-  accountID: string
+  accountID: string,
+  priority: number = 2
 ): Promise<(Horizon.AccountResponse & { home_domain?: string | undefined }) | null> {
   const fetchQueue = getFetchQueue(horizonURL)
   const url = new URL(`/accounts/${accountID}?${qs.stringify(identification)}`, horizonURL)
-  const response = await fetchQueue.add(() => fetch(String(url)), { priority: 2 })
+  const response = await fetchQueue.add(() => fetch(String(url)), { priority })
 
   if (response.status === 404) {
     return null

--- a/src/Workers/net-worker/stellar-network.ts
+++ b/src/Workers/net-worker/stellar-network.ts
@@ -181,11 +181,14 @@ export async function submitTransaction(horizonURL: string, txEnvelopeXdr: strin
   const fetchQueue = getFetchQueue(horizonURL)
   const url = new URL(`/transactions?${qs.stringify({ tx: txEnvelopeXdr })}`, horizonURL)
 
-  const response = await fetchQueue.add(() => {
-    return fetch(String(url), {
-      method: "POST"
-    })
-  })
+  const response = await fetchQueue.add(
+    () => {
+      return fetch(String(url), {
+        method: "POST"
+      })
+    },
+    { priority: 20 }
+  )
 
   if (response.status === 200) {
     handleSubmittedTransaction(horizonURL, new Transaction(txEnvelopeXdr, network))


### PR DESCRIPTION
Set the priority of transaction submissions to `20` so that they are less likely to result in "Request timed out" errors. 