### PR TITLE
Fix macOS signing issues

### DIFF
--- a/electron-build.yml
+++ b/electron-build.yml
@@ -30,7 +30,6 @@ squirrelWindows:
 
 mac:
   hardenedRuntime: true
-  strictVerify: false
   entitlements: ./electron/build/entitlements.mac.inherit.plist
 
 linux:
@@ -38,4 +37,5 @@ linux:
   artifactName: Solar-Wallet-${version}.${ext}
   category: Utility
 
+afterPack: ./scripts/electron-builder-afterpack.js
 afterSign: ./scripts/electron-builder-aftersign.js

--- a/scripts/electron-builder-afterpack.js
+++ b/scripts/electron-builder-afterpack.js
@@ -1,0 +1,71 @@
+const { exec } = require("child_process")
+
+module.exports = async ({ electronPlatformName, appOutDir, packager }) => {
+  // only macos
+  if (electronPlatformName !== `darwin`) return
+  const appName = packager.appInfo.productFilename
+  const appPath = `${appOutDir}/${appName}.app`
+
+  await removeInvalidSymlinks({ appPath })
+}
+
+async function removeInvalidSymlinks({
+  // string
+  appPath
+}) {
+  const invalidSymlinksInManyLines = await new Promise((resolve, reject) => {
+    exec(`find '${appPath}/Contents' -type l ! -exec test -e {} \\; -print`, (error, stdout, stderr) => {
+      console.log(`command: find ${appPath}/Contents -type l ! -exec test -e {} \\; -print`)
+      if (error) {
+        console.error(`error: ${error.message}`)
+        return reject(error)
+      }
+      if (stderr) {
+        console.log(`stderr: ${stderr}`)
+        return reject(stderr)
+      }
+      console.log(`stdout: ${stdout}`)
+      resolve(stdout)
+    })
+  })
+
+  console.log("======invalidSymlinksInManyLines======")
+  console.log(invalidSymlinksInManyLines)
+  console.log("===========================")
+
+  const invalidSymlinksInArray = invalidSymlinksInManyLines
+    .split("\n")
+    .map(invalidSymlink => invalidSymlink.trim())
+    .filter(maybeEmptyPath => maybeEmptyPath !== "")
+
+  console.log("======invalidSymlinksInArray======")
+  console.log(invalidSymlinksInArray)
+  console.log("===========================")
+
+  const waitUntilAllInvalidSymlinksRemoved = invalidSymlinksInArray.map(invalidSymlink => {
+    return new Promise((resolve, reject) => {
+      exec(`rm '${invalidSymlink}'`, (error, stdout, stderr) => {
+        console.log(`command: rm ${invalidSymlink}`)
+
+        if (error) {
+          console.error(`error: ${error.message}`)
+          return reject(error)
+        }
+        if (stderr) {
+          console.log(`stderr: ${stderr}`)
+          return reject(stderr)
+        }
+        console.log(`stdout: ${stdout}`)
+        resolve(stdout)
+      })
+    })
+  })
+
+  try {
+    await Promise.all(waitUntilAllInvalidSymlinksRemoved)
+  } catch (e) {
+    console.log(`error happened while removing all invalid symlinks. message: ${e.message}`)
+  }
+
+  return
+}


### PR DESCRIPTION
Adds an afterpack script based on [this](https://github.com/electron-userland/electron-builder/issues/1892#issuecomment-818409327) snippet to remove symlinks that break the notarization of mac builds. 

This issue can only be detected by running `spctl -a -t open --context context:primary-signature -v ./Solar\ Wallet.app` on the unpacked `.app` file from the `.dmg`. The notarization process itself does not fail but macOS prevents the user from installing the application. 