### PR TITLE
Workaround for testnet timeouts

### DIFF
--- a/src/App/contexts/stellar.tsx
+++ b/src/App/contexts/stellar.tsx
@@ -27,12 +27,7 @@ const initialHorizonSelection: Promise<[string[], string[]]> = (async () => {
     )
   )
 
-  const testnetHorizonURLs: string[] = [
-    await netWorker.checkHorizonOrFailover(
-      "https://stellar-horizon-testnet.satoshipay.io/",
-      "https://horizon-testnet.stellar.org"
-    )
-  ]
+  const testnetHorizonURLs: string[] = ["https://horizon-testnet.stellar.org"]
 
   return Promise.all([pubnetHorizonURLs, testnetHorizonURLs])
 })()


### PR DESCRIPTION
Only use SDF testnet horizon. Fixes #1258.