### PR TITLE
Fix trading form input field issues

### DIFF
--- a/i18n/locales/en/trading.json
+++ b/i18n/locales/en/trading.json
@@ -55,9 +55,10 @@
   "validation": {
     "primary-amount-missing": "No amount specified.",
     "primary-asset-missing": "No asset selected.",
-    "secondary-asset-missing": "No asset selected.",
     "invalid-amount": "Invalid amount specified.",
-    "invalid-price": "Invalid price"
+    "invalid-price": "Invalid price",
+    "not-enough-balance": "Exceeds your spendable balance",
+    "secondary-asset-missing": "No asset selected."
   },
   "warning": {
     "title": "Warning",

--- a/src/Assets/components/CustomTrustline.tsx
+++ b/src/Assets/components/CustomTrustline.tsx
@@ -56,7 +56,7 @@ function CustomTrustlineDialog(props: Props) {
         />
         <TextField
           inputProps={{
-            pattern: "[0-9]*",
+            pattern: "^[0-9]*(.[0-9]+)?$",
             inputMode: "decimal"
           }}
           fullWidth

--- a/src/Generic/components/FormFields.tsx
+++ b/src/Generic/components/FormFields.tsx
@@ -75,10 +75,6 @@ export const PriceInput = React.memo(function PriceInput(props: PriceInputProps)
         ),
         ...textfieldProps.InputProps
       }}
-      type={
-        // Prevent `The specified value (...) is not a valid number` warning
-        readOnly ? undefined : "number"
-      }
       style={{
         pointerEvents: props.readOnly ? "none" : undefined,
         ...textfieldProps.style

--- a/src/Generic/lib/form.ts
+++ b/src/Generic/lib/form.ts
@@ -1,0 +1,18 @@
+import BigNumber, { BigSource } from "big.js"
+
+export const isValidAmount = (amount: string) => /^[0-9]*([\.,][0-9]+)?$/.test(amount)
+
+// replaces ',' with '.' in a string
+export function replaceCommaWithDot(input: string) {
+  return input.replace(/,/g, ".")
+}
+
+// should be used when creating a Big from user input because there are issues with
+// parsing a Big from number-strings with a comma on iOS
+export function FormBigNumber(value: BigSource) {
+  if (typeof value === "string") {
+    return BigNumber(replaceCommaWithDot(value))
+  } else {
+    return BigNumber(value)
+  }
+}

--- a/src/Generic/lib/strings.ts
+++ b/src/Generic/lib/strings.ts
@@ -8,3 +8,11 @@ export function max(strings: string[], leftpad?: string): string | undefined {
     return maxValue === undefined || thisValue > maxValue ? thisValue : maxValue
   }, undefined)
 }
+
+// replaces ',' with '.' in a string
+// this can be used with strings that represent a number before passing them to Big()
+export function replaceCommaWithDot(input: string) {
+  return input.replace(/,/g, ".")
+}
+
+export const isValidAmount = (amount: string) => /^[0-9]+([\.,][0-9]+)?$/.test(amount)

--- a/src/Generic/lib/strings.ts
+++ b/src/Generic/lib/strings.ts
@@ -15,4 +15,4 @@ export function replaceCommaWithDot(input: string) {
   return input.replace(/,/g, ".")
 }
 
-export const isValidAmount = (amount: string) => /^[0-9]+([\.,][0-9]+)?$/.test(amount)
+export const isValidAmount = (amount: string) => /^[0-9]*([\.,][0-9]+)?$/.test(amount)

--- a/src/Generic/lib/strings.ts
+++ b/src/Generic/lib/strings.ts
@@ -8,11 +8,3 @@ export function max(strings: string[], leftpad?: string): string | undefined {
     return maxValue === undefined || thisValue > maxValue ? thisValue : maxValue
   }, undefined)
 }
-
-// replaces ',' with '.' in a string
-// this can be used with strings that represent a number before passing them to Big()
-export function replaceCommaWithDot(input: string) {
-  return input.replace(/,/g, ".")
-}
-
-export const isValidAmount = (amount: string) => /^[0-9]*([\.,][0-9]+)?$/.test(amount)

--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -22,7 +22,7 @@ import { PriceInput, QRReader } from "~Generic/components/FormFields"
 import { formatBalance } from "~Generic/lib/balances"
 import { HorizontalLayout } from "~Layout/components/Box"
 import Portal from "~Generic/components/Portal"
-import { isValidAmount, replaceCommaWithDot } from "~Generic/lib/strings"
+import { FormBigNumber, isValidAmount, replaceCommaWithDot } from "~Generic/lib/form"
 
 export interface PaymentFormValues {
   amount: string
@@ -213,9 +213,9 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
         inputRef={form.register({
           required: t<string>("payment.validation.no-price"),
           validate: value => {
-            if (!isValidAmount(value) || BigNumber(replaceCommaWithDot(value)).eq(0)) {
+            if (!isValidAmount(value) || FormBigNumber(value).eq(0)) {
               return t<string>("payment.validation.invalid-price")
-            } else if (BigNumber(replaceCommaWithDot(value)).gt(spendableBalance)) {
+            } else if (FormBigNumber(value).gt(spendableBalance)) {
               return t<string>("payment.validation.not-enough-funds")
             } else {
               return undefined

--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -22,6 +22,7 @@ import { PriceInput, QRReader } from "~Generic/components/FormFields"
 import { formatBalance } from "~Generic/lib/balances"
 import { HorizontalLayout } from "~Layout/components/Box"
 import Portal from "~Generic/components/Portal"
+import { isValidAmount, replaceCommaWithDot } from "~Generic/lib/strings"
 
 export interface PaymentFormValues {
   amount: string
@@ -211,8 +212,15 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
         error={Boolean(form.errors.amount)}
         inputRef={form.register({
           required: t<string>("payment.validation.no-price"),
-          pattern: { value: /^[0-9]+(\.[0-9]+)?$/, message: t<string>("payment.validation.invalid-price") },
-          validate: value => BigNumber(value).lte(spendableBalance) || t<string>("payment.validation.not-enough-funds")
+          validate: value => {
+            if (!isValidAmount(value)) {
+              return t<string>("payment.validation.invalid-price")
+            } else if (BigNumber(replaceCommaWithDot(value)).gt(spendableBalance)) {
+              return t<string>("payment.validation.not-enough-funds")
+            } else {
+              return undefined
+            }
+          }
         })}
         label={form.errors.amount ? form.errors.amount.message : t("payment.inputs.price.label")}
         margin="normal"
@@ -355,7 +363,7 @@ function PaymentFormContainer(props: Props) {
 
     const payment = await createPaymentOperation({
       asset: asset || Asset.native(),
-      amount: formValues.amount,
+      amount: replaceCommaWithDot(formValues.amount),
       destination,
       horizon
     })

--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -213,7 +213,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
         inputRef={form.register({
           required: t<string>("payment.validation.no-price"),
           validate: value => {
-            if (!isValidAmount(value)) {
+            if (!isValidAmount(value) || BigNumber(replaceCommaWithDot(value)).eq(0)) {
               return t<string>("payment.validation.invalid-price")
             } else if (BigNumber(replaceCommaWithDot(value)).gt(spendableBalance)) {
               return t<string>("payment.validation.not-enough-funds")

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -282,7 +282,7 @@ function TradingForm(props: Props) {
             })}
             error={Boolean(form.errors.primaryAmountString)}
             inputProps={{
-              pattern: "[0-9]*",
+              pattern: "^[0-9]*(.[0-9]+)?$",
               inputMode: "decimal",
               min: "0.0000001",
               max: maxPrimaryAmount.toFixed(7),

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -34,7 +34,13 @@ import {
 } from "~Generic/lib/stellar"
 import { createTransaction } from "~Generic/lib/transaction"
 import { Box, HorizontalLayout, VerticalLayout } from "~Layout/components/Box"
-import { bigNumberToInputValue, isValidAmount, TradingFormValues, useCalculation } from "../hooks/form"
+import {
+  bigNumberToInputValue,
+  replaceCommaWithDot,
+  isValidAmount,
+  TradingFormValues,
+  useCalculation
+} from "../hooks/form"
 import TradingPrice from "./TradingPrice"
 
 const useStyles = makeStyles({
@@ -141,7 +147,8 @@ function TradingForm(props: Props) {
   }
 
   const validateManualPrice = React.useCallback(() => {
-    const value = BigNumber(manualPrice).gt(0) ? manualPrice : defaultPrice
+    const dottedManualPrice = replaceCommaWithDot(manualPrice)
+    const value = BigNumber(dottedManualPrice).gt(0) ? dottedManualPrice : defaultPrice
     const valid = isValidAmount(value) && BigNumber(value).gt(0)
     if (!valid) {
       if (!expanded) {
@@ -320,7 +327,6 @@ function TradingForm(props: Props) {
             )}
             required
             style={{ flexGrow: 1, flexShrink: 1, width: "55%" }}
-            type="number"
           />
         </HorizontalLayout>
         <HorizontalLayout margin="8px 0 32px">
@@ -394,6 +400,12 @@ function TradingForm(props: Props) {
               }
               control={form.control}
               name="manualPrice"
+              rules={{
+                validate: value => {
+                  const valid = isValidAmount(value)
+                  return valid || t<string>("trading.validation.invalid-price")
+                }
+              }}
               valueName="manualPrice"
             />
           </ExpansionPanelDetails>

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -1,4 +1,3 @@
-import BigNumber from "big.js"
 import React from "react"
 import { Controller, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -32,11 +31,11 @@ import {
   getAccountMinimumBalance,
   getSpendableBalance
 } from "~Generic/lib/stellar"
+import { FormBigNumber, isValidAmount } from "~Generic/lib/form"
 import { createTransaction } from "~Generic/lib/transaction"
 import { Box, HorizontalLayout, VerticalLayout } from "~Layout/components/Box"
 import { bigNumberToInputValue, TradingFormValues, useCalculation } from "../hooks/form"
 import TradingPrice from "./TradingPrice"
-import { isValidAmount, replaceCommaWithDot } from "~Generic/lib/strings"
 
 const useStyles = makeStyles({
   expansionPanel: {
@@ -142,9 +141,8 @@ function TradingForm(props: Props) {
   }
 
   const validateManualPrice = React.useCallback(() => {
-    const dottedManualPrice = replaceCommaWithDot(manualPrice)
-    const value = BigNumber(dottedManualPrice).gt(0) ? dottedManualPrice : defaultPrice
-    const valid = isValidAmount(value) && BigNumber(value).gt(0)
+    const value = FormBigNumber(manualPrice).gt(0) ? manualPrice : defaultPrice
+    const valid = isValidAmount(value) && FormBigNumber(value).gt(0)
     if (!valid) {
       if (!expanded) {
         setExpanded(true)

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -34,14 +34,9 @@ import {
 } from "~Generic/lib/stellar"
 import { createTransaction } from "~Generic/lib/transaction"
 import { Box, HorizontalLayout, VerticalLayout } from "~Layout/components/Box"
-import {
-  bigNumberToInputValue,
-  replaceCommaWithDot,
-  isValidAmount,
-  TradingFormValues,
-  useCalculation
-} from "../hooks/form"
+import { bigNumberToInputValue, TradingFormValues, useCalculation } from "../hooks/form"
 import TradingPrice from "./TradingPrice"
+import { isValidAmount, replaceCommaWithDot } from "~Generic/lib/strings"
 
 const useStyles = makeStyles({
   expansionPanel: {

--- a/src/Trading/components/TradingForm.tsx
+++ b/src/Trading/components/TradingForm.tsx
@@ -272,12 +272,18 @@ function TradingForm(props: Props) {
             inputRef={form.register({
               required: t<string>("trading.validation.primary-amount-missing"),
               validate: value => {
-                const amountInvalid =
-                  primaryAmount.lt(0) ||
-                  (value.length > 0 && primaryAmount.eq(0)) ||
+                const amountInvalid = primaryAmount.lt(0) || (value.length > 0 && primaryAmount.eq(0))
+                const exceedsBalance =
                   (props.primaryAction === "sell" && primaryBalance && primaryAmount.gt(spendablePrimaryBalance)) ||
                   (props.primaryAction === "buy" && secondaryBalance && secondaryAmount.gt(spendableSecondaryBalance))
-                return !amountInvalid || t<string>("trading.validation.invalid-amount")
+
+                if (amountInvalid) {
+                  return t<string>("trading.validation.invalid-amount")
+                } else if (exceedsBalance) {
+                  return t<string>("trading.validation.not-enough-balance")
+                } else {
+                  return true
+                }
               }
             })}
             error={Boolean(form.errors.primaryAmountString)}

--- a/src/Trading/components/TradingPrice.tsx
+++ b/src/Trading/components/TradingPrice.tsx
@@ -64,7 +64,6 @@ const TradingPrice = React.forwardRef(function TradingPrice(props: TradingPriceP
       onChange={props.onChange}
       onFocus={props.selectOnFocus ? event => event.target.select() : undefined}
       style={props.style}
-      type="number"
       value={props.defaultPrice ? props.defaultPrice : props.manualPrice}
     />
   )

--- a/src/Trading/components/TradingPrice.tsx
+++ b/src/Trading/components/TradingPrice.tsx
@@ -52,7 +52,7 @@ const TradingPrice = React.forwardRef(function TradingPrice(props: TradingPriceP
   return (
     <TextField
       inputProps={{
-        pattern: "[0-9]*",
+        pattern: "^[0-9]*(.[0-9]+)?$",
         inputMode: "decimal",
         min: "0.0000001"
       }}

--- a/src/Trading/hooks/form.ts
+++ b/src/Trading/hooks/form.ts
@@ -8,7 +8,7 @@ import { BASE_RESERVE, balancelineToAsset, getAccountMinimumBalance, getSpendabl
 import { useConversionOffers } from "./conversion"
 
 export const bigNumberToInputValue = (bignum: BigNumber, overrides?: BalanceFormattingOptions) =>
-  formatBalance(bignum, { minimumSignificants: 3, maximumSignificants: 9, ...overrides })
+  formatBalance(bignum, { minimumSignificants: 3, maximumSignificants: 9, groupThousands: false, ...overrides })
 
 function findMatchingBalance(balances: AccountData["balances"], asset: Asset) {
   return balances.find(balance => balancelineToAsset(balance).equals(asset))

--- a/src/Trading/hooks/form.ts
+++ b/src/Trading/hooks/form.ts
@@ -25,6 +25,12 @@ function getSpendableBalanceWithoutBaseReserve(accountMinimumBalance: BigNumber,
   return spendableBalance.cmp(BigNumber(0)) < 0 ? BigNumber(0) : spendableBalance
 }
 
+// replaces ',' with '.' in a string
+// this can be used with strings that represent a number before passing them to Big()
+export function replaceCommaWithDot(input: string) {
+  return input.replace(/,/g, ".")
+}
+
 export interface TradingFormValues {
   primaryAsset: Asset | undefined
   primaryAmountString: string
@@ -58,17 +64,22 @@ export function useCalculation(parameters: CalculationParameters): CalculationRe
   const { accountData, priceMode, primaryAction, tradePair } = parameters
   const { manualPrice, primaryAmountString, primaryAsset, secondaryAsset } = parameters.values
 
+  const dottedManualPrice = replaceCommaWithDot(manualPrice)
+  const dottedPrimaryAmountString = replaceCommaWithDot(primaryAmountString)
+
   const price =
-    manualPrice && isValidAmount(manualPrice)
+    dottedManualPrice && isValidAmount(dottedManualPrice)
       ? priceMode === "secondary"
-        ? BigNumber(manualPrice)
-        : BigNumber(manualPrice).eq(0) // prevent division by zero
+        ? BigNumber(dottedManualPrice)
+        : BigNumber(dottedManualPrice).eq(0) // prevent division by zero
         ? BigNumber(0)
-        : BigNumber(1).div(manualPrice)
+        : BigNumber(1).div(dottedManualPrice)
       : BigNumber(0)
 
   const primaryAmount =
-    primaryAmountString && isValidAmount(primaryAmountString) ? BigNumber(primaryAmountString) : BigNumber(0)
+    dottedPrimaryAmountString && isValidAmount(dottedPrimaryAmountString)
+      ? BigNumber(dottedPrimaryAmountString)
+      : BigNumber(0)
 
   const primaryBalance = primaryAsset ? findMatchingBalance(accountData.balances, primaryAsset) : undefined
   const secondaryBalance = secondaryAsset ? findMatchingBalance(accountData.balances, secondaryAsset) : undefined

--- a/src/Trading/hooks/form.ts
+++ b/src/Trading/hooks/form.ts
@@ -4,12 +4,11 @@ import { AccountData } from "~Generic/lib/account"
 import { formatBalance, BalanceFormattingOptions } from "~Generic/lib/balances"
 import { calculateSpread, FixedOrderbookRecord } from "~Generic/lib/orderbook"
 import { BASE_RESERVE, balancelineToAsset, getAccountMinimumBalance, getSpendableBalance } from "~Generic/lib/stellar"
+import { isValidAmount, replaceCommaWithDot } from "~Generic/lib/strings"
 import { useConversionOffers } from "./conversion"
 
 export const bigNumberToInputValue = (bignum: BigNumber, overrides?: BalanceFormattingOptions) =>
   formatBalance(bignum, { minimumSignificants: 3, maximumSignificants: 9, ...overrides })
-
-export const isValidAmount = (amount: string) => /^[0-9]+([\.,][0-9]+)?$/.test(amount)
 
 function findMatchingBalance(balances: AccountData["balances"], asset: Asset) {
   return balances.find(balance => balancelineToAsset(balance).equals(asset))
@@ -23,12 +22,6 @@ function getSpendableBalanceWithoutBaseReserve(accountMinimumBalance: BigNumber,
 
   // return 0 if calculated balance is negative
   return spendableBalance.cmp(BigNumber(0)) < 0 ? BigNumber(0) : spendableBalance
-}
-
-// replaces ',' with '.' in a string
-// this can be used with strings that represent a number before passing them to Big()
-export function replaceCommaWithDot(input: string) {
-  return input.replace(/,/g, ".")
 }
 
 export interface TradingFormValues {

--- a/src/Trading/hooks/form.ts
+++ b/src/Trading/hooks/form.ts
@@ -2,9 +2,9 @@ import BigNumber from "big.js"
 import { Asset, Horizon } from "stellar-sdk"
 import { AccountData } from "~Generic/lib/account"
 import { formatBalance, BalanceFormattingOptions } from "~Generic/lib/balances"
+import { FormBigNumber, isValidAmount } from "~Generic/lib/form"
 import { calculateSpread, FixedOrderbookRecord } from "~Generic/lib/orderbook"
 import { BASE_RESERVE, balancelineToAsset, getAccountMinimumBalance, getSpendableBalance } from "~Generic/lib/stellar"
-import { isValidAmount, replaceCommaWithDot } from "~Generic/lib/strings"
 import { useConversionOffers } from "./conversion"
 
 export const bigNumberToInputValue = (bignum: BigNumber, overrides?: BalanceFormattingOptions) =>
@@ -57,22 +57,17 @@ export function useCalculation(parameters: CalculationParameters): CalculationRe
   const { accountData, priceMode, primaryAction, tradePair } = parameters
   const { manualPrice, primaryAmountString, primaryAsset, secondaryAsset } = parameters.values
 
-  const dottedManualPrice = replaceCommaWithDot(manualPrice)
-  const dottedPrimaryAmountString = replaceCommaWithDot(primaryAmountString)
-
   const price =
-    dottedManualPrice && isValidAmount(dottedManualPrice)
+    manualPrice && isValidAmount(manualPrice)
       ? priceMode === "secondary"
-        ? BigNumber(dottedManualPrice)
-        : BigNumber(dottedManualPrice).eq(0) // prevent division by zero
+        ? FormBigNumber(manualPrice)
+        : FormBigNumber(manualPrice).eq(0) // prevent division by zero
         ? BigNumber(0)
-        : BigNumber(1).div(dottedManualPrice)
+        : BigNumber(1).div(FormBigNumber(manualPrice))
       : BigNumber(0)
 
   const primaryAmount =
-    dottedPrimaryAmountString && isValidAmount(dottedPrimaryAmountString)
-      ? BigNumber(dottedPrimaryAmountString)
-      : BigNumber(0)
+    primaryAmountString && isValidAmount(primaryAmountString) ? FormBigNumber(primaryAmountString) : BigNumber(0)
 
   const primaryBalance = primaryAsset ? findMatchingBalance(accountData.balances, primaryAsset) : undefined
   const secondaryBalance = secondaryAsset ? findMatchingBalance(accountData.balances, secondaryAsset) : undefined

--- a/src/Transaction/stories/SubmissionProgress.tsx
+++ b/src/Transaction/stories/SubmissionProgress.tsx
@@ -18,6 +18,6 @@ storiesOf("SubmissionProgress", module)
     <SubmissionProgress
       type={SubmissionType.default}
       promise={Promise.reject(new Error("Test error"))}
-      onRetry={() => undefined}
+      onRetry={() => Promise.resolve()}
     />
   ))


### PR DESCRIPTION
Fixes issues on iOS where the user was unable to enter a valid amount because the on-screen keyboard only showed a comma which was not accepted by the validation mechanism (when the device is set up for EU regions).

Seems like this issue appears on iOS only. When entering a value with a comma into the input field (either the primary amount or manual price, does not matter) it is not propagated correctly, i.e. the onChange event only contains `""`. Removing the `type: "number"` prop helps here, but this is not enough as `Big.js` somehow still has issues with the comma string and throws an `Invalid number` error when trying to instantiate a new `Big()`. That's where the `replaceCommaWithDot(input:string)` function comes into play. 

Also closes #1251 by re-introducing the validation rule such that the price input field will already show an "Invalid amount" error instead of first showing it when the user clicks on the submit button. 

