### PR TITLE
Fix iOS CORS issue

### DIFF
--- a/cordova/config/config.template
+++ b/cordova/config/config.template
@@ -122,4 +122,6 @@
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="SplashScreenDelay" value="$SPLASH_SCREEN_DELAY" />
     <preference name="SwiftVersion" value="5.0" />
+    <preference name="scheme" value="app" />
+    <preference name="hostname" value="localhost" />
 </widget>


### PR DESCRIPTION
Fixes the "Origin null is not allowed by Access-Control-Allow-Origin." error thrown on iOS when trying to fetch some URLs. The fix is described [here](https://cordova.apache.org/announcements/2020/06/01/cordova-ios-release-6.0.0.html).