### PR TITLE
Catch error when setting item in localstorage

### DIFF
--- a/src/Generic/lib/persistent-cache.ts
+++ b/src/Generic/lib/persistent-cache.ts
@@ -89,8 +89,14 @@ export function createPersistentCache<Value>(
         index = index.slice(-options.maxItems)
       }
 
-      localStorage.setItem(LocalStorageItemKey(key), JSON.stringify(value))
-      localStorage.setItem(LocalStorageIndexKey(), JSON.stringify(index))
+      try {
+        // Might fail if item is too large
+        localStorage.setItem(LocalStorageItemKey(key), JSON.stringify(value))
+        localStorage.setItem(LocalStorageIndexKey(), JSON.stringify(index))
+      } catch (error) {
+        // tslint:disable-next-line:no-console
+        console.error("Could not save item in local storage: ", value, error)
+      }
     }
   }
 }


### PR DESCRIPTION
Seems like the actual issue is that the response from `https://ticker.stellar.org/assets.json` is too large to put into localStorage. But the problem remains the same and is fixed with this PR.

Closes #1278. 