### PR TITLE
Add windows build troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ docker run --rm -ti \
  -v /Volumes/Certificates/solar:/root/Certs \
  electronuserland/builder:wine-mono bash -c 'npm config set script-shell bash && npm install && npm run build:win:signed'
  ```
+ 
+ **Note:** We have seen weird module resolution troubles with Parcel. In this case make sure to `rm -rf node_modules/` **on the host**, then try again.
 
 ### Signed binaries
 


### PR DESCRIPTION
Parcel was unable to resolve `require("react")` in one of our dependencies in the windows build docker container. I made sure (in the container!) that the `react` package is installed and can be resolved. All fine.

Seemed to have been some uber weird behavior probably caused by the way docker interleaves mounted volumes and local container directories under the same path.